### PR TITLE
Prevent the edit buton from being clicked while the data is loading

### DIFF
--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Deep Harbor Administration Portal{% endblock %}
+{% block title %}Pumping Station: One Administration Portal{% endblock %}
 {% block content %}
 
 <style>
@@ -59,7 +59,7 @@
     }
 </style>
 
-<h1>Deep Harbor Administration Portal</h1>
+<h1>Pumping Station: One Administration Portal</h1>
 
 {% if user %}
 <!-- We're logged in -->


### PR DESCRIPTION
If the user clicks the edit button while the data is still loading, they can get it into a state where the it seems like it's able to be edited, but in fact cannot. Fix for @hawleynr 