### PR TITLE
Pre-populate fields so they can be edited later

### DIFF
--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -161,12 +161,32 @@ def signup_submit():
         "from": "Member Portal Signup",
         "timestamp": datetime.now().isoformat()
     }
+    # We are adding the RFID tags in the access data because we want them 
+    # to be able to enter it in the signup form and have it show up in their 
+    # profile right away instead of having to go into the dashboard and add 
+    # it after the fact. This is because the RFID tag is required for them 
+    # to be able to access the space, so it's better to have it in there 
+    # from the start. We can always update it later if they get a new tag or something.
+    access_data = {
+        "rfid_tags": []
+    }
+    authorizations_data = {
+        "computer_authorizations": [],
+        "authorizations": []
+    }
+    extras_data = {
+        "storage_area": None,        
+    }
+    
     logger.debug(f"Waiver signed: {waiver_signed}, Waiver signed at: {waiver_signed_at}")
     logger.debug(f"Identity data to be sent for signup: {identity_data}")
     logger.debug(f"Connections data to be sent for signup: {connections_data}")
     logger.debug(f"Status data to be sent for signup: {status_data}")
     logger.debug(f"Forms data to be sent for signup: {forms_data}")
     logger.debug(f"Notes data to be sent for signup: {notes_data}")
+    logger.debug(f"Access data to be sent for signup: {access_data}")
+    logger.debug(f"Authorizations data to be sent for signup: {authorizations_data}")
+    logger.debug(f"Extras data to be sent for signup: {extras_data}")
     try:
         # Get access token for DHService
         access_token = dhservices.get_access_token(
@@ -203,6 +223,16 @@ def signup_submit():
         # And we add a note about the new signup
         dhservices.update_member_notes(access_token, member_id, notes_data)
         logger.info(f"Added note for new signup for member {member_id}")
+        
+        # These are empty but we want the record to show everything on
+        # first pass so that the admins can make changes as the fields
+        # would be null otherwise.
+        dhservices.update_member_access(access_token, member_id, access_data)
+        logger.info(f"Set initial access data for member {member_id}")
+        dhservices.update_member_authorizations(access_token, member_id, authorizations_data)
+        logger.info(f"Set initial authorizations data for member {member_id}")
+        dhservices.update_member_extras(access_token, member_id, extras_data)
+        logger.info(f"Set initial extras data for member {member_id}")
     except Exception as e:
         logger.error(f"Error creating new member: {str(e)}")
         flash('Error creating new member', 'error')

--- a/code/DHMemberPortal/dhservices.py
+++ b/code/DHMemberPortal/dhservices.py
@@ -225,7 +225,7 @@ def update_member_authorizations(access_token: str, member_id: str, auth_data: d
     url = f"{DH_API_BASE_URL}/v1/member/authorizations/"
     headers = {
         "Authorization": f"Bearer {access_token}",
-        "x-member-id": member_id  # FastAPI expects dashes, not underscores, which came as a big surprise
+        "X-Member-ID": str(member_id)  # FastAPI expects dashes, not underscores, which came as a big surprise
     }
     logger.debug(f"Sending authorization update - member_id: {member_id}, data: {auth_data}")
     response = requests.post(url, headers=headers, json=auth_data)


### PR DESCRIPTION
Fixes #77 . When the record is created, make sure all the fields are initially created so that the admin portal can edit them (the expectation is that the fields already have _something_ so null is not considered. 