### PR TITLE
Empty tags are filtered out of the list

### DIFF
--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -381,6 +381,8 @@ BEGIN
                           THEN 'ACTIVE'
                           ELSE 'INACTIVE'
                  END AS status
+	WHERE    at.tag IS NOT NULL
+        AND      TRIM(at.tag) <> ''
         FROM     all_tags at
         ORDER BY at.tag;
 END;


### PR DESCRIPTION
Member had an empty tag in their profile ("") that the `get_all_tags_for_member` did not like. 