### PR TITLE
Add Grafana Okta env file copy step to dev setup

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -132,6 +132,13 @@ find code -name "config.ini.example" -exec sh -c \
 
 Config files are gitignored and will never be committed.
 
+The Grafana service also needs an env file for Okta configuration.
+Copy the example file (the defaults work for dev):
+
+```bash
+cp -n .env.grafana.okta.example .env.grafana.okta.production
+```
+
 ### 2. Generate Seed Data
 
 ```bash
@@ -171,6 +178,7 @@ All 14 services have a `config.ini.example` that works for dev:
 | Workers | DH2AD, DH2RFID | DEV_MODE=true bypasses hardware calls |
 | External | ST2DH, WF2DH, DH2MG | Creds blank; won't receive/send external data |
 | Utilities | RFID2DB | Disabled in dev (hardware profile) |
+| Grafana | .env.grafana.okta.production | Copied from .env.grafana.okta.example; Okta fields blank in dev |
 
 ## Seed Data
 

--- a/dh_dev.sh
+++ b/dh_dev.sh
@@ -86,6 +86,16 @@ cmd_setup() {
     echo "  Copied: $config_count, Skipped: $skip_count"
     echo ""
 
+    # Step 1b: Copy Grafana Okta env file
+    echo "--- Copying Grafana Okta env file ---"
+    if [[ -f ".env.grafana.okta.production" ]]; then
+        echo "  SKIP: .env.grafana.okta.production (already exists)"
+    else
+        cp .env.grafana.okta.example .env.grafana.okta.production
+        echo "  COPY: .env.grafana.okta.example -> .env.grafana.okta.production"
+    fi
+    echo ""
+
     # Step 2: Generate seed data
     echo "--- Generating seed data ---"
     if [[ -f "pg/sql/seed_data.local.sql" ]] && [[ -s "pg/sql/seed_data.local.sql" ]]; then


### PR DESCRIPTION
## Summary
- Adds `.env.grafana.okta.example` → `.env.grafana.okta.production` copy step to `DEV_SETUP.md` manual setup instructions
- Adds the same copy step to `dh_dev.sh setup` so it's handled automatically
- Adds Grafana row to the Config Files table in `DEV_SETUP.md`

## Test plan
- [ ] Run `./dh_dev.sh setup` on a fresh clone and verify `.env.grafana.okta.production` is created
- [ ] Run `./dh_dev.sh setup` again and verify it skips the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)