### PR TITLE
Add dev helper script and DEV_SETUP.md documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ flask_session/
 .claude
 *.code-workspace
 pg/db-init/02-seed_data.sql
+pg/sql/seed_data.local.sql

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -1,0 +1,235 @@
+# Deep Harbor — Dev Environment Setup
+
+Set up and run Deep Harbor locally for development. The dev environment
+runs entirely in Docker with no external dependencies (no Azure B2C,
+no Active Directory, no RFID hardware, no Stripe, no Mailgun).
+
+## Prerequisites
+
+- **Docker** and **Docker Compose** (v2.24.0+, with `docker compose` syntax)
+- **uv** — Python package runner, needed for seed data generation
+  ```bash
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  ```
+- **Git**
+
+## Quick Start
+
+```bash
+git clone https://github.com/pumpingstationone/deepharbor.git
+cd deepharbor
+git checkout dev
+./dh_dev.sh setup
+```
+
+`dh_dev.sh setup` copies config files, generates seed data, and starts
+all containers. First build takes a few minutes.
+
+## Day-to-Day Commands
+
+```bash
+./dh_dev.sh start    # Build and start the dev environment
+./dh_dev.sh stop     # Stop containers (database persists)
+./dh_dev.sh reset    # Full reset: remove volumes, rebuild, start (re-seeds DB)
+./dh_dev.sh clean    # Remove all dev artifacts (return to fresh clone state)
+./dh_dev.sh status   # Show container status
+```
+
+## Access Points
+
+| Service         | URL                        | Credentials     |
+|-----------------|----------------------------|-----------------|
+| Admin Portal    | http://localhost:5001      | Dev user picker  |
+| Member Portal   | http://localhost:5002      | Dev user picker  |
+| API Gateway     | http://localhost:8808      | OAuth2 token     |
+| PostgreSQL      | localhost:5432             | dh / dh          |
+| Grafana         | http://localhost:3300      | admin / admin    |
+
+## What the Dev Environment Does Differently
+
+The dev compose overlay (`docker-compose.dev.yml`) makes these changes
+on top of the production compose file:
+
+1. **Disables hardware services** — AD controller, RFID reader, and
+   RFID2DB are gated behind a `hardware` profile and won't start
+2. **Switches to bridge networking** — Portals and ST2DH move from
+   `network_mode: host` to the Docker bridge network
+3. **Bypasses authentication** — `AUTH_MODE=dev` replaces Azure B2C
+   login with a dev user picker showing preset seed-data members
+4. **Bypasses external calls** — `DEV_MODE=true` on worker services
+   (DH2AD, DH2RFID) so they return success without contacting
+   hardware controllers
+5. **Loads seed data** — 25 members inserted on first boot (10 dev
+   users with stable IDs + 15 random members)
+6. **Remaps ports** — Gateway 80→8808, Grafana 3000→3300 to avoid
+   conflicts with other local services
+
+## Dev Auth Bypass
+
+When `AUTH_MODE=dev`, the portals show a user picker instead of the
+Azure B2C login flow. You can select a preset user or enter any member
+ID manually.
+
+**Admin Portal** (http://localhost:5001):
+
+| Name            | ID | Role          |
+|-----------------|----|---------------|
+| Ada Lovelace    | 1  | Administrator |
+| Nikola Tesla    | 3  | Authorizer    |
+| Grace Hopper    | 5  | Board         |
+
+**Member Portal** (http://localhost:5002):
+
+| Name               | ID | Description                   |
+|--------------------|----|-------------------------------|
+| Rosalind Franklin  | 7  | Active member with full data  |
+| Dorothy Vaughan    | 16 | Brand new member, minimal data |
+| Marie Curie        | 9  | Inactive member               |
+
+Authorization still works normally — the portals make real API calls
+to DHService to check roles and permissions. Only the Azure B2C
+authentication step is bypassed.
+
+## Manual Setup
+
+If you prefer not to use `dh_dev.sh setup`:
+
+### 1. Copy Config Files
+
+Every service needs a `config.ini`. The `.example` files work as-is
+for dev:
+
+```bash
+find code -name "config.ini.example" -exec sh -c \
+  'for f; do cp -n "$f" "${f%.example}"; done' _ {} +
+```
+
+Config files are gitignored and will never be committed.
+
+### 2. Generate Seed Data
+
+```bash
+tools/seed_data.sh generate              # 25 members (15 random + 10 dev)
+tools/seed_data.sh generate 100          # 110 members (100 random + 10 dev)
+tools/seed_data.sh generate 50 myseed    # Reproducible with a specific seed
+tools/seed_data.sh static                # Hand-crafted static data (25 members)
+tools/seed_data.sh status                # Show current seed data info
+```
+
+Output goes to `pg/sql/seed_data.local.sql` (gitignored), which is
+mounted into the database container during init. The static reference
+data lives in `pg/sql/seed_data.sql` (committed to git).
+
+### 3. Start / Stop
+
+```bash
+# Start
+docker compose -f docker-compose.yaml -f docker-compose.dev.yml up --build -d
+
+# Stop (preserves database)
+docker compose -f docker-compose.yaml -f docker-compose.dev.yml down
+
+# Stop and reset database
+docker compose -f docker-compose.yaml -f docker-compose.dev.yml down --volumes
+```
+
+## Config Files
+
+All 14 services have a `config.ini.example` that works for dev:
+
+| Category | Services | Dev Notes |
+|----------|----------|-----------|
+| Core API | DHService, DHDispatcher | Fully functional, talks to local DB |
+| Portals | DHAdminPortal, DHMemberPortal | B2C fields blank; AUTH_MODE=dev bypasses login |
+| Business | DHAccess, DHAuthorizations, DHIdentity, DHStatus | Fully functional |
+| Workers | DH2AD, DH2RFID | DEV_MODE=true bypasses hardware calls |
+| External | ST2DH, WF2DH, DH2MG | Creds blank; won't receive/send external data |
+| Utilities | RFID2DB | Disabled in dev (hardware profile) |
+
+## Seed Data
+
+The first 10 members (IDs 1–10) are stable "dev bypass" users with
+known names and roles. They are always included regardless of whether
+you use `generate` or `static` mode.
+
+| ID | Name               | Role          |
+|----|--------------------|---------------|
+| 1  | Ada Lovelace       | Administrator |
+| 2  | Charles Babbage    | Administrator |
+| 3  | Nikola Tesla       | Authorizer    |
+| 4  | Marie Curie        | Authorizer    |
+| 5  | Grace Hopper       | Board         |
+| 6  | Alan Turing        | Board         |
+| 7  | Rosalind Franklin  | Active Member |
+| 8  | Linus Torvalds     | Active Member |
+| 9  | Margaret Hamilton  | Inactive      |
+| 10 | Dennis Ritchie     | Inactive      |
+
+The seed data only loads on first boot (PostgreSQL initdb). If the
+volume already has data, init scripts are skipped. Use `./dh_dev.sh reset`
+to re-seed.
+
+## Architecture Overview
+
+```
+Browser
+  │
+  ├── Admin Portal (:5001)  ──┐
+  └── Member Portal (:5002) ──┤
+                               │
+                        Gateway / nginx (:8808)
+                               │
+                        DHService API (FastAPI)
+                               │
+                        PostgreSQL / TimescaleDB (:5432)
+                               │
+                        triggers + pg_notify
+                               │
+                        DHDispatcher
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+         DHIdentity       DHAccess         DHStatus
+              │                │
+           DH2AD           DH2RFID
+         [DEV_MODE]       [DEV_MODE]
+        (no-op in dev)   (no-op in dev)
+```
+
+## Troubleshooting
+
+**Containers keep restarting**
+
+Check logs: `docker compose -f docker-compose.yaml -f docker-compose.dev.yml logs -f`
+
+Common causes:
+- Missing `config.ini` files — run `./dh_dev.sh setup`
+- Missing seed data — run `tools/seed_data.sh generate`
+- Port conflicts — check if 5001, 5002, 5432, 8808, or 3300 are in use
+
+**Database not seeding**
+
+The seed data only loads on first boot. If the volume already exists,
+init scripts are skipped:
+
+```bash
+./dh_dev.sh reset    # removes volumes, re-seeds on next start
+```
+
+**Auth bypass not working**
+
+If you see the Azure B2C login page instead of the dev user picker,
+the portals are running without the dev compose override. Make sure
+you're using both compose files:
+
+```bash
+docker compose -f docker-compose.yaml -f docker-compose.dev.yml up --build -d
+```
+
+Or just use `./dh_dev.sh start`.
+
+**Worker errors in logs**
+
+DH2AD and DH2RFID have `DEV_MODE=true` set, which should bypass
+hardware calls. If you see errors in their logs, they're non-blocking —
+the dispatcher marks changes as processed regardless.

--- a/dh_dev.sh
+++ b/dh_dev.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# dh_dev.sh — Manage the Deep Harbor dev environment
+#
+# Usage:
+#   ./dh_dev.sh setup       One-time setup: copy configs, generate seed data, start
+#   ./dh_dev.sh start       Build and start the dev environment
+#   ./dh_dev.sh stop        Stop containers (database persists)
+#   ./dh_dev.sh reset       Full reset: remove volumes, rebuild, start (re-seeds DB)
+#   ./dh_dev.sh status      Show container status
+#   ./dh_dev.sh clean       Remove all dev artifacts (containers, volumes, configs, seed data)
+#
+# After running setup once, use start/stop/reset for day-to-day operations.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+COMPOSE="docker compose -f docker-compose.yaml -f docker-compose.dev.yml"
+
+usage() {
+    echo "Usage: $0 <command>"
+    echo ""
+    echo "Commands:"
+    echo "  setup    One-time first-run setup (copy configs, seed data, build, start)"
+    echo "  start    Build and start the dev environment"
+    echo "  stop     Stop containers (database volume preserved)"
+    echo "  reset    Full reset: stop, remove volumes, rebuild, start"
+    echo "  clean    Remove all dev artifacts (return to fresh clone state)"
+    echo "  status   Show container status"
+    echo ""
+    echo "Examples:"
+    echo "  $0 setup              First time? Run this."
+    echo "  $0 start              Start after a previous stop"
+    echo "  $0 stop               Stop without losing data"
+    echo "  $0 reset              Nuke everything and start fresh"
+    echo "  $0 clean              Remove everything, back to fresh clone"
+    echo "  $0 status             Check what's running"
+}
+
+print_access() {
+    echo ""
+    echo "  Admin Portal:  http://localhost:5001"
+    echo "  Member Portal: http://localhost:5002"
+    echo "  API Gateway:   http://localhost:8808"
+    echo "  Grafana:       http://localhost:3300 (admin/admin)"
+    echo "  PostgreSQL:    localhost:5432 (dh/dh)"
+}
+
+preflight() {
+    if [[ ! -f "pg/sql/seed_data.local.sql" ]]; then
+        echo "ERROR: No seed data found at pg/sql/seed_data.local.sql"
+        echo "Run '$0 setup' first, or generate seed data:"
+        echo "  tools/seed_data.sh generate"
+        exit 1
+    fi
+
+    if ! find code -name "config.ini" -type f -print -quit | grep -q .; then
+        echo "ERROR: No config.ini files found. Run '$0 setup' first."
+        exit 1
+    fi
+}
+
+cmd_setup() {
+    echo "=== Deep Harbor Dev Environment Setup ==="
+    echo ""
+
+    # Step 1: Copy config.ini.example -> config.ini (skip if exists)
+    echo "--- Copying config.ini files ---"
+    local config_count=0
+    local skip_count=0
+    while IFS= read -r example; do
+        target="${example%.example}"
+        if [[ -f "$target" ]]; then
+            echo "  SKIP: $target (already exists)"
+            ((skip_count++))
+        else
+            cp "$example" "$target"
+            echo "  COPY: $example"
+            ((config_count++))
+        fi
+    done < <(find code -name "config.ini.example" -type f | sort)
+    echo "  Copied: $config_count, Skipped: $skip_count"
+    echo ""
+
+    # Step 2: Generate seed data
+    echo "--- Generating seed data ---"
+    if [[ -f "pg/sql/seed_data.local.sql" ]] && [[ -s "pg/sql/seed_data.local.sql" ]]; then
+        echo "  Seed data already exists ($(wc -l < pg/sql/seed_data.local.sql) lines)"
+        echo "  To regenerate: tools/seed_data.sh generate"
+    else
+        if command -v uv &> /dev/null; then
+            tools/seed_data.sh generate
+        else
+            echo "  WARNING: uv not installed, using static seed data"
+            tools/seed_data.sh static
+        fi
+    fi
+    echo ""
+
+    # Step 3: Build and start
+    echo "--- Building and starting ---"
+    cmd_start
+
+    echo ""
+    echo "=== Setup complete ==="
+    echo ""
+    echo "Day-to-day commands:"
+    echo "  $0 start    Start the dev environment"
+    echo "  $0 stop     Stop containers (database persists)"
+    echo "  $0 reset    Full reset: stop, remove volumes, rebuild, start"
+}
+
+cmd_start() {
+    preflight
+
+    echo "Starting Deep Harbor dev environment..."
+    $COMPOSE up --build -d
+
+    echo ""
+    echo "Dev environment started."
+    print_access
+}
+
+cmd_stop() {
+    echo "Stopping Deep Harbor dev environment..."
+    $COMPOSE down
+
+    echo "Dev environment stopped. Database volume preserved."
+    echo "Run '$0 start' to restart (data persists)."
+    echo "Run '$0 reset' for a full reset (re-seeds database)."
+}
+
+cmd_reset() {
+    START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
+    echo "Resetting Deep Harbor dev environment. Started at: $START_TIME"
+
+    echo "Stopping and removing volumes..."
+    $COMPOSE down --volumes
+
+    sleep 2
+
+    echo "Rebuilding and starting..."
+    cmd_start
+
+    END_TIME=$(date +"%Y-%m-%d %H:%M:%S")
+    echo ""
+    echo "Reset completed. Ended at: $END_TIME"
+
+    START_SEC=$(date -d "$START_TIME" +%s)
+    END_SEC=$(date -d "$END_TIME" +%s)
+    DURATION=$((END_SEC - START_SEC))
+    MINUTES=$((DURATION / 60))
+    SECS=$((DURATION % 60))
+    echo "Total duration: $MINUTES minutes, $SECS seconds"
+}
+
+cmd_clean() {
+    echo "Cleaning Deep Harbor dev environment..."
+
+    # Stop containers and remove volumes
+    $COMPOSE down --volumes 2>/dev/null || true
+
+    # Remove all config.ini files
+    local config_count
+    config_count=$(find code -name "config.ini" -type f | wc -l)
+    if [[ "$config_count" -gt 0 ]]; then
+        find code -name "config.ini" -type f -delete
+        echo "Removed $config_count config.ini files"
+    fi
+
+    # Remove generated seed data
+    if [[ -f "pg/sql/seed_data.local.sql" ]]; then
+        rm -f pg/sql/seed_data.local.sql
+        echo "Removed pg/sql/seed_data.local.sql"
+    fi
+
+    echo ""
+    echo "Clean complete. Run '$0 setup' to start fresh."
+}
+
+cmd_status() {
+    $COMPOSE ps
+}
+
+# Main dispatch
+case "${1:-}" in
+    setup)
+        cmd_setup
+        ;;
+    start)
+        cmd_start
+        ;;
+    stop)
+        cmd_stop
+        ;;
+    reset)
+        cmd_reset
+        ;;
+    clean)
+        cmd_clean
+        ;;
+    status)
+        cmd_status
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    "")
+        usage
+        exit 1
+        ;;
+    *)
+        echo "Unknown command: $1"
+        echo ""
+        usage
+        exit 1
+        ;;
+esac

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
 
   db:
     volumes:
