### PR TITLE
Add DB view update tool and fix partial form submission data wipe

### DIFF
--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -26,6 +26,20 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 
+### Fields updatable from dashboard forms, grouped by JSONB column.
+### Only fields present in the form submission are updated — partial
+### forms won't wipe fields they don't include.
+### To add a new field, just add its name to the relevant list.
+UPDATABLE_FIELDS = {
+    "identity": ["first_name", "last_name", "nickname", "pronouns"],
+}
+
+def apply_form_fields(form, data_dict, field_list):
+    """Update data_dict with form values only for fields present in the submission."""
+    for field in field_list:
+        if field in form:
+            data_dict[field] = form[field].strip() or None
+
 ###############################################################################
 # Health check endpoint
 ###############################################################################
@@ -461,6 +475,7 @@ def member_floof():
         return error
 
     return render_template('dashboard_floof.html',
+                         identity=member_info.get('identity', {}) if isinstance(member_info, dict) else {},
                          status=member_info.get('status', {}) if isinstance(member_info, dict) else {},
                          user=session.get('user'))
 
@@ -479,11 +494,6 @@ def member_update_profile():
     member_id = session['member_id']
     user_email = session.get('email')
 
-    first_name = request.form.get('first_name', '').strip()
-    last_name = request.form.get('last_name', '').strip()
-    nickname = request.form.get('nickname', '').strip()
-    rfid_tags_raw = request.form.get('rfid_tags', '').strip()
-
     try:
         member_info = dhservices.get_full_member_info(access_token, member_id)
         identity_data = (member_info.get('identity') if isinstance(member_info, dict) else {}) or {}
@@ -491,14 +501,14 @@ def member_update_profile():
         logger.error(f"Error fetching identity for update: {str(e)}", exc_info=True)
         identity_data = {}
 
-    identity_data["first_name"] = first_name or None
-    identity_data["last_name"] = last_name or None
-    identity_data["nickname"] = nickname or None
+    apply_form_fields(request.form, identity_data, UPDATABLE_FIELDS["identity"])
 
     if not identity_data.get("emails") and user_email:
         identity_data["emails"] = [{"type": "primary", "email_address": user_email}]
 
-    rfid_tags = [tag.strip() for tag in rfid_tags_raw.split(',') if tag.strip()]
+    # Only process RFID tags if the field is in the form
+    rfid_tags_raw = request.form.get('rfid_tags', '').strip() if 'rfid_tags' in request.form else None
+    rfid_tags = [tag.strip() for tag in rfid_tags_raw.split(',') if tag.strip()] if rfid_tags_raw is not None else []
     access_data = {"rfid_tags": rfid_tags}
 
     # Validate RFID tags: must be exactly 10 numeric digits
@@ -515,7 +525,8 @@ def member_update_profile():
 
     try:
         dhservices.update_member_identity(access_token, member_id, identity_data)
-        dhservices.update_member_access(access_token, member_id, access_data)
+        if 'rfid_tags' in request.form:
+            dhservices.update_member_access(access_token, member_id, access_data)
         flash('Profile updated successfully', 'success')
         if source_page == 'keys':
             flash('Remember to test your new keys before leaving the building, hearing the key reader beep does not mean the key works. Ask for help so you don\'t get locked out.', 'warning')
@@ -524,6 +535,8 @@ def member_update_profile():
         flash('Error updating profile', 'error')
     if source_page == 'keys':
         return redirect(url_for('member_keys'))
+    if source_page == 'floof':
+        return redirect(url_for('member_floof'))
     return redirect(url_for('member_profile'))
 
 @app.route("/logout")

--- a/pg/README.md
+++ b/pg/README.md
@@ -29,6 +29,39 @@ This directory contains the necessary files and configurations for setting up an
      ```bash
      docker-compose restart
      ```
