### PR TITLE
Add .gitattributes to force LF on shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for shell scripts and other files that break with CRLF.
+# Prevents issues on Windows/WSL where core.autocrlf=true converts LF to CRLF.
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- On WSL with `core.autocrlf=true`, git converts LF to CRLF on checkout, silently breaking all shell scripts
- Bash interprets `\r` as part of command names (e.g. `true\r` instead of `true`), so `|| true` guards fail invisibly
- This was the root cause of a second user hitting the same `dh_dev.sh setup` failure even after #71
- Adds `.gitattributes` forcing `eol=lf` on `*.sh` files so line endings are always correct regardless of git config

## Test plan
- [x] Verified `true\r` causes `command not found` (exit 127) while `true` works
- [x] With `.gitattributes`, `git checkout` produces LF endings on `.sh` files even with `core.autocrlf=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)