### PR TITLE
Add seed data SQL and generator for dev environment

### DIFF
--- a/pg/sql/seed_data.sql
+++ b/pg/sql/seed_data.sql
@@ -1,0 +1,427 @@
+/*
+ * Deep Harbor Seed Data
+ *
+ * This file populates the database with ~25 fictional members for
+ * local development and testing. It runs as 02-seed_data.sql during
+ * Docker first-boot init, after the schema (01-pgsql_schema.sql)
+ * is already in place.
+ *
+ * IMPORTANT: The first 10 members are "dev bypass" users with stable,
+ * predictable IDs (1-10). Issue #13 (dev auth bypass) references
+ * these IDs directly. Don't reorder them.
+ *
+ * Inserting members fires the audit trigger, log_member_changes(),
+ * and pg_notify. First boot will be noisy as the dispatcher processes
+ * ~25 change events. This is expected and harmless with DEV_MODE=true
+ * on the worker services.
+ */
+
+
+/* =====================================================================
+ * Dev Bypass Users (IDs 1-10)
+ *
+ * These are inserted first so their IDs are predictable. Each pair
+ * serves a specific role in the dev auth bypass:
+ *   IDs 1-2:  Administrators (role_id=2)
+ *   IDs 3-4:  Authorizers    (role_id=1)
+ *   IDs 5-6:  Board members  (role_id=3)
+ *   IDs 7-8:  Active members (no role)
+ *   IDs 9-10: Inactive members (no role)
+ * ===================================================================== */
+
+/* ID 1 - Ada Lovelace, Administrator
+ * Well-populated active member with lots of data — good for testing
+ * the admin portal with a full member record.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Ada", "last_name": "Lovelace", "nickname": "enchantress_of_numbers", "active_directory_username": "alovelace", "emails": [{"type": "primary", "email_address": "ada.lovelace@example.com"}]}'::jsonb,
+    '{"discord_username": "ada_admin"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Stripe Member - $65", "member_since": "2020-01-15"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-1234", "waiver_signed_date": "2020-01-15", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2020-01-22"}'::jsonb,
+    '{"rfid_tags": ["12345678", "87654321"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Mig Welders", "Tig Welders", "Jointer", "Planer", "Mitre Saw", "Sanders", "Wood Drill Press", "Router Table"], "computer_authorizations": ["Epilog Authorized Users", "Tormach Authorized Users", "ShopBot Authorized Users"]}'::jsonb,
+    '{"storage_id": "A-01", "storage_area": "North Wall"}'::jsonb,
+    '{"notes": [{"date": "2020-01-22", "author": "System", "text": "Completed orientation and safety training"}, {"date": "2023-06-10", "author": "Board", "text": "Granted administrator access to the admin portal"}]}'::jsonb
+);
+
+/* ID 2 - Charles Babbage, Administrator
+ * Another admin with slightly different data — useful for testing
+ * multi-admin scenarios.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Charles", "last_name": "Babbage", "nickname": "difference_engine", "active_directory_username": "cbabbage", "emails": [{"type": "primary", "email_address": "charles.babbage@example.com"}]}'::jsonb,
+    '{"discord_username": "cbabbage"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Member - Cash Payment", "member_since": "2019-03-10"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-5678", "waiver_signed_date": "2019-03-10", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2019-03-17"}'::jsonb,
+    '{"rfid_tags": ["23456789"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Metal Band Saw", "Metal Drill Press", "Bridgeport Mill", "Clausing Lathe"], "computer_authorizations": ["Boss Authorized Users", "CNC Plasma Authorized Users"]}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2019-03-17", "author": "System", "text": "Orientation completed"}, {"date": "2024-01-15", "author": "Board", "text": "Added as administrator"}]}'::jsonb
+);
+
+/* ID 3 - Nikola Tesla, Authorizer
+ * Heavy on authorizations — this is someone who trains others on
+ * equipment, so they should have auths on most things.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Nikola", "last_name": "Tesla", "nickname": "spark_lord", "active_directory_username": "ntesla", "emails": [{"type": "primary", "email_address": "nikola.tesla@example.com"}]}'::jsonb,
+    '{"discord_username": "spark_lord"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Volunteer", "member_since": "2018-06-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "PP-9012", "waiver_signed_date": "2018-06-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2018-06-08"}'::jsonb,
+    '{"rfid_tags": ["11223344"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Mig Welders", "Tig Welders", "Jointer", "Planer", "Mitre Saw", "Sanders", "Wood Drill Press", "Router Table", "Metal Band Saw", "Metal Drill Press", "Bridgeport Mill", "Clausing Lathe", "LeBlond Lathe", "Surface Grinder", "Hand held plasma cutter", "Pneumatic Power Tools", "Powder Coating Equipment", "Tube Bending Equipment"], "computer_authorizations": ["Epilog Authorized Users", "Tormach Authorized Users", "Universal Authorized Users", "Boss Authorized Users", "CNC Plasma Authorized Users", "ShopBot Authorized Users"]}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2018-06-08", "author": "System", "text": "Completed orientation"}, {"date": "2019-02-14", "author": "Board", "text": "Approved as equipment authorizer for metalworking and CNC areas"}]}'::jsonb
+);
+
+/* ID 4 - Hedy Lamarr, Authorizer
+ * Another authorizer, focused on different equipment areas.
+ * Has storage because she''s a volunteer with free storage.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Hedy", "last_name": "Lamarr", "nickname": "frequency_hopper", "active_directory_username": "hlamarr", "emails": [{"type": "primary", "email_address": "hedy.lamarr@example.com"}]}'::jsonb,
+    '{"discord_username": "hedy_builds"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Volunteer w/ Free Storage", "member_since": "2019-09-15"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-3456", "waiver_signed_date": "2019-09-15", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2019-09-22"}'::jsonb,
+    '{"rfid_tags": ["44556677", "55667788"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Wood Lathe", "Wood Mini Lathe", "Drum Sander", "Panel Saw", "Saw Dado", "Square Chisel Morticer", "Jointer", "Planer", "Ender 3D Printers", "Prusa 3D printers", "Formlabs Form 3 printer"], "computer_authorizations": ["Epilog Authorized Users", "Universal Authorized Users", "Vinyl Cutter Authorized Users", "Mimaki CJV30 printer Users"]}'::jsonb,
+    '{"storage_id": "C-05", "storage_area": "Woodshop Corner"}'::jsonb,
+    '{"notes": [{"date": "2019-09-22", "author": "System", "text": "Completed orientation and all woodshop authorizations"}, {"date": "2020-04-01", "author": "Board", "text": "Approved as authorizer for woodshop, 3D printing, and laser areas"}]}'::jsonb
+);
+
+/* ID 5 - Grace Hopper, Board Member
+ * Board member with basic authorizations — she''s more of a
+ * governance person than a shop user.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Grace", "last_name": "Hopper", "nickname": "queen_bug", "active_directory_username": "ghopper", "emails": [{"type": "primary", "email_address": "grace.hopper@example.com"}]}'::jsonb,
+    '{"discord_username": "admiral_grace"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Board Member / Officer", "member_since": "2017-11-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-7890", "waiver_signed_date": "2017-11-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2017-11-08"}'::jsonb,
+    '{"rfid_tags": ["99887766"]}'::jsonb,
+    '{"authorizations": ["Ender 3D Printers", "Prusa 3D printers", "Band Saw"], "computer_authorizations": []}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2017-11-08", "author": "System", "text": "Completed orientation"}, {"date": "2022-01-01", "author": "Board", "text": "Elected to board of directors"}]}'::jsonb
+);
+
+/* ID 6 - Margaret Hamilton, Board Member
+ * Another board member. Has a bit more shop experience.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Margaret", "last_name": "Hamilton", "nickname": "stack_overflow", "active_directory_username": "mhamilton", "emails": [{"type": "primary", "email_address": "margaret.hamilton@example.com"}]}'::jsonb,
+    '{"discord_username": "mhamilton_apollo"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Board Member / Officer", "member_since": "2018-03-15"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-2345", "waiver_signed_date": "2018-03-15", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2018-03-22"}'::jsonb,
+    '{"rfid_tags": ["77665544"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Mitre Saw", "Sanders", "Ender 3D Printers"], "computer_authorizations": ["Epilog Authorized Users"]}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2018-03-22", "author": "System", "text": "Completed orientation"}, {"date": "2023-01-01", "author": "Board", "text": "Elected to board"}]}'::jsonb
+);
+
+/* ID 7 - Rosalind Franklin, Active Member
+ * Well-populated active member with storage — good for testing
+ * the member portal with a full member record.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Rosalind", "last_name": "Franklin", "nickname": "photo_51", "active_directory_username": "rfranklin", "emails": [{"type": "primary", "email_address": "rosalind.franklin@example.com"}]}'::jsonb,
+    '{"discord_username": "xray_rosalind"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Member - Cash Payment", "member_since": "2021-04-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-6789", "waiver_signed_date": "2021-04-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2021-04-08"}'::jsonb,
+    '{"rfid_tags": ["33221100", "44332211"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Mig Welders", "Jointer", "Planer", "Ender 3D Printers", "Prusa 3D printers"], "computer_authorizations": ["Epilog Authorized Users", "Tormach Authorized Users"]}'::jsonb,
+    '{"storage_id": "B-12", "storage_area": "South Wall"}'::jsonb,
+    '{"notes": [{"date": "2021-04-08", "author": "System", "text": "Completed orientation and basic woodshop training"}]}'::jsonb
+);
+
+/* ID 8 - Katherine Johnson, Active Member
+ * Another well-populated active member — different set of auths.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Katherine", "last_name": "Johnson", "nickname": "human_computer", "active_directory_username": "kjohnson", "emails": [{"type": "primary", "email_address": "katherine.johnson@example.com"}]}'::jsonb,
+    '{"discord_username": "kjohnson_math"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Stripe Member - $65", "member_since": "2022-02-14"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-0123", "waiver_signed_date": "2022-02-14", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2022-02-21"}'::jsonb,
+    '{"rfid_tags": ["66778899"]}'::jsonb,
+    '{"authorizations": ["Ender 3D Printers", "Prusa 3D printers", "Formlabs Form 3 printer", "Tier one Sewing Machine", "Serger sewing machine", "Button sewing machines"], "computer_authorizations": ["Epilog Authorized Users", "Vinyl Cutter Authorized Users"]}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2022-02-21", "author": "System", "text": "Completed orientation, focused on textiles and 3D printing"}]}'::jsonb
+);
+
+/* ID 9 - Marie Curie, Inactive Member
+ * Former active member who let their membership lapse. Still has
+ * data on record from when they were active.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Marie", "last_name": "Curie", "nickname": "glow_girl", "active_directory_username": "mcurie", "emails": [{"type": "primary", "email_address": "marie.curie@example.com"}]}'::jsonb,
+    '{"discord_username": "mcurie_rad"}'::jsonb,
+    '{"membership_status": "Inactive", "membership_level": "Member - Cash Payment", "member_since": "2018-06-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-4567", "waiver_signed_date": "2018-06-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2018-06-08"}'::jsonb,
+    '{"rfid_tags": ["33445566"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Mig Welders", "Cold Metals Basic"], "computer_authorizations": []}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2018-06-08", "author": "System", "text": "Completed orientation"}, {"date": "2024-03-01", "author": "System", "text": "Membership lapsed — moved to inactive"}]}'::jsonb
+);
+
+/* ID 10 - Laika Sputnik, Inactive Member
+ * Another inactive member. This one has less data — they
+ * were only a member briefly.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Laika", "last_name": "Sputnik", "nickname": "good_dog", "active_directory_username": "lsputnik", "emails": [{"type": "primary", "email_address": "laika.sputnik@example.com"}]}'::jsonb,
+    NULL,
+    '{"membership_status": "Inactive", "membership_level": "Stripe Member - $65", "member_since": "2023-09-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-8901", "waiver_signed_date": "2023-09-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2023-09-08"}'::jsonb,
+    NULL,
+    '{"authorizations": ["Band Saw", "Ender 3D Printers"], "computer_authorizations": []}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2023-09-08", "author": "System", "text": "Completed orientation"}, {"date": "2024-06-01", "author": "System", "text": "Membership lapsed after 9 months"}]}'::jsonb
+);
+
+
+/* =====================================================================
+ * Additional Members (IDs 11-25)
+ *
+ * These round out the seed data with a mix of membership levels,
+ * authorization counts, and data completeness. Famous scientists,
+ * engineers, and inventors — all fictional usage, @example.com emails.
+ * ===================================================================== */
+
+/* ID 11 - Wernher von Braun, Area Host
+ * Long-time member who hosts the metalworking area. Tons of auths.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Wernher", "last_name": "Von Braun", "nickname": "rocket_man", "active_directory_username": "wvonbraun", "emails": [{"type": "primary", "email_address": "wernher.vonbraun@example.com"}]}'::jsonb,
+    '{"discord_username": "rocketman_w"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Area Host", "member_since": "2017-01-15"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-1111", "waiver_signed_date": "2017-01-15", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2017-01-22"}'::jsonb,
+    '{"rfid_tags": ["10203040", "50607080"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Mig Welders", "Tig Welders", "Metal Band Saw", "Metal Drill Press", "Bridgeport Mill", "Clausing Lathe", "LeBlond Lathe", "Surface Grinder", "Hand held plasma cutter", "Pneumatic Power Tools", "Powder Coating Equipment", "Tube Bending Equipment", "Cold Metals Basic"], "computer_authorizations": ["Boss Authorized Users", "CNC Plasma Authorized Users", "Tormach Authorized Users"]}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2017-01-22", "author": "System", "text": "Completed orientation"}, {"date": "2018-05-01", "author": "Board", "text": "Appointed area host for metalworking"}]}'::jsonb
+);
+
+/* ID 12 - Emmy Noether, Stripe Member w/ Storage
+ * Active member with storage who does a lot of woodworking and 3D printing.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Emmy", "last_name": "Noether", "nickname": "symmetry_queen", "active_directory_username": "enoether", "emails": [{"type": "primary", "email_address": "emmy.noether@example.com"}]}'::jsonb,
+    '{"discord_username": "emmy_makes"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Stripe Member w/ Storage - $95", "member_since": "2021-08-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-2222", "waiver_signed_date": "2021-08-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2021-08-08"}'::jsonb,
+    '{"rfid_tags": ["11112222", "33334444", "55556666"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Jointer", "Planer", "Mitre Saw", "Router Table", "Wood Lathe", "Drum Sander", "Panel Saw", "Ender 3D Printers", "Prusa 3D printers", "Formlabs Form 3 printer"], "computer_authorizations": ["Epilog Authorized Users", "Universal Authorized Users", "ShopBot Authorized Users"]}'::jsonb,
+    '{"storage_id": "D-08", "storage_area": "East Wall"}'::jsonb,
+    NULL
+);
+
+/* ID 13 - Richard Feynman, Member - Grandfathered Price
+ * Long-time member still on the old pricing. Mostly does electronics.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Richard", "last_name": "Feynman", "nickname": "surely_joking", "active_directory_username": "rfeynman", "emails": [{"type": "primary", "email_address": "richard.feynman@example.com"}]}'::jsonb,
+    '{"discord_username": "feynman_diagrams"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Member - Grandfathered Price", "member_since": "2016-05-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-3333", "waiver_signed_date": "2016-05-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2016-05-08"}'::jsonb,
+    '{"rfid_tags": ["77778888"]}'::jsonb,
+    '{"authorizations": ["Ender 3D Printers", "Band Saw", "Sanders"], "computer_authorizations": []}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2016-05-08", "author": "System", "text": "Completed orientation — mostly interested in electronics bench"}]}'::jsonb
+);
+
+/* ID 14 - Barbara McClintock, Scholarship Member
+ * Scholarship member who''s been getting into more shop equipment.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Barbara", "last_name": "McClintock", "nickname": "jumping_genes", "active_directory_username": "bmcclintock", "emails": [{"type": "primary", "email_address": "barbara.mcclintock@example.com"}]}'::jsonb,
+    '{"discord_username": "barb_bio"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Scholarship", "member_since": "2024-01-15"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-4444", "waiver_signed_date": "2024-01-15", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2024-01-22"}'::jsonb,
+    '{"rfid_tags": ["99990000"]}'::jsonb,
+    '{"authorizations": ["Band Saw", "Ender 3D Printers", "Tier one Sewing Machine"], "computer_authorizations": []}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2024-01-22", "author": "System", "text": "Completed orientation"}, {"date": "2024-01-15", "author": "Board", "text": "Approved scholarship membership"}]}'::jsonb
+);
+
+/* ID 15 - Guglielmo Marconi, Stripe Volunteer w/ Paid Storage
+ * Volunteer who helps with the radio and electronics area.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Guglielmo", "last_name": "Marconi", "nickname": "radio_wave", "active_directory_username": "gmarconi", "emails": [{"type": "primary", "email_address": "guglielmo.marconi@example.com"}]}'::jsonb,
+    '{"discord_username": "marconi_radio"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Stripe Volunteer w/ Paid Storage - $30", "member_since": "2020-07-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-5555", "waiver_signed_date": "2020-07-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2020-07-08"}'::jsonb,
+    '{"rfid_tags": ["12121212"]}'::jsonb,
+    '{"authorizations": ["Band Saw", "Sanders", "Ender 3D Printers", "Cold Metals Basic"], "computer_authorizations": []}'::jsonb,
+    '{"storage_id": "E-03", "storage_area": "Electronics Bench"}'::jsonb,
+    NULL
+);
+
+/* ID 16 - Dorothy Vaughan, New Member (brand new)
+ * Just signed up — barely anything filled in yet. Good for testing
+ * the new member experience.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Dorothy", "last_name": "Vaughan", "nickname": null, "active_directory_username": null, "emails": [{"type": "primary", "email_address": "dorothy.vaughan@example.com"}]}'::jsonb,
+    NULL,
+    '{"membership_status": "Active", "membership_level": "New Member", "member_since": "2026-02-10"}'::jsonb,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+);
+
+/* ID 17 - James Watt, Member w/ Storage - Cash Payment
+ * Does a lot of metalworking. Has storage for ongoing projects.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "James", "last_name": "Watt", "nickname": "steam_power", "active_directory_username": "jwatt", "emails": [{"type": "primary", "email_address": "james.watt@example.com"}]}'::jsonb,
+    '{"discord_username": "jwatt_steam"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Member w/ Storage - Cash Payment", "member_since": "2019-11-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-6666", "waiver_signed_date": "2019-11-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2019-11-08"}'::jsonb,
+    '{"rfid_tags": ["34343434"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Mig Welders", "Tig Welders", "Metal Band Saw", "Metal Drill Press", "Bridgeport Mill", "Blacksmithing"], "computer_authorizations": ["CNC Plasma Authorized Users"]}'::jsonb,
+    '{"storage_id": "F-15", "storage_area": "Metalshop"}'::jsonb,
+    NULL
+);
+
+/* ID 18 - Chien-Shiung Wu, Member - PayPal
+ * Active member, pays via PayPal. Mix of auths.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Chien-Shiung", "last_name": "Wu", "nickname": "first_lady_of_physics", "active_directory_username": "cwu", "emails": [{"type": "primary", "email_address": "chienshiung.wu@example.com"}]}'::jsonb,
+    '{"discord_username": "cswu_physics"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Member - PayPal", "member_since": "2022-09-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-7777", "waiver_signed_date": "2022-09-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2022-09-08"}'::jsonb,
+    '{"rfid_tags": ["56565656"]}'::jsonb,
+    '{"authorizations": ["Ender 3D Printers", "Prusa 3D printers", "Band Saw", "Table Saw", "Mitre Saw"], "computer_authorizations": ["Epilog Authorized Users"]}'::jsonb,
+    NULL,
+    NULL
+);
+
+/* ID 19 - Buckminster Fuller, Stripe Member - $65
+ * Geodesic dome enthusiast. Mostly woodworking auths.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Buckminster", "last_name": "Fuller", "nickname": "bucky_ball", "active_directory_username": "bfuller", "emails": [{"type": "primary", "email_address": "buckminster.fuller@example.com"}]}'::jsonb,
+    '{"discord_username": "bucky_dome"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Stripe Member - $65", "member_since": "2023-03-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-8888", "waiver_signed_date": "2023-03-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2023-03-08"}'::jsonb,
+    '{"rfid_tags": ["78787878"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Jointer", "Planer", "Mitre Saw", "Router Table", "Wood Drill Press", "Multi-Router", "Panel Saw"], "computer_authorizations": ["ShopBot Authorized Users"]}'::jsonb,
+    NULL,
+    NULL
+);
+
+/* ID 20 - Rachel Carson, Contractor
+ * Active contractor — limited time engagement.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Rachel", "last_name": "Carson", "nickname": "silent_spring", "active_directory_username": "rcarson", "emails": [{"type": "primary", "email_address": "rachel.carson@example.com"}]}'::jsonb,
+    NULL,
+    '{"membership_status": "Active", "membership_level": "Contractor", "member_since": "2025-06-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-9999", "waiver_signed_date": "2025-06-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2025-06-08"}'::jsonb,
+    '{"rfid_tags": ["90909090"]}'::jsonb,
+    '{"authorizations": ["Band Saw", "Sanders"], "computer_authorizations": []}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2025-06-01", "author": "Board", "text": "Contractor engagement for building renovation project"}]}'::jsonb
+);
+
+/* ID 21 - Philo Farnsworth, Member w/ Storage - Grandfathered Price
+ * Long-time member on grandfathered pricing with storage.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Philo", "last_name": "Farnsworth", "nickname": "tv_inventor", "active_directory_username": "pfarnsworth", "emails": [{"type": "primary", "email_address": "philo.farnsworth@example.com"}]}'::jsonb,
+    '{"discord_username": "philo_tv"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Member w/ Storage - Grandfathered Price", "member_since": "2016-09-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-1010", "waiver_signed_date": "2016-09-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2016-09-08"}'::jsonb,
+    '{"rfid_tags": ["21212121"]}'::jsonb,
+    '{"authorizations": ["Band Saw", "Table Saw", "Ender 3D Printers", "Sanders", "Wood Drill Press", "Cold Metals Basic", "Coffee Roaster"], "computer_authorizations": []}'::jsonb,
+    '{"storage_id": "A-22", "storage_area": "North Wall"}'::jsonb,
+    NULL
+);
+
+/* ID 22 - Jocelyn Bell Burnell, Volunteer w/ Paid Storage
+ * Volunteer who helps with outreach. Has storage for teaching materials.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Jocelyn", "last_name": "Bell Burnell", "nickname": "pulsar_finder", "active_directory_username": "jbellburnell", "emails": [{"type": "primary", "email_address": "jocelyn.bellburnell@example.com"}]}'::jsonb,
+    '{"discord_username": "jocelyn_stars"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Volunteer w/ Paid Storage", "member_since": "2021-01-15"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-1212", "waiver_signed_date": "2021-01-15", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2021-01-22"}'::jsonb,
+    '{"rfid_tags": ["43434343"]}'::jsonb,
+    '{"authorizations": ["Ender 3D Printers", "Prusa 3D printers", "Band Saw", "Tier one Sewing Machine", "Billiards"], "computer_authorizations": ["Epilog Authorized Users"]}'::jsonb,
+    '{"storage_id": "G-01", "storage_area": "Classroom"}'::jsonb,
+    '{"notes": [{"date": "2021-02-01", "author": "Board", "text": "Volunteering to run monthly intro-to-science workshops for kids"}]}'::jsonb
+);
+
+/* ID 23 - Dmitri Mendeleev, Inactive - Member - Grandfathered Price
+ * Was on grandfathered pricing for a long time. Moved away.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Dmitri", "last_name": "Mendeleev", "nickname": "periodic_table", "active_directory_username": "dmendeleev", "emails": [{"type": "primary", "email_address": "dmitri.mendeleev@example.com"}]}'::jsonb,
+    '{"discord_username": "element118"}'::jsonb,
+    '{"membership_status": "Inactive", "membership_level": "Member - Grandfathered Price", "member_since": "2015-03-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-1313", "waiver_signed_date": "2015-03-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2015-03-08"}'::jsonb,
+    '{"rfid_tags": ["65656565"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Mig Welders", "Metal Band Saw", "Blacksmithing"], "computer_authorizations": []}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2015-03-08", "author": "System", "text": "Completed orientation"}, {"date": "2024-09-01", "author": "System", "text": "Membership lapsed — member relocated out of state"}]}'::jsonb
+);
+
+/* ID 24 - Michael Faraday, Inactive - Member - PayPal
+ * Former PayPal member. Expired after a year.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Michael", "last_name": "Faraday", "nickname": "field_lines", "active_directory_username": "mfaraday", "emails": [{"type": "primary", "email_address": "michael.faraday@example.com"}]}'::jsonb,
+    NULL,
+    '{"membership_status": "Inactive", "membership_level": "Member - PayPal", "member_since": "2022-05-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-1414", "waiver_signed_date": "2022-05-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2022-05-08"}'::jsonb,
+    NULL,
+    '{"authorizations": ["Band Saw", "Ender 3D Printers", "Sanders"], "computer_authorizations": []}'::jsonb,
+    NULL,
+    '{"notes": [{"date": "2023-05-01", "author": "System", "text": "PayPal subscription expired — moved to inactive"}]}'::jsonb
+);
+
+/* ID 25 - George Washington Carver, Member w/ Storage - PayPal
+ * Active member with PayPal storage plan. Into woodworking and textiles.
+ */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "George Washington", "last_name": "Carver", "nickname": "peanut_wizard", "active_directory_username": "gwcarver", "emails": [{"type": "primary", "email_address": "george.carver@example.com"}]}'::jsonb,
+    '{"discord_username": "gwcarver_makes"}'::jsonb,
+    '{"membership_status": "Active", "membership_level": "Member w/ Storage - PayPal", "member_since": "2020-10-01"}'::jsonb,
+    '{"id_check_1": "IL", "id_check_2": "DL-1515", "waiver_signed_date": "2020-10-01", "terms_of_use_accepted": "true", "essentials_form": "completed", "orientation_completed_date": "2020-10-08"}'::jsonb,
+    '{"rfid_tags": ["87878787"]}'::jsonb,
+    '{"authorizations": ["Table Saw", "Band Saw", "Jointer", "Planer", "Wood Lathe", "Tier one Sewing Machine", "Serger sewing machine", "Button sewing machines", "Saw Dado"], "computer_authorizations": ["Vinyl Cutter Authorized Users", "Mimaki CJV30 printer Users"]}'::jsonb,
+    '{"storage_id": "B-07", "storage_area": "South Wall"}'::jsonb,
+    NULL
+);
+
+
+/* =====================================================================
+ * Role Assignments for Dev Bypass Users
+ *
+ * Roles: Authorizer (1), Administrator (2), Board (3)
+ * These are referenced by the dev auth bypass (issue #13) so the
+ * dev login page can show role-appropriate options.
+ * ===================================================================== */
+
+INSERT INTO member_to_role (role_id, member_id) VALUES (2, 1);   /* Ada Lovelace -> Administrator */
+INSERT INTO member_to_role (role_id, member_id) VALUES (2, 2);   /* Charles Babbage -> Administrator */
+INSERT INTO member_to_role (role_id, member_id) VALUES (1, 3);   /* Nikola Tesla -> Authorizer */
+INSERT INTO member_to_role (role_id, member_id) VALUES (1, 4);   /* Hedy Lamarr -> Authorizer */
+INSERT INTO member_to_role (role_id, member_id) VALUES (3, 5);   /* Grace Hopper -> Board */
+INSERT INTO member_to_role (role_id, member_id) VALUES (3, 6);   /* Margaret Hamilton -> Board */
+
+
+/* Reset the member identity sequence to account for seed data.
+ * This ensures that any members created at runtime start with
+ * IDs after the seed data range.
+ */
+SELECT setval(pg_get_serial_sequence('member', 'id'), (SELECT MAX(id) FROM member));
+
+/* That's all the seed data! On first boot the dispatcher will
+ * process the ~25 member_changes records created by the insert
+ * triggers. With DEV_MODE=true on the worker services, these
+ * will be handled gracefully without trying to talk to hardware.
+ */

