### PR TITLE
Sort membership types by name

### DIFF
--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -652,7 +652,7 @@ def get_available_membership_levels() -> list[dict]:
         with conn.cursor() as cur:
             cur.execute(
                 """SELECT id, name, description
-                   FROM membership_types_lookup"""
+                   FROM membership_types_lookup order by name"""
             )
             results = cur.fetchall()
     for result in results:


### PR DESCRIPTION
Fixes #86 . The membership levels should be sorted by name.