### PR TITLE
Fix identity update corrupting wrong member via email lookup

### DIFF
--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -388,14 +388,11 @@ def _get_authenticated_member_info():
         return None, redirect(url_for("index") if AUTH_MODE == "dev" else url_for("login"))
 
     access_token = session['access_token']
-    user_email = session['email']
+    member_id = session['member_id']
 
     try:
-        logger.info(f"Fetching member data for user: {user_email}")
-        member_data = dhservices.get_member_id(access_token, user_email)
-        member_id = member_data.get("member_id")
+        logger.info(f"Fetching member data for member {member_id}")
         member_info = dhservices.get_full_member_info(access_token, member_id)
-        logger.info(f"Member info loaded for member {member_id}")
         return member_info, None
     except Exception as e:
         logger.error(f"Error fetching member data: {str(e)}", exc_info=True)

--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -317,7 +317,13 @@ def add_update_identity(identity_dict, member_id=None):
     if isinstance(identity_dict, dict):
         last_updated_by = identity_dict.pop("modified_by", None)
 
-    if member_id is None:
+    caller_provided_member_id = member_id is not None
+    if caller_provided_member_id and member_id <= 0:
+        error_message = f"Invalid member_id: {member_id} (must be positive)."
+        logger.error(error_message)
+        return prepare_return_payload(None, error_message)
+
+    if not caller_provided_member_id:
         email_address = get_primary_email(identity_dict)
         if not email_address:
             error_message = "No primary email address found in payload and no member_id provided."
@@ -326,11 +332,11 @@ def add_update_identity(identity_dict, member_id=None):
         member_id = get_member_id_from_email(email_address)
 
     error_message = "OK"
-    
+
     try:
         with get_db_connection() as conn:
             with conn.cursor() as cur:
-                if member_id:
+                if member_id is not None:
                     if last_updated_by is not None:
                         cur.execute(
                             "UPDATE member SET identity = %s, last_updated_by = %s WHERE id = %s",
@@ -341,7 +347,12 @@ def add_update_identity(identity_dict, member_id=None):
                             "UPDATE member SET identity = %s WHERE id = %s",
                             (json.dumps(identity_dict), member_id),
                         )
+                    if cur.rowcount == 0:
+                        error_message = f"No member found with id {member_id}; nothing updated."
+                        logger.warning(error_message)
+                        return prepare_return_payload(None, error_message)
                 else:
