### PR TITLE
Add DEV_MODE bypass to worker services (dh2ad, dh2rfid)

### DIFF
--- a/code/workers/DH2AD/main.py
+++ b/code/workers/DH2AD/main.py
@@ -13,6 +13,17 @@ from config import config
 # Our FastAPI app
 app = FastAPI()
 
+###############################################################################
+# Dev Mode Configuration
+###############################################################################
+
+# When DEV_MODE is set, we skip the file queue and controller communication
+# and return simulated success responses instead. This lets us run without
+# DHADController in the dev environment.
+DEV_MODE = os.environ.get("DEV_MODE", "").lower() in ("true", "1", "yes")
+if DEV_MODE:
+    logger.info("DEV_MODE is enabled — controller communication will be simulated")
+
 #
 # Okay, we do *not* talk to Active Directory or B2C directly here.
 # Because this worker is designed to be run in a containerized environment
@@ -85,10 +96,25 @@ def check_responses(sent_ids):
 def perform_ad_operation(operation, payload=None, timeout=10):
     if payload is None:
         payload = {}
-    payload["operation"] = operation    
-    
+    payload["operation"] = operation
+
+    # In dev mode, skip the file queue and return a simulated success
+    # so we don't need the DHADController service running
+    if DEV_MODE:
+        logger.info(f"DEV_MODE active — skipping controller, returning simulated success for '{operation}'")
+        mock_payload = dict(payload)
+        mock_payload["current_time"] = datetime.datetime.now().isoformat()
+        return True, {
+            "result": "success",
+            "status": "success",
+            "data": {
+                "status": "success",
+                "data": mock_payload
+            }
+        }
+
     msg_id = send_message_async(payload)
-    
+
     # Now wait for response
     start_time = time.time()
     while time.time() - start_time < timeout:
@@ -96,7 +122,7 @@ def perform_ad_operation(operation, payload=None, timeout=10):
         if msg_id in completed:
             return True, data
         time.sleep(0.5)
-    
+
     logger.error(f"Timeout waiting for response for message {msg_id}")
     return False, None
 

--- a/code/workers/DH2RFID/main.py
+++ b/code/workers/DH2RFID/main.py
@@ -14,6 +14,17 @@ from dhs_logging import logger
 # Our FastAPI app
 app = FastAPI()
 
+###############################################################################
+# Dev Mode Configuration
+###############################################################################
+
+# When DEV_MODE is set, we skip the file queue and controller communication
+# and return simulated success responses instead. This lets us run without
+# DHRFIDReader in the dev environment.
+DEV_MODE = os.environ.get("DEV_MODE", "").lower() in ("true", "1", "yes")
+if DEV_MODE:
+    logger.info("DEV_MODE is enabled — controller communication will be simulated")
+
 #
 # Okay, why are we not just talking to the board directly here?
 # Because this worker is designed to be run in a containerized environment
@@ -92,9 +103,23 @@ def perform_board_operation(operation, tag_id=None, converted_tag=None, timeout=
         "tag_id": tag_id,
         "converted_tag": converted_tag
     }
-    
+
+    # In dev mode, skip the file queue and return a simulated success
+    # so we don't need the DHRFIDReader service running
+    if DEV_MODE:
+        logger.info(f"DEV_MODE active — skipping controller, returning simulated success for '{operation}'")
+        return True, {
+            "result": "success",
+            "status": "success",
+            "data": {
+                "current_time": datetime.datetime.now().isoformat(),
+                "tag_id": tag_id,
+                "operation": operation
+            }
+        }
+
     msg_id = send_message_async(payload)
-    
+
     # Now wait for response
     start_time = time.time()
     while time.time() - start_time < timeout:
@@ -102,7 +127,7 @@ def perform_board_operation(operation, tag_id=None, converted_tag=None, timeout=
         if msg_id in completed:
             return True, data
         time.sleep(0.5)
-    
+
     logger.error(f"Timeout waiting for response for message {msg_id}")
     return False, None
 


### PR DESCRIPTION
## Summary
- When `DEV_MODE` env var is truthy (`true`, `1`, `yes`), `perform_ad_operation()` in DH2AD and `perform_board_operation()` in DH2RFID short-circuit before writing to the file queue or polling for controller responses
- Returns simulated success responses with realistic data structures so callers (dhidentity, dhaccess, dispatcher) don't choke
- Zero impact on production — if the env var isn't set, behavior is identical to today
- `docker-compose.dev.yml` already sets `DEV_MODE: "true"` on both services (#10)

## What this fixes
Without DHADController/DHRFIDReader (disabled in dev — they need physical hardware), the workers poll for responses that never arrive → 10s timeout → HTTP 500 → business services fail → dispatcher retries endlessly.

## Files changed
- `code/workers/DH2AD/main.py` — DEV_MODE check + bypass in `perform_ad_operation()`
- `code/workers/DH2RFID/main.py` — DEV_MODE check + bypass in `perform_board_operation()`

## Test plan
- [ ] Rebuild dev environment with `docker compose -f docker-compose.yaml -f docker-compose.dev.yml up --build -d`
- [ ] Verify dh2ad and dh2rfid logs show "DEV_MODE is enabled" on startup
- [ ] Trigger a member change that flows through dhidentity/dhaccess → dh2ad/dh2rfid
- [ ] Confirm no timeout errors, simulated success responses logged
- [ ] Verify production compose (without dev override) still works normally

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)