### PR TITLE
Fix DHDispatcher race condition, add deduplication and HTTP timeouts

### DIFF
--- a/code/DHDispatcher/main.py
+++ b/code/DHDispatcher/main.py
@@ -210,7 +210,7 @@ def process_row(row):
         "change_type": change_type,
         "change_data": change_data,
     }
-    response = requests.post(url, json=payload)
+    response = requests.post(url, json=payload, timeout=30)
     if response.status_code != 200:
         logger.error(
             f"Failed to process change for change row id={row['id']}: {response.text}" 
@@ -227,8 +227,34 @@ def process_row(row):
     return True
 
 
+# Deduplicate a batch: when multiple rows exist for the same member_id +
+# change_type, only the latest matters because downstream services read
+# current DB state. Earlier rows are redundant and can be marked processed.
+def deduplicate_batch(rows):
+    latest = {}
+    for row in rows:
+        data = row.get("data", {})
+        key = (data.get("member_id"), data.get("change"))
+        latest[key] = row
+
+    latest_ids = {row["id"] for row in latest.values()}
+    to_process = [r for r in rows if r["id"] in latest_ids]
+    to_skip = [r for r in rows if r["id"] not in latest_ids]
+    return to_process, to_skip
+
+
 # Process a batch of rows sequentially by id
 def process_batch(conn, cur, rows):
+    # Deduplicate: for same member_id + change_type, only process the latest
+    rows, skipped = deduplicate_batch(rows)
+    if skipped:
+        skip_ids = [r["id"] for r in skipped]
+        logger.info(
+            f"Deduplicating: skipping {len(skipped)} superseded row(s): ids={skip_ids}"
+        )
+        mark_batch_as_processed(cur, skip_ids)
+        conn.commit()
+
     processed_count = 0
 
     for row_dict in rows:
@@ -300,9 +326,11 @@ def process_pending_notifications(conn, cur):
             f"Received {notification_count} notification(s); processing unprocessed rows..."
         )
 
-    # Fetch and process all unprocessed rows in id order
-    # This handles the case where multiple inserts happened and notifications
-    # might arrive out of order or be coalesced
+    # Fetch and process all unprocessed rows in id order.
+    # Keep looping until no unprocessed rows remain — new rows may have been
+    # inserted while we were processing the previous batch (e.g., portal sends
+    # identity then access ~100ms apart, and the HTTP call to process identity
+    # takes 1-2s).
     last_id = 0
 
     while True:
@@ -314,9 +342,6 @@ def process_pending_notifications(conn, cur):
         process_batch(conn, cur, rows)
 
         last_id = rows[-1]["id"]
-
-        if len(rows) < BATCH_SIZE:
-            break
 
 
 ###############################################################################
@@ -350,27 +375,35 @@ def main():
 
                 # Main wait loop
                 while True:
-                    # Wait for notifications; block until data available
-                    # Use a timeout to periodically check for unprocessed rows
-                    # (handles edge cases where notifications might be missed)
-                    ready = select.select([conn], [], [], 60.0)
+                    # Before blocking on select, check if notifications are
+                    # already buffered in conn.notifies. This happens when
+                    # DB operations (commit, set_isolation_level, execute)
+                    # consume notification data from the TCP socket as a
+                    # side effect — select.select() then sees an empty
+                    # socket and would block, even though notifications
+                    # are waiting in memory.
+                    conn.poll()
+                    has_buffered = len(conn.notifies) > 0
 