+                    # Signup path: no caller member_id and email lookup found no match — INSERT
                     if last_updated_by is not None:
                         cur.execute(
                             "INSERT INTO member (identity, last_updated_by) VALUES (%s, %s) RETURNING id",
@@ -361,7 +372,7 @@ def add_update_identity(identity_dict, member_id=None):
     except Exception as e:
         error_message = f"Error adding/updating member identity: {e}"
         logger.error(error_message)
-    
+
     return prepare_return_payload(member_id, error_message)
 
 def change_email_address(email_change_dict):

--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -303,21 +303,28 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
     logger.debug(f"Paginated search found {len(members)} members (total={total})")
     return _paginated_response(members, total, page, per_page)
 
-def add_update_identity(identity_dict):
-    logger.debug(f"Adding/updating member identity: {identity_dict}")
-    
+def add_update_identity(identity_dict, member_id=None):
+    # When member_id is provided by the caller (standard update path), update
+    # that row directly. Email-based lookup is only used as a fallback for the
+    # signup path where the caller does not yet have a member_id. Looking up
+    # by email for updates is unsafe because multiple members can share an
+    # email (seed data, race conditions), and SELECT ... fetchone() returns
+    # a non-deterministic row — which would overwrite the wrong member.
+    logger.debug(f"Adding/updating member identity for member_id={member_id}: {identity_dict}")
+
     # Extract modified_by if present and identity_dict is a dictionary
     last_updated_by = None
     if isinstance(identity_dict, dict):
         last_updated_by = identity_dict.pop("modified_by", None)
-    
-    email_address = get_primary_email(identity_dict)
-    if not email_address:
-        error_message = "No primary email address found in payload."
-        logger.error(error_message)
-        return prepare_return_payload(None, error_message)
 
-    member_id = get_member_id_from_email(email_address)
+    if member_id is None:
+        email_address = get_primary_email(identity_dict)
+        if not email_address:
+            error_message = "No primary email address found in payload and no member_id provided."
+            logger.error(error_message)
+            return prepare_return_payload(None, error_message)
+        member_id = get_member_id_from_email(email_address)
+
     error_message = "OK"
     
     try:

--- a/code/DHService/v1.py
+++ b/code/DHService/v1.py
@@ -162,11 +162,17 @@ async def get_member_by_stripe_customer_id(current_user: AuthenticatedClient, st
 async def update_member_identity(
     current_client: AuthenticatedClient,
     request: Request,
+    x_member_id: Annotated[int | None, Header()] = None,
 ):
-    """Add or update member identity information."""
+    """Add or update member identity information.
+
+    When X-Member-ID is provided, updates that member by id. When omitted
+    (signup path), falls back to matching an existing member by primary
+    email or inserting a new row.
+    """
     data = await request.json()
-    logger.debug(f"In update_member_identity with {data}")
-    return db.add_update_identity(data)
+    logger.debug(f"In update_member_identity with member_id={x_member_id}, data={data}")
+    return db.add_update_identity(data, member_id=x_member_id)
 
 @app.post("/v1/member/change_email_address/")
 async def change_member_email_address(


### PR DESCRIPTION
## Summary

Fixes #243. The `POST /v1/member/identity/` endpoint in DHService was the only member POST endpoint that ignored `X-Member-ID` and resolved the target member by email lookup. When multiple members share an email (dev seed data has intentional duplicates, and real-world data can collide), identity updates non-deterministically overwrote the wrong member.

The DHMemberPortal was also re-resolving the session's member by email on every dashboard page load, producing visible session-hopping even when identity writes were safe.

## Changes

- **DHService `POST /v1/member/identity/`** accepts `X-Member-ID: Annotated[int | None, Header()]`. When present, updates that row by id. When absent (signup path), falls back to email-lookup or INSERT.
- **`db.add_update_identity()`** takes an optional `member_id` param. Non-positive values are rejected; non-matching UPDATEs return an explicit "no member found" error instead of misleading OK. INSERT is only reachable from the signup fallback path.
- **DHMemberPortal `_get_authenticated_member_info()`** uses `session['member_id']` (set at login) instead of re-running `get_member_id(email)` on every page.

## Test plan

17 scenarios tested against the dev environment at ps1-member.mime.starset.net:

- [x] Member portal save hits only member 7, not duplicate members {28, 37, 56}
- [x] Multiple consecutive saves deterministic, all hit member 7
- [x] Admin portal edit of member 56 hits only member 56 (header wins over conflicting body)
- [x] Signup path: new unique email → INSERT; existing email → email-lookup UPDATE
- [x] Profile update with identity fields (nickname, pronouns) only updates session owner
- [x] End-to-end flow: DHService → member_changes → DHDispatcher → DHIdentity → DH2AD all carry correct member_id
- [x] Session isolation verified with Dorothy (16) vs duplicate Dorothy (46)
- [x] Session stability across 10 rapid reloads + 6 dashboard pages
- [x] Malformed `X-Member-ID` (strings, floats, SQL injection, null, whitespace) handled correctly
- [x] `X-Member-ID: 0` / negative rejected (found and fixed during testing)
- [x] SQL injection, unicode, 10k-char values stored safely (parameterized queries)
- [x] `modified_by` field captured correctly via admin portal
- [x] 10 concurrent writes to same member all succeed, no cross-member corruption
- [x] Other POST endpoints (notes, access, extras) unaffected
- [x] Audit trail has no gaps, all hashes present
- [x] Log sweep: zero unexpected errors

## Follow-ups (not in this PR)

- Pre-existing: `POST /v1/member/identity/` returns 500 on malformed JSON instead of 400; doesn't validate payload structure (accepts arrays, strings, empty objects)
- Pre-existing: DHMemberPortal profile save sends identity update even when unchanged, causing noisy audit versions
- Separate issue: Static seed data has intentional duplicate emails for pending test members — needs distinct emails
- Separate issue: Dev seed data gets loaded twice on container init (60 members from a 30-row seed file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)