### PR TITLE
Added endpoint for determining version that is currently live

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,8 @@
-config.ini
 .env
+config.ini
 __pycache__/
-*.pyc
 wa2dh.log
 .vscode/
 *~
 flask_session/
 *.swp
-.serena
-.claude
-*.code-workspace

--- a/code/DHAdminPortal/.dockerignore
+++ b/code/DHAdminPortal/.dockerignore
@@ -1,3 +1,4 @@
+.env
 .venv
 Dockerfile
 start_services.sh

--- a/code/DHAdminPortal/Dockerfile
+++ b/code/DHAdminPortal/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t dhservice:latest .
 #
 
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 # Install uv.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -16,6 +16,12 @@ COPY . /app
 
 # Install the application dependencies.
 WORKDIR /app
+
+ARG GIT_VERSION=unknown
+
+RUN awk -v ver="$GIT_VERSION" 'BEGIN{ingit=0} /^\[git\]$/{ingit=1} /^\[/{if($0!="[git]") ingit=0} ingit && /^version=/{sub(/^version=.*/, "version=" ver)} {print}' config.ini > config.ini.tmp \
+  && mv config.ini.tmp config.ini
+
 RUN uv sync --frozen --no-cache
 
 # Set Flask environment variables

--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -9,6 +9,7 @@ import msal
 import dhservices
 from dhs_logging import logger
 import app_config
+from config import config
 
 app = Flask(__name__)
 app.config.from_object(app_config)
@@ -25,6 +26,10 @@ app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 @app.route("/health")
 def health():
     return "OK", 200
+
+@app.route("/version")
+def version():
+    return {"version": config["git"]["version"]}, 200
 
 ###############################################################################
 # Flask routes for B2C flows, including login and logout

--- a/code/DHAdminPortal/restart.sh
+++ b/code/DHAdminPortal/restart.sh
@@ -3,6 +3,9 @@
 # Get the current directory name and convert to lowercase
 SERVICE=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
 
+# Set up the git version string from the current commit
+echo "GIT_VERSION=$(git branch --show-current)-$(git rev-parse --short HEAD)" > .env
+
 # Rebuild the Docker image
 echo "Rebuilding image for service: $SERVICE"
 docker compose build "$SERVICE"

--- a/code/DHMemberPortal/.dockerignore
+++ b/code/DHMemberPortal/.dockerignore
@@ -1,3 +1,4 @@
+.env
 .venv
 Dockerfile
 start_services.sh

--- a/code/DHMemberPortal/Dockerfile
+++ b/code/DHMemberPortal/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t dhservice:latest .
 #
 
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 # Install uv.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -17,6 +17,11 @@ COPY . /app
 # Install the application dependencies.
 WORKDIR /app
 RUN uv sync --frozen --no-cache
+
+ARG GIT_VERSION=unknown
+
+RUN awk -v ver="$GIT_VERSION" 'BEGIN{ingit=0} /^\[git\]$/{ingit=1} /^\[/{if($0!="[git]") ingit=0} ingit && /^version=/{sub(/^version=.*/, "version=" ver)} {print}' config.ini > config.ini.tmp \
+  && mv config.ini.tmp config.ini
 
 # Set Flask environment variables
 ENV FLASK_APP=app.py

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -28,6 +28,9 @@ app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 def health():
     return "OK", 200
 
+@app.route("/version")
+def version():
+    return {"version": config["git"]["version"]}, 200
 
 ###############################################################################
 # Flask routes for B2C flows, including login and logout

--- a/code/DHMemberPortal/restart.sh
+++ b/code/DHMemberPortal/restart.sh
@@ -3,6 +3,9 @@
 # Get the current directory name and convert to lowercase
 SERVICE=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
 
+# Set up the git version string from the current commit
+echo "GIT_VERSION=$(git branch --show-current)-$(git rev-parse --short HEAD)" > .env
+
 # Rebuild the Docker image
 echo "Rebuilding image for service: $SERVICE"
 docker compose build "$SERVICE"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,10 @@ services:
   
   # Member Portal Service
   dhmemberportal:
-    build: ./code/DHMemberPortal
+    build: 
+      context: ./code/DHMemberPortal
+      args:
+        GIT_VERSION: "${GIT_VERSION}"
     restart: unless-stopped
     network_mode: host
     healthcheck:
@@ -80,7 +83,10 @@ services:
 
   # The admin portal service
   dhadminportal:
-    build: ./code/DHAdminPortal
+    build: 
+      context: ./code/DHAdminPortal
+      args:
+        GIT_VERSION: "${GIT_VERSION}"
     restart: unless-stopped
     network_mode: host
     healthcheck:
@@ -96,6 +102,7 @@ services:
     container_name: dh_admin_portal
     environment:
       TZ: "America/Chicago"
+    
 
   #########################################################
   # Main Application Service - this is the core
@@ -498,7 +505,12 @@ services:
     network_mode: host
     environment:
       TZ: "America/Chicago"
-      SERVICE_NAME: ST2DH
+      DATABASE_HOST: db
+      DATABASE_PORT: 5432
+      DATABASE_NAME: deepharbor
+      DATABASE_USER: dh
+      DATABASE_PASSWORD: dh
+      SERVICE_NAME: ST2DH      
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5004/health"]
       interval: 30s


### PR DESCRIPTION
This PR adds the an endpoint `/version` to the member and admin portals that show the branch and git hash that is currently live. It's meant as a sanity-check of what version is currently live.