### PR TITLE
Move dev mode banner to every page

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -306,6 +306,7 @@ def _get_token_from_cache(scope=None):
 app.jinja_env.globals.update(_build_auth_code_flow=_build_auth_code_flow)  # Used in template
 app.jinja_env.globals.update(git_version=config.get("git", "version", fallback="unknown"))  # Used in footer
 app.jinja_env.globals.update(now=datetime.now)  # Used in footer for dynamic year
+app.jinja_env.globals.update(auth_mode=AUTH_MODE)  # Used in dev banner
 
 
 ###############################################################################

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -278,3 +278,15 @@ body::after {
         padding: 15px 20px;
     }
 }
+
+/* Dev mode banner */
+.dev-banner {
+    background: #f59e0b;
+    color: #78350f;
+    text-align: center;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 2px 0;
+    letter-spacing: 0.05em;
+    width: 100%;
+}

--- a/code/DHAdminPortal/templates/base.html
+++ b/code/DHAdminPortal/templates/base.html
@@ -21,6 +21,9 @@
 </head>
 
 <body>
+    {% if auth_mode == "dev" %}
+    <div class="dev-banner">DEV MODE — {{ git_version }}</div>
+    {% endif %}
     <div class="header">
         <p class="header-tagline">{% block tagline %}{% endblock %}</p>
         {% block header_actions %}{% endblock %}

--- a/code/DHAdminPortal/templates/dev_login.html
+++ b/code/DHAdminPortal/templates/dev_login.html
@@ -3,16 +3,6 @@
 {% block content %}
 
 <style>
-    .dev-banner {
-        background: #fef3c7;
-        border: 2px solid #f59e0b;
-        border-radius: 8px;
-        padding: 12px 20px;
-        margin-bottom: 24px;
-        text-align: center;
-        color: #92400e;
-        font-weight: 600;
-    }
     .dev-user-card {
         cursor: pointer;
         transition: all 0.2s ease;
@@ -35,10 +25,6 @@
 </style>
 
 <h1>Pumping Station: One Administration Portal</h1>
-
-<div class="dev-banner">
-    DEV MODE — Authentication bypass active. Select a user to log in as.
-</div>
 
 <div class="row justify-content-center">
     <div class="col-md-8">

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -553,6 +553,7 @@ app.jinja_env.globals.update(_build_auth_code_flow=_build_auth_code_flow)  # Use
 app.jinja_env.globals.update(format_date=format_date)  # Used in template
 app.jinja_env.globals.update(git_version=config.get("git", "version", fallback="unknown"))  # Used in footer
 app.jinja_env.globals.update(now=datetime.now)  # Used in footer for dynamic year
+app.jinja_env.globals.update(auth_mode=AUTH_MODE)  # Used in dev banner
 
 
 ###############################################################################

--- a/code/DHMemberPortal/static/css/landing.css
+++ b/code/DHMemberPortal/static/css/landing.css
@@ -389,3 +389,15 @@ body {
         flex-direction: column;
     }
 }
+
+/* Dev mode banner */
+.dev-banner {
+    background: #f59e0b;
+    color: #78350f;
+    text-align: center;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 2px 0;
+    letter-spacing: 0.05em;
+    width: 100%;
+}

--- a/code/DHMemberPortal/templates/base.html
+++ b/code/DHMemberPortal/templates/base.html
@@ -9,6 +9,9 @@
     {% block extra_css %}{% endblock %}
 </head>
 <body>
+    {% if auth_mode == "dev" %}
+    <div class="dev-banner">DEV MODE — {{ git_version }}</div>
+    {% endif %}
     <div class="container">
         <div class="header">
             <img src="{{ url_for('static', filename='images/ps1-logo-horizontal.svg') }}" alt="Pumping Station: One" class="header-logo">

--- a/code/DHMemberPortal/templates/dev_login.html
+++ b/code/DHMemberPortal/templates/dev_login.html
@@ -3,16 +3,6 @@
 {% block tagline %}Member Portal{% endblock %}
 {% block extra_css %}
     <style>
-        .dev-banner {
-            background: #fef3c7;
-            border: 2px solid #f59e0b;
-            border-radius: 8px;
-            padding: 12px 20px;
-            margin-bottom: 24px;
-            text-align: center;
-            color: #92400e;
-            font-weight: 600;
-        }
         .dev-description {
             font-size: 0.85em;
             color: var(--secondary-color);
@@ -41,10 +31,6 @@
     </style>
 {% endblock %}
 {% block body %}
-        <div class="dev-banner">
-            DEV MODE — Authentication bypass active. Select a user to log in as.
-        </div>
-
         {% with messages = get_flashed_messages(with_categories=true) %}
             {% if messages %}
                 {% for category, message in messages %}


### PR DESCRIPTION
## Summary
- Moves the dev mode banner from individual dev login pages to both portal base templates so it appears on every page when `AUTH_MODE=dev`
- Thin amber banner at the top edge showing "DEV MODE — {build version}"
- Removes the old per-page banner CSS and HTML from `dev_login.html` in both portals

Closes #105

## Test plan
- [ ] Run `./dh_dev.sh start` and verify the banner appears on every page in both portals
- [ ] Confirm it's flush to the top edge and not floating/fixed
- [ ] Confirm dev login pages no longer have a duplicate banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)