### PR TITLE
Skip identity update when no identity fields changed

### DIFF
--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -512,6 +512,11 @@ def member_update_profile():
         logger.error(f"Error fetching identity for update: {str(e)}", exc_info=True)
         identity_data = {}
 
+    # Save original identity before applying form fields so we can
+    # skip the update if nothing actually changed — avoids creating
+    # a spurious member_changes row that delays access change processing
+    original_identity = dict(identity_data)
+
     apply_form_fields(request.form, identity_data, UPDATABLE_FIELDS["identity"])
 
     if not identity_data.get("emails") and user_email:
@@ -535,7 +540,8 @@ def member_update_profile():
     source_page = request.form.get('source_page', 'profile')
 
     try:
-        dhservices.update_member_identity(access_token, member_id, identity_data)
+        if identity_data != original_identity:
+            dhservices.update_member_identity(access_token, member_id, identity_data)
         if 'rfid_tags' in request.form:
             dhservices.update_member_access(access_token, member_id, access_data)
         flash('Profile updated successfully', 'success')


### PR DESCRIPTION
## Summary

Fixes the member portal profile update route to skip the identity update API call when no identity fields actually changed.

## Problem

The profile update route unconditionally called `update_member_identity()` on every form submission. Even when only RFID tags changed (or nothing changed), the full identity JSONB was round-tripped through JSON serialization, which often produced a value `IS DISTINCT FROM` the stored version (due to key ordering, null handling, etc.). This created a spurious identity `member_changes` row that DHDispatcher processed before the access change — widening the race window that caused the ~60s RFID dispatch delay.

## Changes

### `code/DHMemberPortal/app.py`

In `member_update_profile()`, save a shallow copy of `identity_data` before `apply_form_fields()`, then compare after. Only call `update_member_identity()` if the identity differs.

## Test plan

- [x] Verified: saving the keys page without changing any identity fields creates zero `member_changes` rows
- [x] Verified: changing an RFID tag still creates the access change row correctly
- [x] Verified: first-time identity round-trip still fires if form values differ from stored JSONB

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)