### PR TITLE
Add theme song URL and duration fields to floof page

### DIFF
--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -31,7 +31,7 @@ app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 ### forms won't wipe fields they don't include.
 ### To add a new field, just add its name to the relevant list.
 UPDATABLE_FIELDS = {
-    "identity": ["first_name", "last_name", "nickname", "pronouns", "nametag_subtitle"],
+    "identity": ["first_name", "last_name", "nickname", "pronouns", "nametag_subtitle", "theme_song_url", "theme_song_duration"],
 }
 
 def apply_form_fields(form, data_dict, field_list):

--- a/code/DHMemberPortal/templates/base.html
+++ b/code/DHMemberPortal/templates/base.html
@@ -145,7 +145,7 @@
                 });
 
                 /* Trim text/tel inputs */
-                form.querySelectorAll('input[type="text"], input[type="tel"], input[type="email"]').forEach(function (input) {
+                form.querySelectorAll('input[type="text"], input[type="tel"], input[type="email"], input[type="url"]').forEach(function (input) {
                     input.value = input.value.trim();
                 });
 
@@ -190,6 +190,31 @@
                     }
                 });
 
+                /* HTTPS URL check */
+                form.querySelectorAll('input[type="url"][data-require-https]').forEach(function (input) {
+                    if (!input.value.trim()) return;
+                    if (!/^https:\/\/.+/.test(input.value.trim())) {
+                        var label = input.getAttribute('data-label') || 'URL';
+                        errors.push(label + ' must start with https://');
+                        input.classList.add('field-error', 'field-shake');
+                        input.addEventListener('animationend', function () { input.classList.remove('field-shake'); }, { once: true });
+                    }
+                });
+
+                /* Number range check */
+                form.querySelectorAll('input[type="number"][data-validate-range]').forEach(function (input) {
+                    if (!input.value.trim()) return;
+                    var val = parseFloat(input.value);
+                    var min = parseFloat(input.getAttribute('min'));
+                    var max = parseFloat(input.getAttribute('max'));
+                    var label = input.getAttribute('data-label') || 'Value';
+                    if (isNaN(val) || val < min || val > max) {
+                        errors.push(label + ' must be between ' + min + ' and ' + max + '.');
+                        input.classList.add('field-error', 'field-shake');
+                        input.addEventListener('animationend', function () { input.classList.remove('field-shake'); }, { once: true });
+                    }
+                });
+
                 if (missing.length > 0 || errors.length > 0) {
                     e.preventDefault();
                     document.getElementById('dh-toast-icon').className = 'fa-solid fa-circle-exclamation text-danger me-2';
@@ -213,6 +238,19 @@
             /* Clear error styling on input */
             form.querySelectorAll('[required]').forEach(function (input) {
                 input.addEventListener('input', function () { input.classList.remove('field-error'); });
+            });
+
+            /* Restrict number inputs to digits and decimal point only */
+            form.querySelectorAll('input[type="number"]').forEach(function (input) {
+                input.addEventListener('keypress', function (e) {
+                    var ch = String.fromCharCode(e.which || e.keyCode);
+                    if (ch === '.' && input.value.indexOf('.') !== -1) { e.preventDefault(); return; }
+                    if (ch !== '.' && (ch < '0' || ch > '9')) { e.preventDefault(); }
+                });
+                input.addEventListener('paste', function (e) {
+                    var text = (e.clipboardData || window.clipboardData).getData('text');
+                    if (!/^\d*\.?\d*$/.test(text)) { e.preventDefault(); }
+                });
             });
         });
     })();

--- a/code/DHMemberPortal/templates/dashboard_floof.html
+++ b/code/DHMemberPortal/templates/dashboard_floof.html
@@ -42,13 +42,34 @@
             <div class="card mb-3">
                 <div class="card-body">
                     <h2 class="card-title mb-3">Entrance Theme Song</h2>
-                    <p>URL to an 10 second or less MP3 that plays as your theme song when you print your name tag.</p>
+                    <form method="POST" action="{{ url_for('member_update_profile') }}" class="dh-validate">
+                    <input type="hidden" name="source_page" value="floof">
                     <div class="info-group">
                         <label>MP3 URL</label>
+                        <span class="info-label-desc">Direct link to an MP3 file that plays as your theme song when you print your name tag.</span>
                         <div class="info-value">
-                            <input type="url" class="form-control" placeholder="Coming soon!" disabled>
+                            <input type="url" class="form-control" name="theme_song_url"
+                                   data-label="MP3 URL" data-require-https
+                                   autocapitalize="none" autocorrect="off" spellcheck="false"
+                                   maxlength="500" placeholder="https://example.com/my-theme.mp3"
+                                   value="{{ identity.theme_song_url or '' }}">
                         </div>
                     </div>
+                    <div class="info-group">
+                        <label>Duration</label>
+                        <span class="info-label-desc">How many seconds of your theme song to play, up to 10 seconds max.</span>
+                        <div class="info-value">
+                            <input type="number" class="form-control" name="theme_song_duration"
+                                   data-label="Duration" data-validate-range
+                                   inputmode="decimal" min="0.1" max="10" step="0.1"
+                                   placeholder="e.g. 5, 7.5"
+                                   value="{{ identity.theme_song_duration or '' }}">
+                        </div>
+                    </div>
+                    <div class="text-center mt-3">
+                        <button type="submit" class="btn btn-primary">Save</button>
+                    </div>
+                    </form>
                 </div>
             </div>
 

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -141,7 +141,9 @@ json_build_object(
         'nickname', m.identity ->> 'nickname'::TEXT,
         'active_directory_username', m.identity ->> 'active_directory_username'::TEXT,
         'pronouns', m.identity ->> 'pronouns'::TEXT,
-        'nametag_subtitle', m.identity ->> 'nametag_subtitle'::TEXT
+        'nametag_subtitle', m.identity ->> 'nametag_subtitle'::TEXT,
+        'theme_song_url', m.identity ->> 'theme_song_url'::TEXT,
+        'theme_song_duration', m.identity ->> 'theme_song_duration'::TEXT
     ),
     'connections', json_build_object(
       'discord_username', m.connections ->> 'discord_username'::TEXT


### PR DESCRIPTION
## Summary
- Enable the entrance theme song card on the floof page with a working form
- Add HTTPS-validated URL field and decimal duration field (0.1–10 seconds)
- Add reusable validators to `dh-validate`: HTTPS URL check, number range check, digit-only keypress filter
- Add `theme_song_url` and `theme_song_duration` to `UPDATABLE_FIELDS` and `v_member_info` view

## Test plan
- [ ] Rebuild member portal container
- [ ] Verify both fields render on `/dashboard/floof` with descriptions
- [ ] Test HTTPS validation rejects `http://` URLs
- [ ] Test duration range validation rejects values > 10
- [ ] Test number field only accepts digits and decimal point
- [ ] Test saving with valid data persists to DB
- [ ] Run `update_view.sh` to apply view changes to dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)