### PR TITLE
Regenerate DHDispatcher uv.lock

### DIFF
--- a/code/DHDispatcher/uv.lock
+++ b/code/DHDispatcher/uv.lock
@@ -43,12 +43,14 @@ source = { virtual = "." }
 dependencies = [
     { name = "psycopg2-binary" },
     { name = "requests" },
+    { name = "urllib3" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "urllib3", specifier = ">=2.6.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Regenerate `uv.lock` in DHDispatcher so `uv sync --locked` succeeds during Docker build

## Test plan
- [x] `docker compose up --build dhdispatcher` builds successfully

Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)