-      - ./pg/sql/seed_data.sql:/docker-entrypoint-initdb.d/02-seed_data.sql
+      - ./pg/sql/seed_data.local.sql:/docker-entrypoint-initdb.d/02-seed_data.sql
 
   #########################################################
   # Front-end services — move from host network to bridge

--- a/tools/seed_data.sh
+++ b/tools/seed_data.sh
@@ -3,16 +3,19 @@
 # seed_data.sh — Manage seed data for the Deep Harbor dev environment
 #
 # This script provides a convenient way to use either the hand-crafted
-# static seed data or the Python generator to populate seed_data.sql.
+# static seed data or the Python generator to create seed_data.local.sql.
+#
+# The static reference data lives in pg/sql/seed_data.sql (committed to git).
+# The working copy used by Docker is pg/sql/seed_data.local.sql (gitignored).
 #
 # Usage:
-#   tools/seed_data.sh static          Use the hand-crafted seed data (25 members)
+#   tools/seed_data.sh static          Copy the hand-crafted seed data (25 members)
 #   tools/seed_data.sh generate        Generate random seed data (25 members by default)
 #   tools/seed_data.sh generate 100    Generate 110 members (100 random + 10 dev users)
 #   tools/seed_data.sh generate 50 abc Generate with specific seed for reproducibility
