### PR TITLE
Increase DH2RFID response timeout from 10s to 30s

### DIFF
--- a/code/workers/DH2RFID/main.py
+++ b/code/workers/DH2RFID/main.py
@@ -97,7 +97,7 @@ def check_responses(sent_ids):
             
     return completed, data
 
-def perform_board_operation(operation, tag_id=None, converted_tag=None, timeout=10):
+def perform_board_operation(operation, tag_id=None, converted_tag=None, timeout=30):
     payload = {
         "operation": operation,
         "tag_id": tag_id,


### PR DESCRIPTION
## Summary

Increases DH2RFID response timeout from 10s to 30s to accommodate the 3-second board operation throttle in DHRFIDReader (#235).

## Rationale

With a 3-second throttle between board operations, a queued sequence like "add tag + remove tag + add tag" takes ~9s+ before the last response returns. The previous 10s timeout would intermittently fail even though the operations would eventually succeed.

30s accommodates up to ~8 queued operations at 3-second intervals.

## Changes

### `code/workers/DH2RFID/main.py`

Changed `perform_board_operation(..., timeout=10)` default to `timeout=30`.

## Test plan

- [x] Code change verified (cannot test end-to-end in dev since `DEV_MODE=true` makes DH2RFID skip the file queue)
- [ ] Verify on production/staging with hardware access

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)