-                    if ready == ([], [], []):
-                        # Timeout: do a quick check for any unprocessed rows
-                        conn.set_isolation_level(
-                            psycopg2.extensions.ISOLATION_LEVEL_READ_COMMITTED
-                        )
-                        unprocessed = count_unprocessed(cur)
-                        if unprocessed > 0:
-                            logger.info(
-                                f"Timeout check: found {unprocessed} unprocessed row(s)."
+                    if not has_buffered:
+                        ready = select.select([conn], [], [], POLL_INTERVAL)
+
+                        if ready == ([], [], []):
+                            # Timeout: do a quick check for any unprocessed rows
+                            conn.set_isolation_level(
+                                psycopg2.extensions.ISOLATION_LEVEL_READ_COMMITTED
                             )
-                            resume_unprocessed(conn, cur)
-                        conn.set_isolation_level(
-                            psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
-                        )
-                        cur.execute(f"LISTEN {CHANNEL};")
-                        continue
+                            unprocessed = count_unprocessed(cur)
+                            if unprocessed > 0:
+                                logger.info(
+                                    f"Timeout check: found {unprocessed} unprocessed row(s)."
+                                )
+                                resume_unprocessed(conn, cur)
+                            conn.set_isolation_level(
+                                psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
+                            )
+                            cur.execute(f"LISTEN {CHANNEL};")
+                            continue
 
                     # Switch to read-committed for processing
                     conn.set_isolation_level(

--- a/code/services/DHAccess/main.py
+++ b/code/services/DHAccess/main.py
@@ -183,7 +183,7 @@ async def change_access(request: dict):
                     url = dh2rfid_add_endpoint
                     logger.debug(f"Add tag URL: {url}")
                     payload = dh2rfid_request
-                    response = requests.post(url, json=payload)
+                    response = requests.post(url, json=payload, timeout=30)
                     if response.status_code != 200:
                         logger.error(f"Failed to add tag via DH2RFID: {response.text}")
                         raise HTTPException(
@@ -197,8 +197,8 @@ async def change_access(request: dict):
                     # Send the request to DH2RFID worker
                     url = dh2rfid_remove_endpoint
                     logger.debug(f"Remove tag URL: {url}")
-                    payload = dh2rfid_request                
-                    response = requests.post(url, json=payload)
+                    payload = dh2rfid_request
+                    response = requests.post(url, json=payload, timeout=30)
                     if response.status_code != 200:
                         logger.error(f"Failed to remove tag via DH2RFID: {response.text}")
                         raise HTTPException(


### PR DESCRIPTION
## Summary

Fixes four DHDispatcher issues discovered during RFID dispatch delay investigation (~62s delay in production on 2026-04-16).

- **#229** — Notification race condition (60s delay)
- **#230** — `POLL_INTERVAL` config ignored (hardcoded 60s timeout)
- **#231** — Missing `timeout=` on `requests.post()` in DHDispatcher and DHAccess
- **#232** — Redundant dispatches for same member+change_type (deduplication)

## Changes

### `code/DHDispatcher/main.py`

1. Removed the `if len(rows) < BATCH_SIZE: break` early exit in `process_pending_notifications()`. Rows inserted during processing (common when portal sends identity + access ~100ms apart and HTTP calls take 1-2s) are now found on the next fetch.

2. Added `conn.poll()` check before `select.select()` in the main loop. DB operations (`commit`, `set_isolation_level`, `execute`) consume pg_notify data from the TCP socket into `conn.notifies` as a side effect — without checking `conn.notifies` first, `select.select()` would block for 60s even with buffered notifications.

3. Replaced hardcoded `60.0` timeout with `POLL_INTERVAL` config value (defaults to 5s).

4. Added `timeout=30` to `requests.post()` at line 213.

5. Added `deduplicate_batch()` function + integration in `process_batch()`. When multiple `member_changes` rows exist for the same `member_id` + `change_type`, only the latest is processed; earlier ones are marked processed without dispatching. Safe because downstream services read current DB state (e.g., DHAccess uses `get_all_tags_for_member()` audit trail).

### `code/services/DHAccess/main.py`

Added `timeout=30` to both `requests.post()` calls to DH2RFID.

## Test plan

Verified end-to-end in dev environment:

- [x] Access change dispatched immediately after identity change (~100ms instead of 60s)
- [x] `conn.notifies` check detects buffered notifications
- [x] 5-second timeout polls instead of 60s
- [x] Deduplication: inserted 3 rapid same-member access changes, only the latest was dispatched, other 2 marked processed without dispatching
- [x] Normal single-tag swap works end-to-end (portal → dispatcher → DHAccess → DH2RFID)

Closes #229, #230, #231, #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)