### PR TITLE
Decouple dev banner from AUTH_MODE with new DEV_BANNER env var

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -56,12 +56,14 @@ on top of the production compose file:
    `network_mode: host` to the Docker bridge network
 3. **Bypasses authentication** — `AUTH_MODE=dev` replaces Azure B2C
    login with a dev user picker showing preset seed-data members
-4. **Bypasses external calls** — `DEV_MODE=true` on worker services
+4. **Shows dev banner** — `DEV_BANNER=true` displays a "DEV MODE"
+   banner at the top of every portal page
+5. **Bypasses external calls** — `DEV_MODE=true` on worker services
    (DH2AD, DH2RFID) so they return success without contacting
    hardware controllers
-5. **Loads seed data** — 25 members inserted on first boot (10 dev
+6. **Loads seed data** — 25 members inserted on first boot (10 dev
    users with stable IDs + 15 random members)
-6. **Remaps ports** — Gateway 80→8808, Grafana 3000→3300 to avoid
+7. **Remaps ports** — Gateway 80→8808, Grafana 3000→3300 to avoid
    conflicts with other local services
 
 ## Dev Auth Bypass
@@ -89,6 +91,27 @@ ID manually.
 Authorization still works normally — the portals make real API calls
 to DHService to check roles and permissions. Only the Azure B2C
 authentication step is bypassed.
+
+## Dev Banner
+
+The `DEV_BANNER` env var controls the "DEV MODE" banner shown at the
+top of every portal page. It's independent of `AUTH_MODE` — you can
+use them separately or together:
+
+| AUTH_MODE | DEV_BANNER | Result |
+|-----------|------------|--------|
+| *(unset)* | *(unset)*  | Normal B2C login, no banner (production) |
+| `dev`     | `true`     | Dev login picker + banner (full dev, the default in docker-compose.dev.yml) |
+| *(unset)* | `true`     | Real B2C login + banner (staging/test deployments) |
+| `dev`     | *(unset)*  | Dev login picker, no banner |
+
+To show the banner on a non-dev deployment, set the `DEV_BANNER`
+environment variable on the portal containers:
+
+```yaml
+environment:
+  DEV_BANNER: "true"
+```
 
 ## Manual Setup
 

--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -14,6 +14,7 @@ from config import config
 
 ### Dev mode flag — read from app_config so we only check the env var once
 AUTH_MODE = app_config.AUTH_MODE
+DEV_BANNER = app_config.DEV_BANNER
 if AUTH_MODE == "dev":
     logger.info("AUTH_MODE=dev — B2C authentication bypassed, dev login enabled")
 
@@ -306,7 +307,8 @@ def _get_token_from_cache(scope=None):
 app.jinja_env.globals.update(_build_auth_code_flow=_build_auth_code_flow)  # Used in template
 app.jinja_env.globals.update(git_version=config.get("git", "version", fallback="unknown"))  # Used in footer
 app.jinja_env.globals.update(now=datetime.now)  # Used in footer for dynamic year
-app.jinja_env.globals.update(auth_mode=AUTH_MODE)  # Used in dev banner
+app.jinja_env.globals.update(auth_mode=AUTH_MODE)  # Used in dev login routes
+app.jinja_env.globals.update(dev_banner=DEV_BANNER)  # Used in dev banner
 
 
 ###############################################################################

--- a/code/DHAdminPortal/app_config.py
+++ b/code/DHAdminPortal/app_config.py
@@ -8,6 +8,7 @@ from config import config
 # AUTH_MODE is set by docker-compose.dev.yml. When it's "dev", we skip
 # all B2C configuration and use a local dev login page instead.
 AUTH_MODE = os.environ.get("AUTH_MODE", "").lower()
+DEV_BANNER = os.environ.get("DEV_BANNER", "").lower() == "true"
 
 ###############################################################################
 # Azure AD B2C Configurations

--- a/code/DHAdminPortal/templates/base.html
+++ b/code/DHAdminPortal/templates/base.html
@@ -28,7 +28,7 @@
 </head>
 
 <body>
-    {% if auth_mode == "dev" %}
+    {% if dev_banner %}
     <div class="dev-banner">DEV MODE — {{ git_version }}</div>
     {% endif %}
     <div class="header">

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -14,6 +14,7 @@ import app_config
 
 ### Dev mode flag — read from app_config so we only check the env var once
 AUTH_MODE = app_config.AUTH_MODE
+DEV_BANNER = app_config.DEV_BANNER
 if AUTH_MODE == "dev":
     logger.info("AUTH_MODE=dev — B2C authentication bypassed, dev login enabled")
 
@@ -613,7 +614,8 @@ app.jinja_env.globals.update(_build_auth_code_flow=_build_auth_code_flow)  # Use
 app.jinja_env.globals.update(format_date=format_date)  # Used in template
 app.jinja_env.globals.update(git_version=config.get("git", "version", fallback="unknown"))  # Used in footer
 app.jinja_env.globals.update(now=datetime.now)  # Used in footer for dynamic year
-app.jinja_env.globals.update(auth_mode=AUTH_MODE)  # Used in dev banner
+app.jinja_env.globals.update(auth_mode=AUTH_MODE)  # Used in dev login routes
+app.jinja_env.globals.update(dev_banner=DEV_BANNER)  # Used in dev banner
 
 
 ###############################################################################

--- a/code/DHMemberPortal/app_config.py
+++ b/code/DHMemberPortal/app_config.py
@@ -8,6 +8,7 @@ from config import config
 # AUTH_MODE is set by docker-compose.dev.yml. When it's "dev", we skip
 # all B2C configuration and use a local dev login page instead.
 AUTH_MODE = os.environ.get("AUTH_MODE", "").lower()
+DEV_BANNER = os.environ.get("DEV_BANNER", "").lower() == "true"
 
 ###############################################################################
 # Azure AD B2C Configurations

--- a/code/DHMemberPortal/templates/base.html
+++ b/code/DHMemberPortal/templates/base.html
@@ -16,7 +16,7 @@
     {% block extra_css %}{% endblock %}
 </head>
 <body>
-    {% if auth_mode == "dev" %}
+    {% if dev_banner %}
     <div class="dev-banner">DEV MODE — {{ git_version }}</div>
     {% endif %}
     <div class="container">

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,7 @@ services:
     environment:
       DH_API_BASE_URL: "http://gateway/dh/service"
       AUTH_MODE: dev
+      DEV_BANNER: "true"
       DH_CLIENT_ID: "dev-member-portal"
       DH_CLIENT_SECRET: "hQgPvJW9RU48tRSQKS8SladAZsKHS34fKetbNr_443E"
 
@@ -57,6 +58,7 @@ services:
     environment:
       DH_API_BASE_URL: "http://gateway/dh/service"
       AUTH_MODE: dev
+      DEV_BANNER: "true"
       DH_CLIENT_ID: "dev-admin-portal"
       DH_CLIENT_SECRET: "ikactyRLicKoI8VHiD9KZEwTrOIhtYjfzm1h6YUjj7M"
 


### PR DESCRIPTION
## Summary
- Adds a new `DEV_BANNER` env var that controls the "DEV MODE" banner independently of `AUTH_MODE`
- Allows staging/test deployments to show the banner while using real B2C auth and Stripe
- Updates `docker-compose.dev.yml` to set `DEV_BANNER=true` so full dev mode still shows the banner
- Documents the new env var and its combinations in `DEV_SETUP.md`

## Test plan
- [ ] Run `./dh_dev.sh start` — both portals should show the dev banner (AUTH_MODE=dev + DEV_BANNER=true)
- [ ] Verify dev login picker still works as before
- [ ] To test banner-only mode: set `DEV_BANNER=true` without `AUTH_MODE=dev` — portal should show B2C login with the banner visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)