### PR TITLE
Member portal: fetch raw identity for save path (preserve birthday)

### DIFF
--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -502,9 +502,13 @@ def member_update_profile():
     member_id = session['member_id']
     user_email = session.get('email')
 
+    # Fetch raw identity JSONB directly (not v_member_info via get_full_member_info)
+    # so fields like birthday that aren't surfaced by the view are preserved when
+    # we round-trip through the save.
     try:
-        member_info = dhservices.get_full_member_info(access_token, member_id)
-        identity_data = (member_info.get('identity') if isinstance(member_info, dict) else {}) or {}
+        identity_data = dhservices.get_member_identity(access_token, member_id) or {}
+        if not isinstance(identity_data, dict):
+            identity_data = {}
     except Exception as e:
         logger.error(f"Error fetching identity for update: {str(e)}", exc_info=True)
         identity_data = {}


### PR DESCRIPTION
## Summary

Fixes #245. The member portal's profile save path was round-tripping identity through the `v_member_info` view, silently dropping fields that the view doesn't surface (`birthday`, etc.) and adding view-shape keys (`member_id`, `primary_email`, `nametag_subtitle`, `theme_song_url`, `theme_song_duration`) into the source-of-truth JSONB on every save.

## Change

One narrow change in `member_update_profile` ([code/DHMemberPortal/app.py:506-510](code/DHMemberPortal/app.py#L506-L510)): fetch the raw identity via `dhservices.get_member_identity()` (which hits `/v1/member/identity/` and returns the raw JSONB from the `member` row) instead of `get_full_member_info()` (which returns the view-shaped subset).

`apply_form_fields` only writes keys listed in `UPDATABLE_FIELDS["identity"]`, so unknown fields like `birthday` are preserved across the round-trip. The display path (`_get_authenticated_member_info`) still uses `get_full_member_info` — unchanged — because the dashboard templates expect the view-shaped dict.

## Test plan

Verified on dev against ps1-member.mime.starset.net:

- [x] Emmy Noether (member 30, pending, `birthday: 1995-03-23`): saved nickname change, confirmed `birthday` preserved and no view-only keys added
- [x] No-op save: unchanged profile does not bump audit version (skip-when-unchanged still works)
- [x] Rosalind Franklin (member 7, email collides with 28/37/56): save still only targets member 7 — does not regress #244
- [x] DHService log confirms payload now contains raw identity fields (`birthday`, `active_directory_username`) and no `primary_email`/`member_id`/`nametag_subtitle`/`theme_song_*` pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)