### PR TITLE
Display git version in member portal footer

### DIFF
--- a/code/DHAdminPortal/config.ini.example
+++ b/code/DHAdminPortal/config.ini.example
@@ -11,3 +11,6 @@ RESETPASSWORD_USER_FLOW =
 client_name = dev-admin-portal
 client_secret = ikactyRLicKoI8VHiD9KZEwTrOIhtYjfzm1h6YUjj7M
 api_base_url = http://localhost/dh/service
+
+[git]
+version=unknown

--- a/code/DHAdminPortal/templates/base.html
+++ b/code/DHAdminPortal/templates/base.html
@@ -48,7 +48,7 @@
 
     {% if user %}
     <hr />
-    <footer class="container"> 
+    <footer class="container">
         <p>Logged in as: {{user.name}} ({{ user.email }}){% if user_role %} <br/> Role: {{ user_role }}{% endif %} <br/> <a href="{{ url_for('logout') }}">Logout</a></p>
     </footer>
     {% endif %}

--- a/code/DHMemberPortal/config.ini.example
+++ b/code/DHMemberPortal/config.ini.example
@@ -11,3 +11,6 @@ RESETPASSWORD_USER_FLOW =
 client_name = dev-member-portal
 client_secret = hQgPvJW9RU48tRSQKS8SladAZsKHS34fKetbNr_443E
 api_base_url = http://localhost/dh/service
+
+[git]
+version=unknown

--- a/code/DHMemberPortal/restart.sh
+++ b/code/DHMemberPortal/restart.sh
@@ -4,7 +4,7 @@
 SERVICE=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
 
 # Set up the git version string from the current commit
-echo "GIT_VERSION=$(git branch --show-current)-$(git rev-parse --short HEAD)" > .env
+echo "GIT_VERSION=$(git branch --show-current)-$(git rev-parse --short HEAD) $(date +%Y-%m-%d)" > .env
 
 # Rebuild the Docker image
 echo "Rebuilding image for service: $SERVICE"

--- a/code/DHMemberPortal/static/css/landing.css
+++ b/code/DHMemberPortal/static/css/landing.css
@@ -235,12 +235,13 @@ body {
 .footer-text {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: 0.1rem;
 }
 
 .footer-text p {
     margin: 0;
     font-size: 0.875rem;
+    line-height: 1.3;
     color: var(--secondary-color);
 }
 
@@ -258,14 +259,15 @@ body {
     font-size: 1rem;
 }
 
-.footer-build {
+.footer-text p.footer-build {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
+    font-size: 0.65rem;
 }
 
 .footer-build a {
-    font-size: 1rem;
+    font-size: 0.875rem;
 }
 
 .header-actions {

--- a/code/DHMemberPortal/templates/base.html
+++ b/code/DHMemberPortal/templates/base.html
@@ -27,8 +27,8 @@
                 <a href="https://pumpingstationone.org"><img src="{{ url_for('static', filename='images/ps1-logo-square.svg') }}" alt="Pumping Station: One" class="footer-logo"></a>
                 <div class="footer-text">
                     <p class="footer-help">Get help: <a href="https://ps1.link/discord"><i class="fa-brands fa-discord"></i></a> <a href="mailto:info@pumpingstationone.org"><i class="fa-solid fa-envelope"></i></a></p>
-                    <p class="footer-build"><a href="https://github.com/pumpingstationone/deepharbor"><i class="fa-brands fa-github"></i></a> {{ git_version }}</p>
                     <p>&copy; {{ now().year }} Pumping Station: One NFP</p>
+                    <p class="footer-build"><a href="https://github.com/pumpingstationone/deepharbor"><i class="fa-brands fa-github"></i></a> {{ git_version }}</p>
                 </div>
             </div>
         </footer>

--- a/dh_dev.sh
+++ b/dh_dev.sh
@@ -17,6 +17,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+export GIT_VERSION="$(git branch --show-current)-$(git rev-parse --short HEAD) $(date +%Y-%m-%d)"
+
 COMPOSE="docker compose -f docker-compose.yaml -f docker-compose.dev.yml"
 
 usage() {

--- a/start_dh.sh
+++ b/start_dh.sh
@@ -3,6 +3,9 @@
 # This script sets up and starts DeepHarbor, including the PostgreSQL database.
 # It assumes Docker and Docker Compose are installed on the system.
 
+# Set up the git version string from the current commit
+export GIT_VERSION="$(git branch --show-current)-$(git rev-parse --short HEAD) $(date +%Y-%m-%d)"
+
 # Create a Docker network for DeepHarbor
 docker network create dh_network
 


### PR DESCRIPTION
## Summary
- Set `GIT_VERSION` (branch-commit date format) in `start_dh.sh` and `dh_dev.sh` so Docker builds inject it into `config.ini`
- Update `restart.sh` to include build date in version string
- Add `[git]` section to `config.ini.example` files for both portals
- Tighten footer line spacing and shrink build version text size in member portal CSS

Partial work for #101 — admin portal footer still needs version display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)