### PR TITLE
Add 3s throttle between RFID board operations

### DIFF
--- a/code/workers/DHRFIDReader/main.py
+++ b/code/workers/DHRFIDReader/main.py
@@ -256,6 +256,12 @@ def process_queue():
                 os.fsync(f.fileno())
             # Rename is an atomic operation
             os.rename(tmp_resp, final_resp)
+
+            # Throttle between board operations to protect old controller
+            # hardware from being overwhelmed by rapid back-to-back commands
+            BOARD_THROTTLE_SECONDS = 3
+            logger.debug(f"Throttling {BOARD_THROTTLE_SECONDS}s before next board operation")
+            time.sleep(BOARD_THROTTLE_SECONDS)
         except Exception as e:
             logger.error(f"Error processing {msg_id}: {e}")
         finally:


### PR DESCRIPTION
## Summary

Adds a 3-second throttle between board operations in DHRFIDReader to protect old controller hardware from rapid back-to-back commands.

## Changes

### `code/workers/DHRFIDReader/main.py`

Added `time.sleep(BOARD_THROTTLE_SECONDS)` after each successful board operation in the `process_queue()` loop. DHRFIDReader is the single chokepoint before the physical hardware, so one throttle point protects the board regardless of which upstream service initiated the request.

## Test plan

- [x] Code change verified (cannot test throttle end-to-end in dev since `DEV_MODE=true` makes DH2RFID skip the file queue)
- [ ] Verify on production/staging with hardware access

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)