### PR TITLE
Add AUTH_MODE=dev bypass for admin and member portals

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -10,6 +10,11 @@ import dhservices
 from dhs_logging import logger
 import app_config
 
+### Dev mode flag — read from app_config so we only check the env var once
+AUTH_MODE = app_config.AUTH_MODE
+if AUTH_MODE == "dev":
+    logger.info("AUTH_MODE=dev — B2C authentication bypassed, dev login enabled")
+
 app = Flask(__name__)
 app.config.from_object(app_config)
 Session(app)
@@ -40,6 +45,8 @@ def index():
     logger.info("Main route accessed")
     
     if not session.get("user"):
+        if AUTH_MODE == "dev":
+            return redirect(url_for("dev_login"))
         logger.info("No user logged in, building auth code flow")
         session["flow"] = _build_auth_code_flow(scopes=app_config.SCOPE)
         return render_template(
@@ -102,6 +109,8 @@ def index():
 
 @app.route("/login")
 def login():
+    if AUTH_MODE == "dev":
+        return redirect(url_for("dev_login"))
     print("Login route accessed")
     # Technically we could use empty list [] as scopes to do just sign in,
     # here we choose to also collect end user consent upfront
@@ -223,12 +232,18 @@ def logout():
             logger.error(f"Failed to log logout activity: {log_error}")
     
     session.clear()  # Wipe out user and its token cache from session
-    response = redirect(  # Also logout from your tenant's web session
-        app_config.AUTHORITY
-        + "/oauth2/v2.0/logout"
-        + "?post_logout_redirect_uri="
-        + url_for("index", _external=True)
-    )
+
+    if AUTH_MODE == "dev":
+        # Dev mode — just redirect to index, no B2C logout needed
+        response = redirect(url_for("index"))
+    else:
+        response = redirect(  # Also logout from your tenant's web session
+            app_config.AUTHORITY
+            + "/oauth2/v2.0/logout"
+            + "?post_logout_redirect_uri="
+            + url_for("index", _external=True)
+        )
+
     # Clear permissions cookie on logout
     response.set_cookie("user_permissions", "", expires=0)
     return response
@@ -283,6 +298,98 @@ def _get_token_from_cache(scope=None):
         return result
 
 app.jinja_env.globals.update(_build_auth_code_flow=_build_auth_code_flow)  # Used in template
+
+
+###############################################################################
+# Dev mode login routes — only active when AUTH_MODE=dev
+# These replace the B2C authentication flow with a simple user picker
+# that lets developers quickly log in as preset seed-data users.
+# Authorization (role/permission checks) still works normally.
+###############################################################################
+
+# Preset users for the dev login page. These match the seed data in
+# pg/sql/seed_data.sql — don't change the IDs without updating the SQL.
+ADMIN_DEV_USERS = [
+    {"member_id": 1, "name": "Ada Lovelace", "email": "ada.lovelace@example.com", "role": "Administrator"},
+    {"member_id": 3, "name": "Nikola Tesla", "email": "nikola.tesla@example.com", "role": "Authorizer"},
+    {"member_id": 5, "name": "Grace Hopper", "email": "grace.hopper@example.com", "role": "Board"},
+]
+
+@app.route("/dev-login")
+def dev_login():
+    """Show the dev login page with preset user options"""
+    if AUTH_MODE != "dev":
+        return redirect(url_for("index"))
+    return render_template("dev_login.html", preset_users=ADMIN_DEV_USERS)
+
+@app.route("/dev-login/select", methods=["POST"])
+def dev_login_select():
+    """Handle dev login — authenticate via DHService API, set session"""
+    if AUTH_MODE != "dev":
+        return redirect(url_for("index"))
+
+    member_id = request.form.get("member_id")
+    if not member_id:
+        return redirect(url_for("dev_login"))
+
+    try:
+        # Get DHService access token — same as the B2C callback does
+        access_token = dhservices.get_access_token(
+            dhservices.DH_CLIENT_ID,
+            dhservices.DH_CLIENT_SECRET
+        )
+
+        # Get member identity to populate session
+        identity = dhservices.get_member_identity(access_token, member_id)
+
+        # Extract email from identity
+        emails = identity.get("emails", [])
+        email = emails[0]["email_address"] if emails else f"dev-user-{member_id}@example.com"
+
+        # Verify they have roles (same check the B2C callback does)
+        roles_data = dhservices.get_member_roles(access_token, member_id)
+        if not roles_data or "roles" not in roles_data or len(roles_data["roles"]) == 0:
+            return render_template("auth_error.html", result={
+                "error": "Authorization Failed",
+                "error_description": f"Member ID {member_id} has no admin roles assigned. "
+                    "The admin portal requires a role (Administrator, Authorizer, or Board)."
+            })
+
+        # Build a user dict that looks like what B2C id_token_claims would give us
+        session["user"] = {
+            "name": f"{identity.get('first_name', '')} {identity.get('last_name', '')}".strip(),
+            "email": email,
+            "preferred_username": email,
+            "dev_mode": True,
+        }
+
+        logger.info(f"Dev login: member_id={member_id}, email={email}")
+
+        # Log login activity
+        try:
+            dhservices.log_user_activity(
+                access_token,
+                str(member_id),
+                {
+                    "activity_details": {
+                        "action": "dev_login",
+                        "email": email,
+                        "roles": roles_data.get("roles", [])
+                    }
+                }
+            )
+        except Exception as log_error:
+            logger.error(f"Failed to log dev login activity: {log_error}")
+
+    except Exception as e:
+        logger.error(f"Dev login error: {e}")
+        return render_template("auth_error.html", result={
+            "error": "Dev Login Error",
+            "error_description": f"Failed to authenticate with DHService: {str(e)}. "
+                "Make sure the database is running and seed data is loaded."
+        })
+
+    return redirect(url_for("index"))
 
 
 ###############################################################################

--- a/code/DHAdminPortal/app_config.py
+++ b/code/DHAdminPortal/app_config.py
@@ -2,40 +2,61 @@ import os
 from config import config
 
 ###############################################################################
+# Auth Mode Configuration
+###############################################################################
+
+# AUTH_MODE is set by docker-compose.dev.yml. When it's "dev", we skip
+# all B2C configuration and use a local dev login page instead.
+AUTH_MODE = os.environ.get("AUTH_MODE", "").lower()
+
+###############################################################################
 # Azure AD B2C Configurations
 ###############################################################################
-b2c_tenant = config["b2c"]["TENANT_NAME"]
 
-signupsignin_user_flow = config["b2c"]["SIGNUPSIGNIN_USER_FLOW"]
-editprofile_user_flow = config["b2c"]["EDITPROFILE_USER_FLOW"]
-resetpassword_user_flow = config["b2c"]["RESETPASSWORD_USER_FLOW"]  # Note: Legacy setting.
+if AUTH_MODE == "dev":
+    # Dev mode — no B2C needed. Set placeholders so the rest of the app
+    # doesn't crash on missing attributes. The actual auth flow will be
+    # intercepted by the dev login routes in app.py.
+    CLIENT_ID = "dev-placeholder"
+    CLIENT_SECRET = "dev-placeholder"
+    AUTHORITY = "https://dev-placeholder.b2clogin.com"
+    B2C_PROFILE_AUTHORITY = AUTHORITY
+    B2C_RESET_PASSWORD_AUTHORITY = AUTHORITY
+    REDIRECT_PATH = "/getAToken"
+    ENDPOINT = ""
+    SCOPE = []
+else:
+    b2c_tenant = config["b2c"]["TENANT_NAME"]
 
-authority_template = (
-    "https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{user_flow}"
-)
+    signupsignin_user_flow = config["b2c"]["SIGNUPSIGNIN_USER_FLOW"]
+    editprofile_user_flow = config["b2c"]["EDITPROFILE_USER_FLOW"]
+    resetpassword_user_flow = config["b2c"]["RESETPASSWORD_USER_FLOW"]  # Note: Legacy setting.
 
-CLIENT_ID = config["b2c"]["CLIENT_ID"]  # Application (client) ID of app registration in Azure portal.
-CLIENT_SECRET = config["b2c"]["CLIENT_SECRET"]  # Application secret.
+    authority_template = (
+        "https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{user_flow}"
+    )
 
-AUTHORITY = authority_template.format(
-    tenant=b2c_tenant, user_flow=signupsignin_user_flow
-)
-B2C_PROFILE_AUTHORITY = authority_template.format(
-    tenant=b2c_tenant, user_flow=editprofile_user_flow
-)
-B2C_RESET_PASSWORD_AUTHORITY = authority_template.format(
-    tenant=b2c_tenant, user_flow=resetpassword_user_flow
-)
+    CLIENT_ID = config["b2c"]["CLIENT_ID"]  # Application (client) ID of app registration in Azure portal.
+    CLIENT_SECRET = config["b2c"]["CLIENT_SECRET"]  # Application secret.
 
-REDIRECT_PATH = "/getAToken"
+    AUTHORITY = authority_template.format(
+        tenant=b2c_tenant, user_flow=signupsignin_user_flow
+    )
+    B2C_PROFILE_AUTHORITY = authority_template.format(
+        tenant=b2c_tenant, user_flow=editprofile_user_flow
+    )
+    B2C_RESET_PASSWORD_AUTHORITY = authority_template.format(
+        tenant=b2c_tenant, user_flow=resetpassword_user_flow
+    )
 
-# This is the API resource endpoint
-ENDPOINT = config["b2c"]["ENDPOINT"]  # Application ID URI of app registration in Azure portal
+    REDIRECT_PATH = "/getAToken"
 
-# These are the scopes you've exposed in the web API app registration in the Azure portal
-SCOPE = []
+    # This is the API resource endpoint
+    ENDPOINT = config["b2c"]["ENDPOINT"]  # Application ID URI of app registration in Azure portal
+
+    # These are the scopes you've exposed in the web API app registration in the Azure portal
+    SCOPE = []
 
 SESSION_TYPE = (
     "filesystem"  # Specifies the token cache should be stored in server-side session
 )
-

--- a/code/DHAdminPortal/config.py
+++ b/code/DHAdminPortal/config.py
@@ -17,3 +17,13 @@ if os.environ.get("DH_API_BASE_URL"):
     if not config.has_section("dh_services"):
         config.add_section("dh_services")
     config.set("dh_services", "api_base_url", os.environ["DH_API_BASE_URL"])
+
+if os.environ.get("DH_CLIENT_ID"):
+    if not config.has_section("dh_services"):
+        config.add_section("dh_services")
+    config.set("dh_services", "client_name", os.environ["DH_CLIENT_ID"])
+
+if os.environ.get("DH_CLIENT_SECRET"):
+    if not config.has_section("dh_services"):
+        config.add_section("dh_services")
+    config.set("dh_services", "client_secret", os.environ["DH_CLIENT_SECRET"])

--- a/code/DHAdminPortal/templates/dev_login.html
+++ b/code/DHAdminPortal/templates/dev_login.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% block title %}Dev Login - Admin Portal{% endblock %}
+{% block content %}
+
+<style>
+    .dev-banner {
+        background: #fef3c7;
+        border: 2px solid #f59e0b;
+        border-radius: 8px;
+        padding: 12px 20px;
+        margin-bottom: 24px;
+        text-align: center;
+        color: #92400e;
+        font-weight: 600;
+    }
+    .dev-user-card {
+        cursor: pointer;
+        transition: all 0.2s ease;
+        border: 2px solid transparent;
+    }
+    .dev-user-card:hover {
+        border-color: #ff69b4;
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    }
+    .dev-role-badge {
+        font-size: 0.8em;
+        padding: 4px 10px;
+        border-radius: 12px;
+        font-weight: 500;
+    }
+    .role-administrator { background: #dbeafe; color: #1e40af; }
+    .role-authorizer { background: #d1fae5; color: #065f46; }
+    .role-board { background: #ede9fe; color: #5b21b6; }
+</style>
+
+<h1>Pumping Station: One Administration Portal</h1>
+
+<div class="dev-banner">
+    DEV MODE — Authentication bypass active. Select a user to log in as.
+</div>
+
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <h3 class="text-center mb-4">Select a Dev User</h3>
+
+        <div class="row g-3 mb-4">
+            {% for user in preset_users %}
+            <div class="col-md-4">
+                <form method="POST" action="{{ url_for('dev_login_select') }}">
+                    <input type="hidden" name="member_id" value="{{ user.member_id }}">
+                    <div class="card dev-user-card" onclick="this.closest('form').submit()">
+                        <div class="card-body text-center">
+                            <h5 class="card-title">{{ user.name }}</h5>
+                            <span class="dev-role-badge role-{{ user.role|lower }}">{{ user.role }}</span>
+                            <p class="card-text mt-2"><small class="text-muted">ID: {{ user.member_id }}</small></p>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            {% endfor %}
+        </div>
+
+        <hr>
+
+        <h5 class="text-center mb-3">Or enter a member ID manually</h5>
+        <form method="POST" action="{{ url_for('dev_login_select') }}" class="d-flex justify-content-center gap-2">
+            <input type="number" name="member_id" class="form-control" style="max-width: 200px;"
+                   placeholder="Member ID" min="1" required>
+            <button type="submit" class="btn btn-primary">Log In</button>
+        </form>
+    </div>
+</div>
+
+{% endblock %}

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -12,6 +12,11 @@ from dhs_logging import logger
 from config import config
 import app_config
 
+### Dev mode flag — read from app_config so we only check the env var once
+AUTH_MODE = app_config.AUTH_MODE
+if AUTH_MODE == "dev":
+    logger.info("AUTH_MODE=dev — B2C authentication bypassed, dev login enabled")
+
 app = Flask(__name__)
 app.config.from_object(app_config)
 Session(app)
@@ -41,6 +46,8 @@ def anonymous():
 @app.route('/')
 def index():
     """Landing page with login and signup options"""
+    if AUTH_MODE == "dev":
+        return render_template('dev_login.html', preset_users=MEMBER_DEV_USERS)
     return render_template('landing.html')
 
 @app.route('/signup')
@@ -210,6 +217,8 @@ def signup_submit():
 
 @app.route("/login")
 def login():
+    if AUTH_MODE == "dev":
+        return redirect(url_for("index"))
     logger.info("Login route accessed - redirecting to B2C")
     try:
         # Technically, we don't need to save the state because Flask session is stored on the server,
@@ -317,11 +326,11 @@ def member_dashboard():
     
     if not session.get("user"):
         logger.warning("No user in session, redirecting to login")
-        return redirect(url_for("login"))
-    
+        return redirect(url_for("index") if AUTH_MODE == "dev" else url_for("login"))
+
     if 'access_token' not in session or 'member_id' not in session:
         logger.warning("Missing access_token or member_id in session, redirecting to login")
-        return redirect(url_for('login'))
+        return redirect(url_for("index") if AUTH_MODE == "dev" else url_for("login"))
     
     access_token = session['access_token']
     user_email = session['email']
@@ -407,6 +416,11 @@ def member_update_profile():
 def logout():
     logger.info("Logout route accessed")
     session.clear()  # Wipe out user and its token cache from session
+
+    if AUTH_MODE == "dev":
+        # Dev mode — just redirect to index, no B2C logout needed
+        return redirect(url_for("index"))
+
     return redirect(  # Also logout from your tenant's web session
         app_config.AUTHORITY
         + "/oauth2/v2.0/logout"
@@ -504,3 +518,62 @@ def _get_token_from_cache(scope=None):
 app.jinja_env.globals.update(_build_auth_code_flow=_build_auth_code_flow)  # Used in template
 # We want to show formatted dates in the dashboard
 app.jinja_env.globals.update(format_date=format_date)  # Used in template
+
+
+###############################################################################
+# Dev mode login routes — only active when AUTH_MODE=dev
+# These replace the B2C authentication flow with a simple user picker
+# that lets developers quickly log in as preset seed-data users.
+###############################################################################
+
+# Preset users for the dev login page. These match the seed data in
+# pg/sql/seed_data.sql — don't change the IDs without updating the SQL.
+MEMBER_DEV_USERS = [
+    {"member_id": 7, "name": "Rosalind Franklin", "email": "rosalind.franklin@example.com", "description": "Active member with full data"},
+    {"member_id": 16, "name": "Dorothy Vaughan", "email": "dorothy.vaughan@example.com", "description": "Brand new member, minimal data"},
+    {"member_id": 9, "name": "Marie Curie", "email": "marie.curie@example.com", "description": "Inactive member"},
+]
+
+@app.route("/dev-login/select", methods=["POST"])
+def dev_login_select():
+    """Handle dev login — authenticate via DHService API, set session"""
+    if AUTH_MODE != "dev":
+        return redirect(url_for("index"))
+
+    member_id = request.form.get("member_id")
+    if not member_id:
+        return redirect(url_for("index"))
+
+    try:
+        # Get DHService access token
+        access_token = dhservices.get_access_token(
+            dhservices.DH_CLIENT_ID,
+            dhservices.DH_CLIENT_SECRET
+        )
+
+        # Get member identity to populate session
+        identity = dhservices.get_member_identity(access_token, member_id)
+
+        # Extract email from identity
+        emails = identity.get("emails", [])
+        email = emails[0]["email_address"] if emails else f"dev-user-{member_id}@example.com"
+
+        # Set session variables to match what the B2C authorized() callback sets
+        session["user"] = {
+            "name": f"{identity.get('first_name', '')} {identity.get('last_name', '')}".strip(),
+            "email": email,
+            "preferred_username": email,
+            "dev_mode": True,
+        }
+        session["access_token"] = access_token
+        session["member_id"] = member_id
+        session["email"] = email
+
+        logger.info(f"Dev login: member_id={member_id}, email={email}")
+
+    except Exception as e:
+        logger.error(f"Dev login error: {e}")
+        flash(f"Dev login failed: {str(e)}. Make sure the database is running and seed data is loaded.", "error")
+        return redirect(url_for("index"))
+
+    return redirect(url_for("member_dashboard"))

--- a/code/DHMemberPortal/app_config.py
+++ b/code/DHMemberPortal/app_config.py
@@ -2,38 +2,60 @@ import os
 from config import config
 
 ###############################################################################
+# Auth Mode Configuration
+###############################################################################
+
+# AUTH_MODE is set by docker-compose.dev.yml. When it's "dev", we skip
+# all B2C configuration and use a local dev login page instead.
+AUTH_MODE = os.environ.get("AUTH_MODE", "").lower()
+
+###############################################################################
 # Azure AD B2C Configurations
 ###############################################################################
-b2c_tenant = config["b2c"]["TENANT_NAME"]
 
-signupsignin_user_flow = config["b2c"]["SIGNUPSIGNIN_USER_FLOW"]
-editprofile_user_flow = config["b2c"]["EDITPROFILE_USER_FLOW"]
-resetpassword_user_flow = config["b2c"]["RESETPASSWORD_USER_FLOW"]  # Note: Legacy setting.
+if AUTH_MODE == "dev":
+    # Dev mode — no B2C needed. Set placeholders so the rest of the app
+    # doesn't crash on missing attributes. The actual auth flow will be
+    # intercepted by the dev login routes in app.py.
+    CLIENT_ID = "dev-placeholder"
+    CLIENT_SECRET = "dev-placeholder"
+    AUTHORITY = "https://dev-placeholder.b2clogin.com"
+    B2C_PROFILE_AUTHORITY = AUTHORITY
+    B2C_RESET_PASSWORD_AUTHORITY = AUTHORITY
+    REDIRECT_PATH = "/getAToken"
+    ENDPOINT = ""
+    SCOPE = []
+else:
+    b2c_tenant = config["b2c"]["TENANT_NAME"]
 
-authority_template = (
-    "https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{user_flow}"
-)
+    signupsignin_user_flow = config["b2c"]["SIGNUPSIGNIN_USER_FLOW"]
+    editprofile_user_flow = config["b2c"]["EDITPROFILE_USER_FLOW"]
+    resetpassword_user_flow = config["b2c"]["RESETPASSWORD_USER_FLOW"]  # Note: Legacy setting.
 
-CLIENT_ID = config["b2c"]["CLIENT_ID"]  # Application (client) ID of app registration in Azure portal.
-CLIENT_SECRET = config["b2c"]["CLIENT_SECRET"]  # Application secret.
+    authority_template = (
+        "https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{user_flow}"
+    )
 
-AUTHORITY = authority_template.format(
-    tenant=b2c_tenant, user_flow=signupsignin_user_flow
-)
-B2C_PROFILE_AUTHORITY = authority_template.format(
-    tenant=b2c_tenant, user_flow=editprofile_user_flow
-)
-B2C_RESET_PASSWORD_AUTHORITY = authority_template.format(
-    tenant=b2c_tenant, user_flow=resetpassword_user_flow
-)
+    CLIENT_ID = config["b2c"]["CLIENT_ID"]  # Application (client) ID of app registration in Azure portal.
+    CLIENT_SECRET = config["b2c"]["CLIENT_SECRET"]  # Application secret.
 
-REDIRECT_PATH = "/getAToken"
+    AUTHORITY = authority_template.format(
+        tenant=b2c_tenant, user_flow=signupsignin_user_flow
+    )
+    B2C_PROFILE_AUTHORITY = authority_template.format(
+        tenant=b2c_tenant, user_flow=editprofile_user_flow
+    )
+    B2C_RESET_PASSWORD_AUTHORITY = authority_template.format(
+        tenant=b2c_tenant, user_flow=resetpassword_user_flow
+    )
 
-# This is the API resource endpoint
-ENDPOINT = config["b2c"]["ENDPOINT"]  # Application ID URI of app registration in Azure portal
+    REDIRECT_PATH = "/getAToken"
 
-# These are the scopes you've exposed in the web API app registration in the Azure portal
-SCOPE = []
+    # This is the API resource endpoint
+    ENDPOINT = config["b2c"]["ENDPOINT"]  # Application ID URI of app registration in Azure portal
+
+    # These are the scopes you've exposed in the web API app registration in the Azure portal
+    SCOPE = []
 
 SESSION_TYPE = (
     "filesystem"  # Specifies the token cache should be stored in server-side session

--- a/code/DHMemberPortal/config.py
+++ b/code/DHMemberPortal/config.py
@@ -17,3 +17,13 @@ if os.environ.get("DH_API_BASE_URL"):
     if not config.has_section("dh_services"):
         config.add_section("dh_services")
     config.set("dh_services", "api_base_url", os.environ["DH_API_BASE_URL"])
+
+if os.environ.get("DH_CLIENT_ID"):
+    if not config.has_section("dh_services"):
+        config.add_section("dh_services")
+    config.set("dh_services", "client_name", os.environ["DH_CLIENT_ID"])
+
+if os.environ.get("DH_CLIENT_SECRET"):
+    if not config.has_section("dh_services"):
+        config.add_section("dh_services")
+    config.set("dh_services", "client_secret", os.environ["DH_CLIENT_SECRET"])

--- a/code/DHMemberPortal/templates/dev_login.html
+++ b/code/DHMemberPortal/templates/dev_login.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dev Login - Member Portal</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/landing.css') }}">
+    <style>
+        .dev-banner {
+            background: #fef3c7;
+            border: 2px solid #f59e0b;
+            border-radius: 8px;
+            padding: 12px 20px;
+            margin-bottom: 24px;
+            text-align: center;
+            color: #92400e;
+            font-weight: 600;
+        }
+        .dev-description {
+            font-size: 0.85em;
+            color: var(--secondary-color);
+            margin-top: 4px;
+            margin-bottom: 0;
+        }
+        .manual-login {
+            margin-top: 2rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border-color);
+        }
+        .manual-login-form {
+            display: flex;
+            gap: 0.5rem;
+            justify-content: center;
+            align-items: center;
+            margin-top: 1rem;
+        }
+        .manual-login-form input {
+            padding: 0.75rem;
+            border: 1px solid var(--border-color);
+            border-radius: 6px;
+            font-size: 1rem;
+            width: 160px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Pumping Station: One</h1>
+            <p class="tagline">Member Portal</p>
+        </div>
+
+        <div class="dev-banner">
+            DEV MODE — Authentication bypass active. Select a user to log in as.
+        </div>
+
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                {% for category, message in messages %}
+                <div class="alert alert-{{ 'error' if category == 'error' else 'info' }}">
+                    {{ message }}
+                </div>
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+
+        <div class="content">
+            {% for user in preset_users %}
+            <div class="card">
+                <h2>{{ user.name }}</h2>
+                <p>{{ user.description }}</p>
+                <p class="dev-description">ID: {{ user.member_id }} | {{ user.email }}</p>
+                <form method="POST" action="{{ url_for('dev_login_select') }}">
+                    <input type="hidden" name="member_id" value="{{ user.member_id }}">
+                    <button type="submit" class="btn btn-primary full-width">Log In as {{ user.name.split()[0] }}</button>
+                </form>
+            </div>
+            {% endfor %}
+        </div>
+
+        <div class="manual-login">
+            <h2 style="text-align: center; margin-bottom: 0.5rem;">Manual Login</h2>
+            <p style="text-align: center; color: var(--secondary-color);">Enter any member ID from the seed data</p>
+            <form method="POST" action="{{ url_for('dev_login_select') }}" class="manual-login-form">
+                <input type="number" name="member_id" placeholder="Member ID" min="1" required>
+                <button type="submit" class="btn btn-secondary">Log In</button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,8 @@ services:
     environment:
       DH_API_BASE_URL: "http://gateway/dh/service"
       AUTH_MODE: dev
+      DH_CLIENT_ID: "dev-member-portal"
+      DH_CLIENT_SECRET: "hQgPvJW9RU48tRSQKS8SladAZsKHS34fKetbNr_443E"
 
   dhadminportal:
     network_mode: !reset ""
@@ -55,6 +57,8 @@ services:
     environment:
       DH_API_BASE_URL: "http://gateway/dh/service"
       AUTH_MODE: dev
+      DH_CLIENT_ID: "dev-admin-portal"
+      DH_CLIENT_SECRET: "ikactyRLicKoI8VHiD9KZEwTrOIhtYjfzm1h6YUjj7M"
 
   #########################################################
   # External services — move st2dh from host to bridge


### PR DESCRIPTION
## Summary
- When `AUTH_MODE=dev` (set by docker-compose.dev.yml), both portals skip MSAL/Azure B2C authentication and show a dev login page with preset seed-data users
- Admin portal presets: Ada Lovelace (Administrator), Nikola Tesla (Authorizer), Grace Hopper (Board)
- Member portal presets: Rosalind Franklin (active), Dorothy Vaughan (new), Marie Curie (inactive)
- Authorization (role/permission checks) still works via real DHService API calls
- Adds DH_CLIENT_ID/DH_CLIENT_SECRET env vars to docker-compose.dev.yml for both portals

## Files changed
- `code/DHAdminPortal/app.py` — dev login routes, AUTH_MODE checks
- `code/DHAdminPortal/app_config.py` — gates B2C config behind AUTH_MODE check
- `code/DHAdminPortal/config.py` — env var overrides for DH_CLIENT_ID/SECRET
- `code/DHAdminPortal/templates/dev_login.html` — new dev user picker page
- `code/DHMemberPortal/app.py` — dev login routes, AUTH_MODE checks
- `code/DHMemberPortal/app_config.py` — gates B2C config behind AUTH_MODE check
- `code/DHMemberPortal/config.py` — env var overrides for DH_CLIENT_ID/SECRET
- `code/DHMemberPortal/templates/dev_login.html` — new dev user picker page
- `docker-compose.dev.yml` — adds DH_CLIENT credentials for both portals

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)