### PR TITLE
Fix dh_dev.sh setup silently exiting before seed data generation

### DIFF
--- a/dh_dev.sh
+++ b/dh_dev.sh
@@ -74,11 +74,11 @@ cmd_setup() {
         target="${example%.example}"
         if [[ -f "$target" ]]; then
             echo "  SKIP: $target (already exists)"
-            ((skip_count++))
+            ((skip_count++)) || true
         else
             cp "$example" "$target"
             echo "  COPY: $example"
-            ((config_count++))
+            ((config_count++)) || true
         fi
     done < <(find code -name "config.ini.example" -type f | sort)
     echo "  Copied: $config_count, Skipped: $skip_count"


### PR DESCRIPTION
## Summary
- `dh_dev.sh setup` was silently exiting after copying the first config.ini file, never reaching seed data generation or container startup
- Root cause: `((var++))` returns exit code 1 when the variable is 0 (bash treats 0 as falsy), and `set -euo pipefail` kills the script on any non-zero exit
- Fix: add `|| true` to both arithmetic increments in `cmd_setup()`

## Test plan
- [x] Run `./dh_dev.sh clean && ./dh_dev.sh setup` — all 3 steps complete (config copy, seed data, build/start)
- [x] Run `./dh_dev.sh start` — starts without "No seed data found" error
- [x] Run `./dh_dev.sh reset` — completes full reset cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)