+## Tools
+
+Database utilities live in `pg/tools/` with shell wrappers in `tools/`.
+
+### update_view — Compare & Apply View Changes
+
+When you add a new field to a JSONB column (e.g., adding `pronouns` to `identity`), the `v_member_info` view in `pg/sql/pgsql_schema.sql` must also be updated to expose it. This tool automates checking and applying those changes.
+
+**Workflow for adding a new field:**
+1. Add the field to the portal code (templates, route handlers)
+2. Add it to the `v_member_info` view in `pg/sql/pgsql_schema.sql`
+3. Run `tools/update_view.sh` to apply the change to the live database
+
+**Usage:**
+```bash
+# Show what's different between schema file and live DB
+tools/update_view.sh --dry-run
+
+# Compare and prompt to apply
+tools/update_view.sh
+
+# Apply without prompting
+tools/update_view.sh --yes
+```
+
+**Database connection** defaults to `dh/dh@localhost:5432/deepharbor`. Override with `--host`, `--port`, `--dbname`, `--user`, `--password`.
+
+### generate_seed_data — Generate Test Data
+
+Generates random member records for dev/testing. Called via `tools/seed_data.sh generate`.
+
+See `tools/seed_data.sh --help` for usage.
+
 ## Additional Resources
 - [PostgreSQL Documentation](https://www.postgresql.org/docs/)
 - [Docker PostgreSQL Image](https://hub.docker.com/_/postgres)

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -139,7 +139,8 @@ json_build_object(
         'last_name', m.identity ->> 'last_name'::TEXT,
         'primary_email', jsonb_path_query_first( m.identity, '$.emails[*] ? (@.type == "primary").email_address' )#>>'{}',
         'nickname', m.identity ->> 'nickname'::TEXT,
-        'active_directory_username', m.identity ->> 'active_directory_username'::TEXT
+        'active_directory_username', m.identity ->> 'active_directory_username'::TEXT,
+        'pronouns', m.identity ->> 'pronouns'::TEXT
     ),
     'connections', json_build_object(
       'discord_username', m.connections ->> 'discord_username'::TEXT

--- a/pg/tools/update_view.py
+++ b/pg/tools/update_view.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+update_view.py — Compare and apply v_member_info view changes
+
+Reads the view definition from pgsql_schema.sql, compares it against the
+live database, shows the differences, and optionally applies the update.
+"""
+
+import argparse
+import re
+import sys
+import textwrap
+
+
+def get_schema_file_view(schema_path):
+    """Extract the CREATE OR REPLACE VIEW v_member_info statement from the schema file."""
+    with open(schema_path, "r") as f:
+        content = f.read()
+
+    # Match from CREATE OR REPLACE VIEW v_member_info through the closing semicolon
+    pattern = r"(CREATE OR REPLACE VIEW v_member_info\s+as\s+.+?;)"
+    match = re.search(pattern, content, re.DOTALL | re.IGNORECASE)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def get_live_view_definition(conn):
+    """Get the current view definition from the live database."""
+    with conn.cursor() as cur:
+        # Check if view exists
+        cur.execute(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.views WHERE table_name = 'v_member_info');"
+        )
+        exists = cur.fetchone()[0]
+        if not exists:
+            return None
+
+        cur.execute("SELECT pg_get_viewdef('v_member_info', true);")
+        result = cur.fetchone()
+        return result[0] if result else None
+
+
+def extract_fields(view_sql):
+    """Extract field names per section from a view definition.
+
+    Returns a dict like:
+        {'identity': ['member_id', 'first_name', ...], 'connections': ['discord_username'], ...}
+    """
+    sections = {}
+    # Find all json_build_object sections with their labels
+    # Pattern: 'section_name', json_build_object(...)
+    # We need to handle nested parentheses for the json_build_object calls
+
+    # First, normalize whitespace for easier parsing
+    normalized = " ".join(view_sql.split())
+
+    # Find section labels followed by json_build_object
+    section_pattern = r"'(\w+)'\s*,\s*json_build_object\s*\("
+    for match in re.finditer(section_pattern, normalized):
+        section_name = match.group(1)
+        start = match.end()
+
+        # Walk forward counting parens to find the matching close
+        depth = 1
+        pos = start
+        while pos < len(normalized) and depth > 0:
+            if normalized[pos] == "(":
+                depth += 1
+            elif normalized[pos] == ")":
+                depth -= 1
+            pos += 1
+
+        section_body = normalized[start : pos - 1]
+
+        # Extract field names: 'field_name', <expression>
+        field_pattern = r"'(\w+)'\s*,"
+        fields = re.findall(field_pattern, section_body)
+        sections[section_name] = fields
+
+    return sections
+
+
+def compare_views(schema_fields, live_fields):
+    """Compare field lists between schema file and live DB.
+
+    Returns (added, removed) where each is a dict of section -> [field_names].
+    """
+    added = {}
+    removed = {}
+
+    all_sections = set(list(schema_fields.keys()) + list(live_fields.keys()))
+    for section in sorted(all_sections):
+        schema_set = set(schema_fields.get(section, []))
+        live_set = set(live_fields.get(section, []))
+
+        new_fields = schema_set - live_set
+        gone_fields = live_set - schema_set
+
+        if new_fields:
+            added[section] = sorted(new_fields)
+        if gone_fields:
+            removed[section] = sorted(gone_fields)
+
+    # Check for entirely new or removed sections
+    new_sections = set(schema_fields.keys()) - set(live_fields.keys())
+    gone_sections = set(live_fields.keys()) - set(schema_fields.keys())
+
+    for section in new_sections:
+        if section not in added:
+            added[section] = sorted(schema_fields[section])
+
+    for section in gone_sections:
+        if section not in removed:
+            removed[section] = sorted(live_fields[section])
+
+    return added, removed
+
+
+def print_comparison(schema_fields, live_fields, added, removed):
+    """Print a readable comparison of the two view definitions."""
+    all_sections = sorted(set(list(schema_fields.keys()) + list(live_fields.keys())))
+
+    for section in all_sections:
+        schema_list = schema_fields.get(section, [])
+        live_list = live_fields.get(section, [])
+        section_added = set(added.get(section, []))
+        section_removed = set(removed.get(section, []))
+
+        if not section_added and not section_removed:
+            continue
+
+        print(f"\n  [{section}]")
+        # Show all fields with markers
+        all_fields_ordered = []
+        seen = set()
+        for f in live_list:
+            all_fields_ordered.append(f)
+            seen.add(f)
+        for f in schema_list:
+            if f not in seen:
+                all_fields_ordered.append(f)
+
+        for field in all_fields_ordered:
+            if field in section_added:
+                print(f"    + {field}")
+            elif field in section_removed:
+                print(f"    - {field}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare and apply v_member_info view changes from schema file to live database."
+    )
+    parser.add_argument(
+        "--host", default="localhost", help="Database host (default: localhost)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=5432, help="Database port (default: 5432)"
+    )
+    parser.add_argument(
+        "--dbname", default="deepharbor", help="Database name (default: deepharbor)"
+    )
+    parser.add_argument(
+        "--user", default="dh", help="Database user (default: dh)"
+    )
+    parser.add_argument(
+        "--password", default="dh", help="Database password (default: dh)"
+    )
+    parser.add_argument(
+        "--schema-file",
+        default=None,
+        help="Path to pgsql_schema.sql (auto-detected from script location)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show differences only, don't prompt or apply",
+    )
+    parser.add_argument(
+        "--yes", "-y", action="store_true", help="Skip confirmation prompt"
+    )
+    args = parser.parse_args()
+
+    # Try importing psycopg2
+    try:
+        import psycopg2
+    except ImportError:
+        print("Error: psycopg2 is required. Install it with:")
+        print("  pip install psycopg2-binary")
+        sys.exit(1)
+
+    # Resolve schema file path
+    if args.schema_file:
+        schema_path = args.schema_file
+    else:
+        import os
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        schema_path = os.path.join(script_dir, "..", "sql", "pgsql_schema.sql")
+
+    # Check schema file exists
+    import os
+    if not os.path.exists(schema_path):
+        print(f"Error: Schema file not found at {schema_path}")
+        sys.exit(1)
+
+    ### Read view from schema file
+    print(f"Reading schema file: {schema_path}")
+    schema_view_sql = get_schema_file_view(schema_path)
+    if not schema_view_sql:
+        print("Error: Could not find CREATE OR REPLACE VIEW v_member_info in schema file")
+        sys.exit(1)
+
+    schema_fields = extract_fields(schema_view_sql)
+    if not schema_fields:
+        print("Error: Could not parse any fields from schema file view definition")
+        sys.exit(1)
+
+    ### Connect to database
+    print(f"Connecting to {args.user}@{args.host}:{args.port}/{args.dbname}...")
+    try:
+        conn = psycopg2.connect(
+            host=args.host,
+            port=args.port,
+            dbname=args.dbname,
+            user=args.user,
+            password=args.password,
+        )
+        conn.autocommit = True
+    except psycopg2.OperationalError as e:
+        print(f"Error: Could not connect to database: {e}")
+        sys.exit(1)
+
+    ### Read live view
+    live_view_sql = get_live_view_definition(conn)
+    if live_view_sql is None:
+        print("Warning: v_member_info view does not exist in the database.")
+        print("The schema file view will be created from scratch.")
+        live_fields = {}
+    else:
+        live_fields = extract_fields(live_view_sql)
+
+    ### Compare
+    added, removed = compare_views(schema_fields, live_fields)
+
+    if not added and not removed:
+        print("\nNo differences found. The live view matches the schema file.")
+        conn.close()
+        sys.exit(0)
+
+    ### Show differences
+    print("\nDifferences found between schema file and live database:")
+    print("  + = in schema file but not in live DB (will be added)")
+    print("  - = in live DB but not in schema file (will be removed)")
+    print_comparison(schema_fields, live_fields, added, removed)
+
+    total_added = sum(len(v) for v in added.values())
+    total_removed = sum(len(v) for v in removed.values())
+    print(f"\nSummary: {total_added} field(s) to add, {total_removed} field(s) to remove")
+
+    if args.dry_run:
+        print("\n(dry run — no changes applied)")
+        conn.close()
+        sys.exit(0)
+
+    ### Confirm and apply
+    if not args.yes:
+        try:
+            response = input("\nApply these changes? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.")
+            conn.close()
+            sys.exit(1)
+
+        if response not in ("y", "yes"):
+            print("Aborted.")
+            conn.close()
+            sys.exit(0)
+
+    ### Apply the view
+    print("\nApplying view update...")
+    try:
+        with conn.cursor() as cur:
+            cur.execute(schema_view_sql)
+        print("View updated successfully.")
+    except Exception as e:
+        print(f"Error applying view update: {e}")
+        conn.close()
+        sys.exit(1)
+
+    ### Verify
+    print("\nVerifying...")
+    updated_view_sql = get_live_view_definition(conn)
+    if updated_view_sql is None:
+        print("Warning: Could not read back the updated view.")
+    else:
+        updated_fields = extract_fields(updated_view_sql)
+        verify_added, verify_removed = compare_views(schema_fields, updated_fields)
+        if not verify_added and not verify_removed:
+            print("Verified: live view now matches the schema file.")
+        else:
+            print("Warning: View was applied but verification shows remaining differences.")
+            print("This may indicate a parsing issue — please check the view manually:")
+            print("  psql -h localhost -U dh -d deepharbor -c \"\\d+ v_member_info\"")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/update_view.sh
+++ b/tools/update_view.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# update_view.sh — Compare and apply v_member_info view changes
+#
+# Compares the view definition in pg/sql/pgsql_schema.sql against the
+# live database, shows what's new or removed, and optionally applies
+# the update.
+#
+# Usage:
+#   tools/update_view.sh              Compare and prompt to apply
+#   tools/update_view.sh --dry-run    Show differences only
+#   tools/update_view.sh --yes        Apply without prompting
+#
+# Database connection defaults to localhost:5432/deepharbor (dh/dh).
+# Override with --host, --port, --dbname, --user, --password.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TOOL="$REPO_ROOT/pg/tools/update_view.py"
+
+usage() {
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Compare the v_member_info view in pg/sql/pgsql_schema.sql against"
+    echo "the live database and optionally apply changes."
+    echo ""
+    echo "Options:"
+    echo "  --dry-run           Show differences only, don't apply"
+    echo "  --yes, -y           Skip confirmation prompt"
+    echo "  --host HOST         Database host (default: localhost)"
+    echo "  --port PORT         Database port (default: 5432)"
+    echo "  --dbname NAME       Database name (default: deepharbor)"
+    echo "  --user USER         Database user (default: dh)"
+    echo "  --password PASS     Database password (default: dh)"
+    echo "  -h, --help          Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  $0                  Compare and prompt to apply"
+    echo "  $0 --dry-run        Just show what's different"
+    echo "  $0 --yes            Apply without asking"
+}
+
+# Show help if requested
+for arg in "$@"; do
+    if [[ "$arg" == "-h" || "$arg" == "--help" || "$arg" == "help" ]]; then
+        usage
+        exit 0
+    fi
+done
+
+# Check uv is available (handles psycopg2-binary dependency automatically)
+if ! command -v uv &> /dev/null; then
+    echo "Error: uv is required. Install it:"
+    echo "  curl -LsSf https://astral.sh/uv/install.sh | sh"
+    exit 1
+fi
+
+# Check the tool script exists
+if [[ ! -f "$TOOL" ]]; then
+    echo "Error: update_view.py not found at $TOOL"
+    exit 1
+fi
+
+# Run with psycopg2-binary provided automatically by uv
+uv run --with psycopg2-binary "$TOOL" "$@"


### PR DESCRIPTION
## Summary
- **New tool**: `tools/update_view.sh` + `pg/tools/update_view.py` — compares the `v_member_info` view definition in `pgsql_schema.sql` against the live database, shows field-level diffs, and applies updates with confirmation. Supports `--dry-run` and `--yes` flags.
- **Bug fix**: The shared `member_update_profile` route unconditionally overwrote all identity fields even when they weren't in the form submission, causing partial forms to silently wipe unrelated data (e.g., saving pronouns from the floof page wiped first_name, last_name, nickname). Introduced `UPDATABLE_FIELDS` dict and `apply_form_fields()` helper so only submitted fields are updated. Also guards RFID/access updates behind field presence checks.
- **Schema**: Added `pronouns` field to `v_member_info` view's identity section
- **Docs**: Added Tools section to `pg/README.md` documenting both `update_view` and `generate_seed_data`

Closes #145

## Test plan
- [ ] Run `tools/update_view.sh --dry-run` against a DB missing the pronouns field — should show it as new
- [ ] Run `tools/update_view.sh --yes` — should apply and verify
- [ ] Run again — should report no differences
- [ ] Save a field from the floof page — verify other identity fields are not wiped
- [ ] Save profile from the profile page — verify all fields still update correctly
- [ ] Save RFID tags from the keys page — verify tags still save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)