### PR TITLE
Add config.ini.example for DHADController and DHRFIDReader

### DIFF
--- a/code/workers/DHADController/config.ini.example
+++ b/code/workers/DHADController/config.ini.example
@@ -1,0 +1,22 @@
+[active_directory]
+domain_name=
+server_ip=
+username=
+password=
+base_dn=
+
+[azure_b2c]
+tenant_name=
+tenant_id=
+client_id=
+client_secret=
+extensions_app_id=
+
+[active_directory_groups]
+# The OU where new users will be created
+member_DN=
+# Base DN for groups that a user can be added to
+tool_base_DN=
+
+[shared]
+SHARED_VOLUME_PATH=/app/shared

--- a/code/workers/DHRFIDReader/config.ini.example
+++ b/code/workers/DHRFIDReader/config.ini.example
@@ -1,0 +1,7 @@
+[shared]
+SHARED_VOLUME_PATH=/app/shared
+
+[rfid_board]
+BOARD_IP=
+BOARD_PORT=60000
+BOARD_SERIAL_NUMBER_AS_INT=


### PR DESCRIPTION
## Summary

- Add `config.ini.example` for **DHADController** (`code/workers/DHADController/`) — identical to DH2AD's example since both services share `ad.py` and `b2c.py` modules and read the same config sections
- Add `config.ini.example` for **DHRFIDReader** (`code/workers/DHRFIDReader/`) — includes `[shared]` and `[rfid_board]` sections with dev defaults from docker-compose.yaml

These were discovered during a full audit of the codebase after resolving issue #49 (now closed). Both services are active in `docker-compose.yaml`, gated behind the `hardware` profile in dev mode.

Also filed #55 to track removing the dead code duplicate at `code/WF2DH/`.

Closes #54

## Test plan

- [ ] Verify every service directory with a `config.py` now has a corresponding `config.ini.example` (only `code/WF2DH/` should be missing — it's dead code tracked by #55)
- [ ] Confirm DHADController example covers all config reads in `main.py`, `ad.py`, and `b2c.py`
- [ ] Confirm DHRFIDReader example covers all config reads in `main.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)