### PR TITLE
Fix admin panel font issues

### DIFF
--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -7,7 +7,7 @@
 }
 
 body {
-    font-family: 'Comic Sans MS', 'Marker Felt', cursive, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     background: linear-gradient(135deg, #ffd6e8 0%, #ffc0e5 50%, #ffb3e6 100%);
     min-height: 100vh;
     padding: 20px;
@@ -53,6 +53,7 @@ body::after {
 
 /* Scope bubblegum content styles to .body-content only */
 .body-content h1 {
+    font-family: 'Comic Neue', cursive;
     color: #ff69b4;
     font-size: 3em;
     text-align: center;

--- a/code/DHAdminPortal/templates/base.html
+++ b/code/DHAdminPortal/templates/base.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {% block metadata %}{% endblock %}
     <title>{% block title %}{% endblock %}</title>
+    <!-- Google Fonts - Comic Neue for header -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@700&display=swap" rel="stylesheet">
     <!-- Bootstrap CSS file reference -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">


### PR DESCRIPTION
## Summary
- Replace `Comic Sans MS` with system font stack for body text (fixes bad Linux fallback)
- Use Comic Neue from Google Fonts for h1 header only, keeping the playful look
- Improves readability and accessibility across all platforms

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)