### PR TITLE
Add DH_API_BASE_URL env var override for portals and ST2DH

### DIFF
--- a/code/DHAdminPortal/config.py
+++ b/code/DHAdminPortal/config.py
@@ -8,3 +8,12 @@ import os
 # create a new configuration parser
 config = configparser.ConfigParser()
 config.read("config.ini")
+
+### Environment variable overrides
+# Allow environment variables to take precedence over config.ini values,
+# handy for running in Docker with bridge networking where the gateway
+# hostname is different from localhost
+if os.environ.get("DH_API_BASE_URL"):
+    if not config.has_section("dh_services"):
+        config.add_section("dh_services")
+    config.set("dh_services", "api_base_url", os.environ["DH_API_BASE_URL"])

--- a/code/DHMemberPortal/config.py
+++ b/code/DHMemberPortal/config.py
@@ -8,3 +8,12 @@ import os
 # create a new configuration parser
 config = configparser.ConfigParser()
 config.read("config.ini")
+
+### Environment variable overrides
+# Allow environment variables to take precedence over config.ini values,
+# handy for running in Docker with bridge networking where the gateway
+# hostname is different from localhost
+if os.environ.get("DH_API_BASE_URL"):
+    if not config.has_section("dh_services"):
+        config.add_section("dh_services")
+    config.set("dh_services", "api_base_url", os.environ["DH_API_BASE_URL"])

--- a/code/external/ST2DH/config.py
+++ b/code/external/ST2DH/config.py
@@ -8,3 +8,12 @@ import os
 # create a new configuration parser
 config = configparser.ConfigParser()
 config.read("config.ini")
+
+### Environment variable overrides
+# Allow environment variables to take precedence over config.ini values,
+# handy for running in Docker with bridge networking where the gateway
+# hostname is different from localhost
+if os.environ.get("DH_API_BASE_URL"):
+    if not config.has_section("dh_services"):
+        config.add_section("dh_services")
+    config.set("dh_services", "api_base_url", os.environ["DH_API_BASE_URL"])

--- a/code/external/ST2DH/dhservices.py
+++ b/code/external/ST2DH/dhservices.py
@@ -1,4 +1,5 @@
 import email
+import os
 import requests
 
 from dhs_logging import logger
@@ -10,8 +11,9 @@ from config import config
 ## DHService API configuration
 ###############################################################################
 
-# This is the base URL for our DHService API
-DH_API_BASE_URL = config.get("dh_services", "api_base_url")
+# This is the base URL for our DHService API, with env var override
+# for running in Docker with bridge networking
+DH_API_BASE_URL = os.environ.get("DH_API_BASE_URL", config.get("dh_services", "api_base_url"))
 # This is the client ID and secret for our DHService API
 DH_CLIENT_ID = config.get("dh_services", "client_name")
 DH_CLIENT_SECRET = config.get("dh_services", "client_secret")


### PR DESCRIPTION
## Summary
- Patch `config.py` in DHAdminPortal, DHMemberPortal, and ST2DH to check for `DH_API_BASE_URL` env var and override the configparser value when set
- Patch ST2DH `dhservices.py` to also read `DH_API_BASE_URL` from env var with fallback to config
- Zero impact on production — if the env var isn't set, behavior is identical to today

## Context
The portals and ST2DH read their API base URL from `config.ini` (hardcoded to `http://localhost/dh/service`). This works with `network_mode: host` but breaks on Docker bridge networking where the gateway is at `http://gateway/dh/service` via Docker DNS. The `docker-compose.dev.yml` (from #10) already sets `DH_API_BASE_URL` on these services — this PR makes them actually read it.

## Test plan
- [ ] Verify services start normally without `DH_API_BASE_URL` set (production behavior unchanged)
- [ ] Verify services use the env var value when `DH_API_BASE_URL` is set via docker-compose.dev.yml
- [ ] Verify portal API calls route correctly through `http://gateway/dh/service` on bridge network

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)