### PR TITLE
Remove unused DATABASE_* env vars from st2dh

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -498,12 +498,7 @@ services:
     network_mode: host
     environment:
       TZ: "America/Chicago"
-      DATABASE_HOST: db
-      DATABASE_PORT: 5432
-      DATABASE_NAME: deepharbor
-      DATABASE_USER: dh
-      DATABASE_PASSWORD: dh
-      SERVICE_NAME: ST2DH      
+      SERVICE_NAME: ST2DH
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5004/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Removes `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_USER`, `DATABASE_PASSWORD` from the `st2dh` service in `docker-compose.yaml`
- ST2DH is a Stripe webhook service that talks to DHService via HTTP — it never connects to PostgreSQL directly
- These were copy-paste from other service definitions

## Test plan
- [ ] Verify `docker compose up --build -d` still starts st2dh correctly
- [ ] Verify st2dh health check passes (it doesn't use these vars)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)