--- a/pg/tools/generate_seed_data.py
+++ b/pg/tools/generate_seed_data.py
@@ -1,0 +1,966 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "faker>=33.0.0",
+# ]
+# ///
+"""
+Generate seed data SQL for the Deep Harbor CRM database.
+
+Produces INSERT statements for the member table with realistic
+fictional data. Always includes 10 hardcoded "dev bypass" users
+(IDs 1-10) first, then generates additional random members.
+
+Usage:
+    uv run pg/tools/generate_seed_data.py
+    uv run pg/tools/generate_seed_data.py --seed abc123 --count 50
+    uv run pg/tools/generate_seed_data.py --count 100 --output pg/sql/seed_data.sql
+"""
+
+import argparse
+import hashlib
+import json
+import random
+import secrets
+import sys
+from datetime import timedelta
+
+from faker import Faker
+
+
+### Lookup data — copied from pgsql_schema.sql
+
+MEMBERSHIP_TYPES = [
+    "Area Host",
+    "Board Member / Officer",
+    "Contractor",
+    "Member - Cash Payment",
+    "Member - Grandfathered Price",
+    "Member - PayPal",
+    "Member w/ Storage - Cash Payment",
+    "Member w/ Storage - Grandfathered Price",
+    "Member w/ Storage - PayPal",
+    "New Member",
+    "Scholarship",
+    "Stripe Member - $65",
+    "Stripe Member w/ Storage - $95",
+    "Stripe Volunteer w/ Paid Storage - $30",
+    "Volunteer",
+    "Volunteer w/ Free Storage",
+    "Volunteer w/ Paid Storage",
+]
+
+# Weighted distribution for random member generation — favors
+# the more common membership types over special ones
+MEMBERSHIP_WEIGHTS = {
+    "Stripe Member - $65": 25,
+    "Member - Cash Payment": 15,
+    "Member - PayPal": 10,
+    "Stripe Member w/ Storage - $95": 8,
+    "Member w/ Storage - Cash Payment": 5,
+    "Member w/ Storage - PayPal": 5,
+    "Member w/ Storage - Grandfathered Price": 3,
+    "Member - Grandfathered Price": 5,
+    "Volunteer": 6,
+    "Volunteer w/ Free Storage": 3,
+    "Volunteer w/ Paid Storage": 3,
+    "Stripe Volunteer w/ Paid Storage - $30": 3,
+    "Scholarship": 3,
+    "New Member": 2,
+    "Area Host": 1,
+    "Contractor": 2,
+    "Board Member / Officer": 1,
+}
+
+# requires_login=true — these go in "computer_authorizations"
+COMPUTER_AUTHORIZATIONS = [
+    "Boss Authorized Users",
+    "CNC Plasma Authorized Users",
+    "Epilog Authorized Users",
+    "ShopBot Authorized Users",
+    "Tormach Authorized Users",
+    "Universal Authorized Users",
+    "Vinyl Cutter Authorized Users",
+    "Mimaki CJV30 printer Users",
+]
+
+# requires_login=false — these go in "authorizations"
+PHYSICAL_AUTHORIZATIONS = [
+    "Band Saw",
+    "Billiards",
+    "Blacksmithing",
+    "Bridgeport Mill",
+    "Button sewing machines",
+    "Clausing Lathe",
+    "Coffee Roaster",
+    "Cold Metals Basic",
+    "Drum Sander",
+    "Ender 3D Printers",
+    "Formlabs Form 3 printer",
+    "Hand held plasma cutter",
+    "Jointer",
+    "LeBlond Lathe",
+    "Metal Band Saw",
+    "Metal Drill Press",
+    "Mig Welders",
+    "Mitre Saw",
+    "Multi-Router",
+    "Panel Saw",
+    "Planer",
+    "Pneumatic Power Tools",
+    "Powder Coating Equipment",
+    "Prusa 3D printers",
+    "Router Table",
+    "Sanders",
+    "Saw Dado",
+    "Serger sewing machine",
+    "Square Chisel Morticer",
+    "Surface Grinder",
+    "Table Saw",
+    "Tier one Sewing Machine",
+    "Tig Welders",
+    "Tube Bending Equipment",
+    "Wood Drill Press",
+    "Wood Lathe",
+    "Wood Mini Lathe",
+]
+
+STORAGE_AREAS = [
+    "North Wall",
+    "South Wall",
+    "East Wall",
+    "West Wall",
+    "Woodshop Corner",
+    "Metalshop",
+    "Electronics Bench",
+    "Classroom",
+    "Main Floor",
+    "Mezzanine",
+]
+
+
+### Dev bypass users — these are always the same, always first
+
+DEV_USERS = [
+    # ID 1 - Ada Lovelace, Administrator
+    {
+        "identity": {
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "nickname": "enchantress_of_numbers",
+            "active_directory_username": "alovelace",
+            "emails": [{"type": "primary", "email_address": "ada.lovelace@example.com"}],
+        },
+        "connections": {"discord_username": "ada_admin"},
+        "status": {
+            "membership_status": "Active",
+            "membership_level": "Stripe Member - $65",
+            "member_since": "2020-01-15",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "DL-1234",
+            "waiver_signed_date": "2020-01-15",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2020-01-22",
+        },
+        "access": {"rfid_tags": ["12345678", "87654321"]},
+        "authorizations": {
+            "authorizations": [
+                "Table Saw", "Band Saw", "Mig Welders", "Tig Welders",
+                "Jointer", "Planer", "Mitre Saw", "Sanders",
+                "Wood Drill Press", "Router Table",
+            ],
+            "computer_authorizations": [
+                "Epilog Authorized Users", "Tormach Authorized Users",
+                "ShopBot Authorized Users",
+            ],
+        },
+        "extras": {"storage_id": "A-01", "storage_area": "North Wall"},
+        "notes": {
+            "notes": [
+                {"date": "2020-01-22", "author": "System", "text": "Completed orientation and safety training"},
+                {"date": "2023-06-10", "author": "Board", "text": "Granted administrator access to the admin portal"},
+            ]
+        },
+    },
+    # ID 2 - Charles Babbage, Administrator
+    {
+        "identity": {
+            "first_name": "Charles",
+            "last_name": "Babbage",
+            "nickname": "difference_engine",
+            "active_directory_username": "cbabbage",
+            "emails": [{"type": "primary", "email_address": "charles.babbage@example.com"}],
+        },
+        "connections": {"discord_username": "cbabbage"},
+        "status": {
+            "membership_status": "Active",
+            "membership_level": "Member - Cash Payment",
+            "member_since": "2019-03-10",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "DL-5678",
+            "waiver_signed_date": "2019-03-10",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2019-03-17",
+        },
+        "access": {"rfid_tags": ["23456789"]},
+        "authorizations": {
+            "authorizations": [
+                "Table Saw", "Band Saw", "Metal Band Saw",
+                "Metal Drill Press", "Bridgeport Mill", "Clausing Lathe",
+            ],
+            "computer_authorizations": [
+                "Boss Authorized Users", "CNC Plasma Authorized Users",
+            ],
+        },
+        "extras": None,
+        "notes": {
+            "notes": [
+                {"date": "2019-03-17", "author": "System", "text": "Orientation completed"},
+                {"date": "2024-01-15", "author": "Board", "text": "Added as administrator"},
+            ]
+        },
+    },
+    # ID 3 - Nikola Tesla, Authorizer
+    {
+        "identity": {
+            "first_name": "Nikola",
+            "last_name": "Tesla",
+            "nickname": "spark_lord",
+            "active_directory_username": "ntesla",
+            "emails": [{"type": "primary", "email_address": "nikola.tesla@example.com"}],
+        },
+        "connections": {"discord_username": "spark_lord"},
+        "status": {
+            "membership_status": "Active",
+            "membership_level": "Volunteer",
+            "member_since": "2018-06-01",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "PP-9012",
+            "waiver_signed_date": "2018-06-01",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2018-06-08",
+        },
+        "access": {"rfid_tags": ["11223344"]},
+        "authorizations": {
+            "authorizations": [
+                "Table Saw", "Band Saw", "Mig Welders", "Tig Welders",
+                "Jointer", "Planer", "Mitre Saw", "Sanders",
+                "Wood Drill Press", "Router Table", "Metal Band Saw",
+                "Metal Drill Press", "Bridgeport Mill", "Clausing Lathe",
+                "LeBlond Lathe", "Surface Grinder", "Hand held plasma cutter",
+                "Pneumatic Power Tools", "Powder Coating Equipment",
+                "Tube Bending Equipment",
+            ],
+            "computer_authorizations": [
+                "Epilog Authorized Users", "Tormach Authorized Users",
+                "Universal Authorized Users", "Boss Authorized Users",
+                "CNC Plasma Authorized Users", "ShopBot Authorized Users",
+            ],
+        },
+        "extras": None,
+        "notes": {
+            "notes": [
+                {"date": "2018-06-08", "author": "System", "text": "Completed orientation"},
+                {"date": "2019-02-14", "author": "Board", "text": "Approved as equipment authorizer for metalworking and CNC areas"},
+            ]
+        },
+    },
+    # ID 4 - Hedy Lamarr, Authorizer
+    {
+        "identity": {
+            "first_name": "Hedy",
+            "last_name": "Lamarr",
+            "nickname": "frequency_hopper",
+            "active_directory_username": "hlamarr",
+            "emails": [{"type": "primary", "email_address": "hedy.lamarr@example.com"}],
+        },
+        "connections": {"discord_username": "hedy_builds"},
+        "status": {
+            "membership_status": "Active",
+            "membership_level": "Volunteer w/ Free Storage",
+            "member_since": "2019-09-15",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "DL-3456",
+            "waiver_signed_date": "2019-09-15",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2019-09-22",
+        },
+        "access": {"rfid_tags": ["44556677", "55667788"]},
+        "authorizations": {
+            "authorizations": [
+                "Table Saw", "Band Saw", "Wood Lathe", "Wood Mini Lathe",
+                "Drum Sander", "Panel Saw", "Saw Dado",
+                "Square Chisel Morticer", "Jointer", "Planer",
+                "Ender 3D Printers", "Prusa 3D printers",
+                "Formlabs Form 3 printer",
+            ],
+            "computer_authorizations": [
+                "Epilog Authorized Users", "Universal Authorized Users",
+                "Vinyl Cutter Authorized Users", "Mimaki CJV30 printer Users",
+            ],
+        },
+        "extras": {"storage_id": "C-05", "storage_area": "Woodshop Corner"},
+        "notes": {
+            "notes": [
+                {"date": "2019-09-22", "author": "System", "text": "Completed orientation and all woodshop authorizations"},
+                {"date": "2020-04-01", "author": "Board", "text": "Approved as authorizer for woodshop, 3D printing, and laser areas"},
+            ]
+        },
+    },
+    # ID 5 - Grace Hopper, Board
+    {
+        "identity": {
+            "first_name": "Grace",
+            "last_name": "Hopper",
+            "nickname": "queen_bug",
+            "active_directory_username": "ghopper",
+            "emails": [{"type": "primary", "email_address": "grace.hopper@example.com"}],
+        },
+        "connections": {"discord_username": "admiral_grace"},
+        "status": {
+            "membership_status": "Active",
+            "membership_level": "Board Member / Officer",
+            "member_since": "2017-11-01",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "DL-7890",
+            "waiver_signed_date": "2017-11-01",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2017-11-08",
+        },
+        "access": {"rfid_tags": ["99887766"]},
+        "authorizations": {
+            "authorizations": ["Ender 3D Printers", "Prusa 3D printers", "Band Saw"],
+            "computer_authorizations": [],
+        },
+        "extras": None,
+        "notes": {
+            "notes": [
+                {"date": "2017-11-08", "author": "System", "text": "Completed orientation"},
+                {"date": "2022-01-01", "author": "Board", "text": "Elected to board of directors"},
+            ]
+        },
+    },
+    # ID 6 - Margaret Hamilton, Board
+    {
+        "identity": {
+            "first_name": "Margaret",
+            "last_name": "Hamilton",
+            "nickname": "stack_overflow",
+            "active_directory_username": "mhamilton",
+            "emails": [{"type": "primary", "email_address": "margaret.hamilton@example.com"}],
+        },
+        "connections": {"discord_username": "mhamilton_apollo"},
+        "status": {
+            "membership_status": "Active",
+            "membership_level": "Board Member / Officer",
+            "member_since": "2018-03-15",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "DL-2345",
+            "waiver_signed_date": "2018-03-15",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2018-03-22",
+        },
+        "access": {"rfid_tags": ["77665544"]},
+        "authorizations": {
+            "authorizations": ["Table Saw", "Mitre Saw", "Sanders", "Ender 3D Printers"],
+            "computer_authorizations": ["Epilog Authorized Users"],
+        },
+        "extras": None,
+        "notes": {
+            "notes": [
+                {"date": "2018-03-22", "author": "System", "text": "Completed orientation"},
+                {"date": "2023-01-01", "author": "Board", "text": "Elected to board"},
+            ]
+        },
+    },
+    # ID 7 - Rosalind Franklin, Active Member
+    {
+        "identity": {
+            "first_name": "Rosalind",
+            "last_name": "Franklin",
+            "nickname": "photo_51",
+            "active_directory_username": "rfranklin",
+            "emails": [{"type": "primary", "email_address": "rosalind.franklin@example.com"}],
+        },
+        "connections": {"discord_username": "xray_rosalind"},
+        "status": {
+            "membership_status": "Active",
+            "membership_level": "Member - Cash Payment",
+            "member_since": "2021-04-01",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "DL-6789",
+            "waiver_signed_date": "2021-04-01",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2021-04-08",
+        },
+        "access": {"rfid_tags": ["33221100", "44332211"]},
+        "authorizations": {
+            "authorizations": [
+                "Table Saw", "Band Saw", "Mig Welders", "Jointer",
+                "Planer", "Ender 3D Printers", "Prusa 3D printers",
+            ],
+            "computer_authorizations": [
+                "Epilog Authorized Users", "Tormach Authorized Users",
+            ],
+        },
+        "extras": {"storage_id": "B-12", "storage_area": "South Wall"},
+        "notes": {
+            "notes": [
+                {"date": "2021-04-08", "author": "System", "text": "Completed orientation and basic woodshop training"},
+            ]
+        },
+    },
+    # ID 8 - Katherine Johnson, Active Member
+    {
+        "identity": {
+            "first_name": "Katherine",
+            "last_name": "Johnson",
+            "nickname": "human_computer",
+            "active_directory_username": "kjohnson",
+            "emails": [{"type": "primary", "email_address": "katherine.johnson@example.com"}],
+        },
+        "connections": {"discord_username": "kjohnson_math"},
+        "status": {
+            "membership_status": "Active",
+            "membership_level": "Stripe Member - $65",
+            "member_since": "2022-02-14",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "DL-0123",
+            "waiver_signed_date": "2022-02-14",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2022-02-21",
+        },
+        "access": {"rfid_tags": ["66778899"]},
+        "authorizations": {
+            "authorizations": [
+                "Ender 3D Printers", "Prusa 3D printers",
+                "Formlabs Form 3 printer", "Tier one Sewing Machine",
+                "Serger sewing machine", "Button sewing machines",
+            ],
+            "computer_authorizations": [
+                "Epilog Authorized Users", "Vinyl Cutter Authorized Users",
+            ],
+        },
+        "extras": None,
+        "notes": {
+            "notes": [
+                {"date": "2022-02-21", "author": "System", "text": "Completed orientation, focused on textiles and 3D printing"},
+            ]
+        },
+    },
+    # ID 9 - Marie Curie, Inactive Member
+    {
+        "identity": {
+            "first_name": "Marie",
+            "last_name": "Curie",
+            "nickname": "glow_girl",
+            "active_directory_username": "mcurie",
+            "emails": [{"type": "primary", "email_address": "marie.curie@example.com"}],
+        },
+        "connections": {"discord_username": "mcurie_rad"},
+        "status": {
+            "membership_status": "Inactive",
+            "membership_level": "Member - Cash Payment",
+            "member_since": "2018-06-01",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "DL-4567",
+            "waiver_signed_date": "2018-06-01",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2018-06-08",
+        },
+        "access": {"rfid_tags": ["33445566"]},
+        "authorizations": {
+            "authorizations": ["Table Saw", "Band Saw", "Mig Welders", "Cold Metals Basic"],
+            "computer_authorizations": [],
+        },
+        "extras": None,
+        "notes": {
+            "notes": [
+                {"date": "2018-06-08", "author": "System", "text": "Completed orientation"},
+                {"date": "2024-03-01", "author": "System", "text": "Membership lapsed \u2014 moved to inactive"},
+            ]
+        },
+    },
+    # ID 10 - Laika Sputnik, Inactive Member
+    {
+        "identity": {
+            "first_name": "Laika",
+            "last_name": "Sputnik",
+            "nickname": "good_dog",
+            "active_directory_username": "lsputnik",
+            "emails": [{"type": "primary", "email_address": "laika.sputnik@example.com"}],
+        },
+        "connections": None,
+        "status": {
+            "membership_status": "Inactive",
+            "membership_level": "Stripe Member - $65",
+            "member_since": "2023-09-01",
+        },
+        "forms": {
+            "id_check_1": "IL",
+            "id_check_2": "DL-8901",
+            "waiver_signed_date": "2023-09-01",
+            "terms_of_use_accepted": "true",
+            "essentials_form": "completed",
+            "orientation_completed_date": "2023-09-08",
+        },
+        "access": None,
+        "authorizations": {
+            "authorizations": ["Band Saw", "Ender 3D Printers"],
+            "computer_authorizations": [],
+        },
+        "extras": None,
+        "notes": {
+            "notes": [
+                {"date": "2023-09-08", "author": "System", "text": "Completed orientation"},
+                {"date": "2024-06-01", "author": "System", "text": "Membership lapsed after 9 months"},
+            ]
+        },
+    },
+]
+
+# RFID tags used by dev users — we track these so the generator
+# doesn't accidentally duplicate them in random members
+DEV_USER_RFID_TAGS = set()
+DEV_USER_USERNAMES = set()
+DEV_USER_EMAILS = set()
+for _user in DEV_USERS:
+    if _user.get("access") and _user["access"].get("rfid_tags"):
+        DEV_USER_RFID_TAGS.update(_user["access"]["rfid_tags"])
+    if _user["identity"].get("active_directory_username"):
+        DEV_USER_USERNAMES.add(_user["identity"]["active_directory_username"])
+    for email_entry in _user["identity"].get("emails", []):
+        DEV_USER_EMAILS.add(email_entry["email_address"])
+
+
+### SQL generation helpers
+
+def make_member_sql(member: dict) -> str:
+    """Convert a member dict to an INSERT INTO member (...) VALUES (...) statement."""
+    columns = [
+        "identity", "connections", "status", "forms",
+        "access", "authorizations", "extras", "notes",
+    ]
+
+    values = []
+    for col in columns:
+        val = member.get(col)
+        if val is None:
+            values.append("NULL")
+        else:
+            json_str = json.dumps(val, ensure_ascii=False)
+            escaped = json_str.replace("'", "''")
+            values.append(f"'{escaped}'::jsonb")
+
+    cols_str = ", ".join(columns)
+    vals_str = ",\n    ".join(values)
+    return f"INSERT INTO member ({cols_str}) VALUES (\n    {vals_str}\n);"
+
+
+def pick_membership_level(is_active: bool, is_new: bool) -> str:
+    """Pick a membership level appropriate for the member's status."""
+    if is_new:
+        return "New Member"
+
+    if not is_active:
+        # Inactive members were on regular paid plans
+        inactive_levels = [
+            "Stripe Member - $65",
+            "Member - Cash Payment",
+            "Member - PayPal",
+            "Member - Grandfathered Price",
+            "Stripe Member w/ Storage - $95",
+        ]
+        return random.choice(inactive_levels)
+
+    # Active members — weighted random from the full list
+    types = list(MEMBERSHIP_WEIGHTS.keys())
+    weights = [MEMBERSHIP_WEIGHTS[t] for t in types]
+    return random.choices(types, weights=weights, k=1)[0]
+
+
+def generate_forms(fake: Faker) -> dict:
+    """Generate a realistic forms JSONB object."""
+    waiver_date = fake.date_between(start_date="-5y", end_date="-1m")
+    orientation_date = waiver_date + timedelta(days=random.randint(1, 14))
+    return {
+        "id_check_1": fake.state_abbr(),
+        "id_check_2": f"DL-{random.randint(1000, 9999)}",
+        "waiver_signed_date": waiver_date.isoformat(),
+        "terms_of_use_accepted": "true",
+        "essentials_form": "completed",
+        "orientation_completed_date": orientation_date.isoformat(),
+    }
+
+
+def generate_unique_rfid_tags(count: int, used_tags: set) -> list[str]:
+    """Generate unique RFID tags (5-8 digit numeric strings)."""
+    tags = []
+    for _ in range(count):
+        for _attempt in range(1000):
+            length = random.randint(5, 8)
+            tag = str(random.randint(10 ** (length - 1), 10**length - 1))
+            if tag not in used_tags:
+                used_tags.add(tag)
+                tags.append(tag)
+                break
+    return tags
+
+
+def generate_authorizations() -> dict | None:
+    """Generate a random set of authorizations."""
+    num_physical = random.choices(
+        [0, 1, 2, 3, 5, 7, 10, 15],
+        weights=[10, 15, 15, 15, 15, 10, 10, 5],
+        k=1,
+    )[0]
+    num_computer = random.choices(
+        [0, 0, 0, 1, 1, 2, 3, 4],
+        weights=[30, 10, 10, 15, 10, 10, 10, 5],
+        k=1,
+    )[0]
+
+    physical = sorted(random.sample(
+        PHYSICAL_AUTHORIZATIONS,
+        min(num_physical, len(PHYSICAL_AUTHORIZATIONS)),
+    ))
+    computer = sorted(random.sample(
+        COMPUTER_AUTHORIZATIONS,
+        min(num_computer, len(COMPUTER_AUTHORIZATIONS)),
+    ))
+
+    if not physical and not computer:
+        return None
+
+    result = {}
+    if physical:
+        result["authorizations"] = physical
+    else:
+        result["authorizations"] = []
+    if computer:
+        result["computer_authorizations"] = computer
+    else:
+        result["computer_authorizations"] = []
+    return result
+
+
+def generate_notes(fake: Faker) -> dict | None:
+    """Generate random notes entries."""
+    num_notes = random.randint(1, 3)
+    notes_list = []
+    for _ in range(num_notes):
+        notes_list.append({
+            "date": fake.date_between(start_date="-3y", end_date="today").isoformat(),
+            "author": random.choice(["System", "Board", "Admin"]),
+            "text": fake.sentence(nb_words=random.randint(5, 15)),
+        })
+    return {"notes": notes_list}
+
+
+def generate_random_member(
+    fake: Faker,
+    used_rfid_tags: set,
+    used_usernames: set,
+    used_emails: set,
+) -> dict:
+    """Generate a single randomized member dict."""
+    # ~80% Active, ~20% Inactive
+    is_active = random.random() < 0.8
+
+    # ~8% of active members are "brand new" (minimal data)
+    is_new = is_active and random.random() < 0.08
+
+    first_name = fake.first_name()
+    last_name = fake.last_name()
+
+    # Build a unique username
+    username = f"{first_name[0].lower()}{last_name.lower()}"
+    base_username = username
+    counter = 1
+    while username in used_usernames:
+        username = f"{base_username}{counter}"
+        counter += 1
+
+    # Build a unique email
+    email = f"{first_name.lower()}.{last_name.lower()}@example.com"
+    base_email = email
+    counter = 1
+    while email in used_emails:
+        email = f"{first_name.lower()}.{last_name.lower()}{counter}@example.com"
+        counter += 1
+
+    if not is_new:
+        used_usernames.add(username)
+    used_emails.add(email)
+
+    # Identity
+    identity = {
+        "first_name": first_name,
+        "last_name": last_name,
+        "nickname": fake.user_name() if not is_new else None,
+        "active_directory_username": username if not is_new else None,
+        "emails": [{"type": "primary", "email_address": email}],
+    }
+
+    # Status
+    membership_level = pick_membership_level(is_active, is_new)
+    if is_new:
+        member_since = fake.date_between(start_date="-14d", end_date="today").isoformat()
+    elif is_active:
+        member_since = fake.date_between(start_date="-7y", end_date="-2m").isoformat()
+    else:
+        member_since = fake.date_between(start_date="-8y", end_date="-1y").isoformat()
+
+    status = {
+        "membership_status": "Active" if is_active else "Inactive",
+        "membership_level": membership_level,
+        "member_since": member_since,
+    }
+
+    # Connections (~65% chance if not new)
+    connections = None
+    if not is_new and random.random() < 0.65:
+        connections = {"discord_username": fake.user_name()}
+
+    # Forms (null if brand new)
+    forms = None if is_new else generate_forms(fake)
+
+    # Access / RFID (null if brand new)
+    access = None
+    if not is_new:
+        num_tags = random.choices([0, 1, 1, 1, 2, 2, 3], k=1)[0]
+        if num_tags > 0:
+            tags = generate_unique_rfid_tags(num_tags, used_rfid_tags)
+            if tags:
+                access = {"rfid_tags": tags}
+
+    # Authorizations (null if brand new)
+    authorizations = None if is_new else generate_authorizations()
+
+    # Extras — storage for members with storage-type plans, or ~15% random
+    extras = None
+    if not is_new:
+        has_storage_plan = "Storage" in membership_level
+        if has_storage_plan or random.random() < 0.15:
+            area = random.choice(STORAGE_AREAS)
+            row_letter = random.choice("ABCDEFGH")
+            slot_number = random.randint(1, 30)
+            extras = {
+                "storage_id": f"{row_letter}-{slot_number:02d}",
+                "storage_area": area,
+            }
+
+    # Notes (~35% chance if not new)
+    notes = None
+    if not is_new and random.random() < 0.35:
+        notes = generate_notes(fake)
+
+    # Inactive members might have a lapsed note
+    if not is_active and (notes is None or random.random() < 0.6):
+        lapsed_note = {
+            "date": fake.date_between(start_date="-6m", end_date="today").isoformat(),
+            "author": "System",
+            "text": random.choice([
+                "Membership lapsed \u2014 moved to inactive",
+                "Payment failed \u2014 membership deactivated",
+                "Member requested deactivation",
+                "Membership expired \u2014 no renewal",
+            ]),
+        }
+        if notes is None:
+            notes = {"notes": [lapsed_note]}
+        else:
+            notes["notes"].append(lapsed_note)
+
+    return {
+        "identity": identity,
+        "connections": connections,
+        "status": status,
+        "forms": forms,
+        "access": access,
+        "authorizations": authorizations,
+        "extras": extras,
+        "notes": notes,
+    }
+
+
+### Role assignment SQL
+
+ROLE_ASSIGNMENTS = [
+    (2, 1, "Ada Lovelace", "Administrator"),
+    (2, 2, "Charles Babbage", "Administrator"),
+    (1, 3, "Nikola Tesla", "Authorizer"),
+    (1, 4, "Hedy Lamarr", "Authorizer"),
+    (3, 5, "Grace Hopper", "Board"),
+    (3, 6, "Margaret Hamilton", "Board"),
+]
+
+
+def generate_role_assignments_sql() -> str:
+    """Generate INSERT statements for member_to_role."""
+    lines = []
+    for role_id, member_id, name, role_name in ROLE_ASSIGNMENTS:
+        lines.append(
+            f"INSERT INTO member_to_role (role_id, member_id) "
+            f"VALUES ({role_id}, {member_id});   "
+            f"/* {name} -> {role_name} */"
+        )
+    return "\n".join(lines)
+
+
+### Main SQL generation
+
+def generate_sql(count: int, seed: str) -> str:
+    """Generate the complete seed data SQL file."""
+    # Convert seed string to integer for random/Faker seeding
+    seed_int = int(hashlib.sha256(seed.encode()).hexdigest()[:16], 16)
+    random.seed(seed_int)
+    Faker.seed(seed_int)
+    fake = Faker()
+
+    lines = []
+
+    # Header
+    lines.append("/*")
+    lines.append(f" * Deep Harbor Seed Data (generated)")
+    lines.append(f" *")
+    lines.append(f" * Seed:  {seed}")
+    lines.append(f" * Count: {count + len(DEV_USERS)} total ({len(DEV_USERS)} dev users + {count} random)")
+    lines.append(f" *")
+    lines.append(f" * Generated by: pg/tools/generate_seed_data.py")
+    lines.append(f" * Reproduce with: uv run pg/tools/generate_seed_data.py --seed {seed} --count {count}")
+    lines.append(f" *")
+    lines.append(f" * IMPORTANT: The first {len(DEV_USERS)} members are dev bypass users with stable IDs.")
+    lines.append(f" * Issue #13 (dev auth bypass) references these IDs. Don't reorder them.")
+    lines.append(f" *")
+    lines.append(f" * Inserting members fires the audit trigger, log_member_changes(),")
+    lines.append(f" * and pg_notify. First boot will be noisy. This is expected.")
+    lines.append(f" */")
+    lines.append("")
+
+    # Dev users
+    lines.append("")
+    lines.append("/* =====================================================")
+    lines.append(f" * Dev Bypass Users (IDs 1-{len(DEV_USERS)})")
+    lines.append(" * ===================================================== */")
+    lines.append("")
+    for i, user in enumerate(DEV_USERS):
+        name = f"{user['identity']['first_name']} {user['identity']['last_name']}"
+        lines.append(f"/* ID {i + 1} - {name} */")
+        lines.append(make_member_sql(user))
+        lines.append("")
+
+    # Random members
+    used_rfid_tags = set(DEV_USER_RFID_TAGS)
+    used_usernames = set(DEV_USER_USERNAMES)
+    used_emails = set(DEV_USER_EMAILS)
+
+    start_id = len(DEV_USERS) + 1
+    end_id = start_id + count - 1
+
+    lines.append("")
+    lines.append("/* =====================================================")
+    lines.append(f" * Random Members (IDs {start_id}-{end_id})")
+    lines.append(" * ===================================================== */")
+    lines.append("")
+
+    for i in range(count):
+        member = generate_random_member(fake, used_rfid_tags, used_usernames, used_emails)
+        name = f"{member['identity']['first_name']} {member['identity']['last_name']}"
+        lines.append(f"/* ID {start_id + i} - {name} */")
+        lines.append(make_member_sql(member))
+        lines.append("")
+
+    # Role assignments
+    lines.append("")
+    lines.append("/* =====================================================")
+    lines.append(" * Role Assignments for Dev Bypass Users")
+    lines.append(" * Roles: Authorizer (1), Administrator (2), Board (3)")
+    lines.append(" * ===================================================== */")
+    lines.append("")
+    lines.append(generate_role_assignments_sql())
+    lines.append("")
+
+    # Sequence reset
+    lines.append("")
+    lines.append("/* Reset the member identity sequence to account for seed data */")
+    lines.append("SELECT setval(pg_get_serial_sequence('member', 'id'), (SELECT MAX(id) FROM member));")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+### CLI
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate seed data SQL for the Deep Harbor CRM database.",
+        epilog="Example: uv run pg/tools/generate_seed_data.py --seed abc123 --count 50",
+    )
+    parser.add_argument(
+        "--seed",
+        type=str,
+        default=None,
+        help="Seed for reproducible output. If omitted, a random seed is "
+             "generated and printed to stderr.",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=15,
+        help="Number of ADDITIONAL random members beyond the 10 dev users "
+             "(default: 15, for 25 total).",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output file path. Defaults to stdout.",
+    )
+
+    args = parser.parse_args()
+
+    seed = args.seed
+    if seed is None:
+        seed = secrets.token_hex(8)
+        print(f"Generated seed: {seed}", file=sys.stderr)
+
+    sql = generate_sql(args.count, seed)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(sql)
+        print(f"Wrote {args.output} ({args.count + len(DEV_USERS)} members)", file=sys.stderr)
+    else:
+        print(sql)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/seed_data.sh
+++ b/tools/seed_data.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# seed_data.sh — Manage seed data for the Deep Harbor dev environment
+#
+# This script provides a convenient way to use either the hand-crafted
+# static seed data or the Python generator to populate seed_data.sql.
+#
+# Usage:
+#   tools/seed_data.sh static          Use the hand-crafted seed data (25 members)
+#   tools/seed_data.sh generate        Generate random seed data (25 members by default)
+#   tools/seed_data.sh generate 100    Generate 110 members (100 random + 10 dev users)
+#   tools/seed_data.sh generate 50 abc Generate with specific seed for reproducibility
+#   tools/seed_data.sh status          Show what's currently in seed_data.sql
+#
+# The output file is pg/sql/seed_data.sql, which docker-compose.dev.yml
+# mounts as /docker-entrypoint-initdb.d/02-seed_data.sql. After changing
+# seed data you'll need to reset the database:
+#   docker compose -f docker-compose.yaml -f docker-compose.dev.yml down -v
+#   docker compose -f docker-compose.yaml -f docker-compose.dev.yml up --build -d
+#
+
+set -euo pipefail
+
+# Figure out the repo root relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SEED_DATA_FILE="$REPO_ROOT/pg/sql/seed_data.sql"
+STATIC_SEED_DATA="$REPO_ROOT/pg/sql/seed_data.sql.static"
+GENERATOR="$REPO_ROOT/pg/tools/generate_seed_data.py"
+
+usage() {
+    echo "Usage: $0 <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  static              Restore the hand-crafted static seed data (25 members)"
+    echo "  generate [N] [SEED] Generate seed data with N random members (default: 15)"
+    echo "                      plus 10 dev bypass users. Optionally specify a seed"
+    echo "                      for reproducibility."
+    echo "  status              Show what's currently in seed_data.sql"
+    echo ""
+    echo "Examples:"
+    echo "  $0 static                  Use the committed static seed data"
+    echo "  $0 generate                Generate 25 members (15 random + 10 dev)"
+    echo "  $0 generate 100            Generate 110 members (100 random + 10 dev)"
+    echo "  $0 generate 50 myseed123   Reproducible: same seed = same output"
+    echo "  $0 status                  Check current seed data file"
+    echo ""
+    echo "After changing seed data, reset the database:"
+    echo "  docker compose -f docker-compose.yaml -f docker-compose.dev.yml down -v"
+    echo "  docker compose -f docker-compose.yaml -f docker-compose.dev.yml up --build -d"
+}
+
+cmd_static() {
+    # Check if git can restore the committed version
+    if git -C "$REPO_ROOT" show HEAD:pg/sql/seed_data.sql > /dev/null 2>&1; then
+        git -C "$REPO_ROOT" show HEAD:pg/sql/seed_data.sql > "$SEED_DATA_FILE"
+        local count
+        count=$(grep -c "INSERT INTO member " "$SEED_DATA_FILE" || true)
+        echo "Restored static seed data: $count member inserts"
+    else
+        echo "Error: No committed seed_data.sql found in git."
+        echo "The static seed data file hasn't been committed yet."
+        exit 1
+    fi
+}
+
+cmd_generate() {
+    local count="${1:-15}"
+    local seed="${2:-}"
+
+    if ! command -v uv &> /dev/null; then
+        echo "Error: uv is required to run the generator. Install it:"
+        echo "  curl -LsSf https://astral.sh/uv/install.sh | sh"
+        exit 1
+    fi
+
+    local seed_args=()
+    if [[ -n "$seed" ]]; then
+        seed_args=(--seed "$seed")
+    fi
+
+    echo "Generating seed data: $count random + 10 dev users = $((count + 10)) total..."
+    uv run "$GENERATOR" --count "$count" "${seed_args[@]}" --output "$SEED_DATA_FILE"
+    echo "Wrote $SEED_DATA_FILE"
+}
+
+cmd_status() {
+    if [[ ! -f "$SEED_DATA_FILE" ]]; then
+        echo "No seed data file found at $SEED_DATA_FILE"
+        exit 0
+    fi
+
+    local member_count role_count
+    member_count=$(grep -c "INSERT INTO member (" "$SEED_DATA_FILE" || true)
+    role_count=$(grep -c "INSERT INTO member_to_role" "$SEED_DATA_FILE" || true)
+
+    echo "Seed data file: $SEED_DATA_FILE"
+    echo "  Members: $member_count"
+    echo "  Role assignments: $role_count"
+
+    # Check if it's generated or static
+    if head -5 "$SEED_DATA_FILE" | grep -q "generated"; then
+        local seed_line
+        seed_line=$(grep "Seed:" "$SEED_DATA_FILE" | head -1 || true)
+        echo "  Type: Generated"
+        echo "  $seed_line"
+    else
+        echo "  Type: Static (hand-crafted)"
+    fi
+}
+
+# Main dispatch
+case "${1:-}" in
+    static)
+        cmd_static
+        ;;
+    generate)
+        cmd_generate "${2:-15}" "${3:-}"
+        ;;
+    status)
+        cmd_status
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    "")
+        usage
+        exit 1
+        ;;
+    *)
+        echo "Unknown command: $1"
+        echo ""
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- **Static seed data** (`pg/sql/seed_data.sql`): 25 hand-crafted fictional members with 10 dev bypass users (IDs 1-10) that issue #13 will reference for dev auth bypass
- **Python generator** (`pg/tools/generate_seed_data.py`): Faker-based script with `--seed` for reproducibility and `--count` for configurable member count. Uses PEP 723 inline metadata — `uv run pg/tools/generate_seed_data.py` just works
- **Bash helper** (`tools/seed_data.sh`): Convenience wrapper for switching between static and generated seed data