-#   tools/seed_data.sh status          Show what's currently in seed_data.sql
+#   tools/seed_data.sh status          Show what's currently in seed_data.local.sql
 #
-# The output file is pg/sql/seed_data.sql, which docker-compose.dev.yml
+# The output file is pg/sql/seed_data.local.sql, which docker-compose.dev.yml
 # mounts as /docker-entrypoint-initdb.d/02-seed_data.sql. After changing
 # seed data you'll need to reset the database:
 #   docker compose -f docker-compose.yaml -f docker-compose.dev.yml down -v
@@ -25,22 +28,22 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-SEED_DATA_FILE="$REPO_ROOT/pg/sql/seed_data.sql"
-STATIC_SEED_DATA="$REPO_ROOT/pg/sql/seed_data.sql.static"
+SEED_DATA_FILE="$REPO_ROOT/pg/sql/seed_data.local.sql"
+STATIC_SOURCE="$REPO_ROOT/pg/sql/seed_data.sql"
 GENERATOR="$REPO_ROOT/pg/tools/generate_seed_data.py"
 
 usage() {
     echo "Usage: $0 <command> [options]"
     echo ""
     echo "Commands:"
-    echo "  static              Restore the hand-crafted static seed data (25 members)"
+    echo "  static              Copy the hand-crafted static seed data (25 members)"
     echo "  generate [N] [SEED] Generate seed data with N random members (default: 15)"
     echo "                      plus 10 dev bypass users. Optionally specify a seed"
     echo "                      for reproducibility."
     echo "  status              Show what's currently in seed_data.sql"
     echo ""
     echo "Examples:"
-    echo "  $0 static                  Use the committed static seed data"
+    echo "  $0 static                  Copy the static seed data to local"
     echo "  $0 generate                Generate 25 members (15 random + 10 dev)"
     echo "  $0 generate 100            Generate 110 members (100 random + 10 dev)"
     echo "  $0 generate 50 myseed123   Reproducible: same seed = same output"
@@ -52,15 +55,15 @@ usage() {
 }
 
 cmd_static() {
-    # Check if git can restore the committed version
-    if git -C "$REPO_ROOT" show HEAD:pg/sql/seed_data.sql > /dev/null 2>&1; then
-        git -C "$REPO_ROOT" show HEAD:pg/sql/seed_data.sql > "$SEED_DATA_FILE"
+    if [[ -f "$STATIC_SOURCE" ]]; then
+        cp "$STATIC_SOURCE" "$SEED_DATA_FILE"
         local count
         count=$(grep -c "INSERT INTO member " "$SEED_DATA_FILE" || true)
-        echo "Restored static seed data: $count member inserts"
+        echo "Copied static seed data: $count member inserts"
+        echo "  From: $STATIC_SOURCE"
+        echo "  To:   $SEED_DATA_FILE"
     else
-        echo "Error: No committed seed_data.sql found in git."
-        echo "The static seed data file hasn't been committed yet."
+        echo "Error: Static seed data not found at $STATIC_SOURCE"
         exit 1
     fi
 }


### PR DESCRIPTION
## Summary
- `dh_dev.sh`: Consolidated dev environment management script with subcommands:
  - `setup` — one-time first-run (copies configs, generates seed data, builds, starts)
  - `start` — build and start with preflight checks
  - `stop` — stop containers, preserve database volume
  - `reset` — full teardown with volume removal, rebuild, re-seed
  - `status` — show container status
- `DEV_SETUP.md`: Comprehensive developer setup guide covering quick start, manual setup, auth bypass details, config reference, seed data management, architecture diagram, and troubleshooting
- Separates seed data into static reference (`pg/sql/seed_data.sql`, committed to git) and working copy (`pg/sql/seed_data.local.sql`, gitignored) so generated seed data doesn't show as uncommitted changes

## Files changed
- `DEV_SETUP.md` — new developer documentation
- `dh_dev.sh` — new consolidated helper script
- `.gitignore` — add `pg/sql/seed_data.local.sql`
- `docker-compose.dev.yml` — mount `seed_data.local.sql` instead of `seed_data.sql`
- `tools/seed_data.sh` — output to `seed_data.local.sql`, copy from static reference

## Test plan
- [ ] Run `./dh_dev.sh setup` from clean state (no config.ini, no seed data)
- [ ] Verify all 14 config.ini files are created from examples
- [ ] Verify seed data is generated at `pg/sql/seed_data.local.sql`
- [ ] Verify `pg/sql/seed_data.sql` (static) is unchanged
- [ ] Verify containers start and health checks pass
- [ ] Verify admin portal at http://localhost:5001 shows dev login
- [ ] Verify member portal at http://localhost:5002 shows dev login
- [ ] Run `./dh_dev.sh stop` and verify clean shutdown
- [ ] Run `./dh_dev.sh start` and verify data persists
- [ ] Run `./dh_dev.sh reset` and verify full rebuild with re-seed
- [ ] Run `./dh_dev.sh status` and verify output

Closes #14, Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)