### Dev bypass users (IDs 1-10)
| IDs | Role | Names |
|-----|------|-------|
| 1-2 | Administrator | Ada Lovelace, Charles Babbage |
| 3-4 | Authorizer | Nikola Tesla, Hedy Lamarr |
| 5-6 | Board | Grace Hopper, Margaret Hamilton |
| 7-8 | Active Member | Rosalind Franklin, Katherine Johnson |
| 9-10 | Inactive Member | Marie Curie, Laika Sputnik |

### Generator usage
```bash
# Use hand-crafted static data (25 members)
tools/seed_data.sh static

# Generate 110 members (100 random + 10 dev)
tools/seed_data.sh generate 100

# Reproducible output with seed
tools/seed_data.sh generate 50 myseed123

# Or call the Python script directly
uv run pg/tools/generate_seed_data.py --seed abc --count 200 --output pg/sql/seed_data.sql
```

## Test plan
- [ ] Verify `tools/seed_data.sh status` shows 25 members
- [ ] Verify `tools/seed_data.sh generate 5 test` produces valid SQL with 15 members
- [ ] Verify `tools/seed_data.sh static` restores the hand-crafted file
- [ ] Verify same `--seed` produces identical output (reproducibility)
- [ ] Full integration: `docker compose down -v && docker compose -f docker-compose.yaml -f docker-compose.dev.yml up --build -d`, then `psql -h localhost -U dh -d deepharbor -c "SELECT count(*) FROM member"` returns 25

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)