### PR TITLE
Rename seed_data.local.sql → seed_data.sql (match .example convention)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ flask_session/
 .claude
 *.code-workspace
 pg/db-init/02-seed_data.sql
-pg/sql/seed_data.local.sql
+pg/sql/seed_data.sql
 .env.local*
 .env.production*
 .env.staging*

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -149,9 +149,10 @@ tools/seed_data.sh static                # Hand-crafted static data (25 members)
 tools/seed_data.sh status                # Show current seed data info
 ```
 
-Output goes to `pg/sql/seed_data.local.sql` (gitignored), which is
-mounted into the database container during init. The static reference
-data lives in `pg/sql/seed_data.sql` (committed to git).
+Output goes to `pg/sql/seed_data.sql` (gitignored working copy), which
+is mounted into the database container during init. The committed
+template lives at `pg/sql/seed_data.sql.example` — this matches the
+repo-wide `config.ini.example` → `config.ini` convention.
 
 ### 3. Start / Stop
 

--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -428,7 +428,7 @@ def requires_view_permission(tab_name):
 ###############################################################################
 
 # Preset users for the dev login page. These match the seed data in
-# pg/sql/seed_data.sql — don't change the IDs without updating the SQL.
+# pg/sql/seed_data.sql.example — don't change the IDs without updating the SQL.
 ADMIN_DEV_USERS = [
     {"member_id": 1, "name": "Ada Lovelace", "email": "ada.lovelace@example.com", "role": "Administrator"},
     {"member_id": 3, "name": "Nikola Tesla", "email": "nikola.tesla@example.com", "role": "Authorizer"},

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -677,7 +677,7 @@ app.jinja_env.globals.update(dev_banner=DEV_BANNER)  # Used in dev banner
 ###############################################################################
 
 # Preset users for the dev login page. These match the seed data in
-# pg/sql/seed_data.sql — don't change the IDs without updating the SQL.
+# pg/sql/seed_data.sql.example — don't change the IDs without updating the SQL.
 MEMBER_DEV_USERS = [
     {"member_id": 7, "name": "Rosalind Franklin", "email": "rosalind.franklin@example.com", "description": "Active member with full data"},
     {"member_id": 16, "name": "Dorothy Vaughan", "email": "dorothy.vaughan@example.com", "description": "Brand new member, minimal data"},

--- a/dh_dev.sh
+++ b/dh_dev.sh
@@ -51,8 +51,16 @@ print_access() {
 }
 
 preflight() {
-    if [[ ! -f "pg/sql/seed_data.local.sql" ]]; then
-        echo "ERROR: No seed data found at pg/sql/seed_data.local.sql"
+    # Migration: the seed working copy was renamed from seed_data.local.sql
+    # to seed_data.sql to match the repo's config.ini.example convention.
+    # If a pre-rename file still exists, move it into place.
+    if [[ -f "pg/sql/seed_data.local.sql" ]] && [[ ! -f "pg/sql/seed_data.sql" ]]; then
+        echo "Migrating pg/sql/seed_data.local.sql → pg/sql/seed_data.sql..."
+        mv "pg/sql/seed_data.local.sql" "pg/sql/seed_data.sql"
+    fi
+
+    if [[ ! -f "pg/sql/seed_data.sql" ]]; then
+        echo "ERROR: No seed data found at pg/sql/seed_data.sql"
         echo "Run '$0 setup' first, or generate seed data:"
         echo "  tools/seed_data.sh generate"
         exit 1
@@ -98,8 +106,8 @@ cmd_setup() {
 
     # Step 2: Generate seed data
     echo "--- Generating seed data ---"
-    if [[ -f "pg/sql/seed_data.local.sql" ]] && [[ -s "pg/sql/seed_data.local.sql" ]]; then
-        echo "  Seed data already exists ($(wc -l < pg/sql/seed_data.local.sql) lines)"
+    if [[ -f "pg/sql/seed_data.sql" ]] && [[ -s "pg/sql/seed_data.sql" ]]; then
+        echo "  Seed data already exists ($(wc -l < pg/sql/seed_data.sql) lines)"
         echo "  To regenerate: tools/seed_data.sh generate"
     else
         if command -v uv &> /dev/null; then
@@ -182,10 +190,16 @@ cmd_clean() {
         echo "Removed $config_count config.ini files"
     fi
 
-    # Remove generated seed data
+    # Remove the seed data working copy (template seed_data.sql.example is
+    # committed and never touched)
+    if [[ -f "pg/sql/seed_data.sql" ]]; then
+        rm -f pg/sql/seed_data.sql
+        echo "Removed pg/sql/seed_data.sql"
+    fi
+    # Also clean up the pre-rename filename if a stale copy is around
     if [[ -f "pg/sql/seed_data.local.sql" ]]; then
         rm -f pg/sql/seed_data.local.sql
-        echo "Removed pg/sql/seed_data.local.sql"
+        echo "Removed pg/sql/seed_data.local.sql (legacy name)"
     fi
 
     echo ""

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
 
   db:
     volumes:
-      - ./pg/sql/seed_data.local.sql:/docker-entrypoint-initdb.d/02-seed_data.sql
+      - ./pg/sql/seed_data.sql:/docker-entrypoint-initdb.d/02-seed_data.sql
 
   #########################################################
   # Front-end services — move from host network to bridge

--- a/pg/sql/seed_data.sql.example
+++ b/pg/sql/seed_data.sql.example
@@ -1,19 +1,24 @@
 /*
- * Deep Harbor Seed Data
+ * Deep Harbor Seed Data — template
  *
- * This file populates the database with ~30 fictional members for
- * local development and testing. It runs as 02-seed_data.sql during
- * Docker first-boot init, after the schema (01-pgsql_schema.sql)
- * is already in place.
+ * This is the COMMITTED template for ~30 fictional dev members. Docker
+ * does NOT load this file directly. It loads pg/sql/seed_data.sql
+ * (gitignored working copy). To use this template:
+ *
+ *   tools/seed_data.sh static    # copies this file → seed_data.sql
+ *   ./dh_dev.sh reset            # wipes DB and reloads from seed_data.sql
+ *
+ * The seed_data.sql / seed_data.sql.example split follows the same
+ * pattern as config.ini / config.ini.example used throughout the repo.
  *
  * IMPORTANT: The first 10 members are "dev bypass" users with stable,
- * predictable IDs (1-10). Issue #13 (dev auth bypass) references
- * these IDs directly. Don't reorder them.
+ * predictable IDs (1-10). Issue #13 (dev auth bypass) references these
+ * IDs directly. Don't reorder them.
  *
- * Inserting members fires the audit trigger, log_member_changes(),
- * and pg_notify. First boot will be noisy as the dispatcher processes
- * ~25 change events. This is expected and harmless with DEV_MODE=true
- * on the worker services.
+ * Inserting members fires the audit trigger, log_member_changes(), and
+ * pg_notify. First boot will be noisy as the dispatcher processes ~25
+ * change events. This is expected and harmless with DEV_MODE=true on
+ * the worker services.
  */
 
 

--- a/tools/seed_data.sh
+++ b/tools/seed_data.sh
@@ -3,23 +3,22 @@
 # seed_data.sh — Manage seed data for the Deep Harbor dev environment
 #
 # This script provides a convenient way to use either the hand-crafted
-# static seed data or the Python generator to create seed_data.local.sql.
+# static seed data or the Python generator to create pg/sql/seed_data.sql.
 #
-# The static reference data lives in pg/sql/seed_data.sql (committed to git).
-# The working copy used by Docker is pg/sql/seed_data.local.sql (gitignored).
+# Files (matching the repo's config.ini.example → config.ini pattern):
+#   pg/sql/seed_data.sql.example  — committed template (hand-crafted reference)
+#   pg/sql/seed_data.sql          — gitignored working copy; Docker mounts this
 #
 # Usage:
-#   tools/seed_data.sh static          Copy the hand-crafted seed data (25 members)
+#   tools/seed_data.sh static          Copy the template over the working copy
 #   tools/seed_data.sh generate        Generate random seed data (25 members by default)
 #   tools/seed_data.sh generate 100    Generate 110 members (100 random + 10 dev users)
 #   tools/seed_data.sh generate 50 abc Generate with specific seed for reproducibility
-#   tools/seed_data.sh status          Show what's currently in seed_data.local.sql
+#   tools/seed_data.sh status          Show what's currently in the working copy
 #
-# The output file is pg/sql/seed_data.local.sql, which docker-compose.dev.yml
-# mounts as /docker-entrypoint-initdb.d/02-seed_data.sql. After changing
-# seed data you'll need to reset the database:
-#   docker compose -f docker-compose.yaml -f docker-compose.dev.yml down -v
-#   docker compose -f docker-compose.yaml -f docker-compose.dev.yml up --build -d
+# These commands only touch the file. To apply changes to the running DB
+# you need to reset (dh_dev.sh reset), because PostgreSQL only runs
+# /docker-entrypoint-initdb.d scripts on an empty volume.
 #
 
 set -euo pipefail
@@ -28,30 +27,30 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-SEED_DATA_FILE="$REPO_ROOT/pg/sql/seed_data.local.sql"
-STATIC_SOURCE="$REPO_ROOT/pg/sql/seed_data.sql"
+SEED_DATA_FILE="$REPO_ROOT/pg/sql/seed_data.sql"
+STATIC_SOURCE="$REPO_ROOT/pg/sql/seed_data.sql.example"
 GENERATOR="$REPO_ROOT/pg/tools/generate_seed_data.py"
 
 usage() {
     echo "Usage: $0 <command> [options]"
     echo ""
     echo "Commands:"
-    echo "  static              Copy the hand-crafted static seed data (25 members)"
+    echo "  static              Copy the hand-crafted template (seed_data.sql.example)"
+    echo "                      over the working copy (seed_data.sql)"
     echo "  generate [N] [SEED] Generate seed data with N random members (default: 15)"
     echo "                      plus 10 dev bypass users. Optionally specify a seed"
     echo "                      for reproducibility."
-    echo "  status              Show what's currently in seed_data.sql"
+    echo "  status              Show what's currently in the working copy"
     echo ""
     echo "Examples:"
-    echo "  $0 static                  Copy the static seed data to local"
+    echo "  $0 static                  Restore the hand-crafted template"
     echo "  $0 generate                Generate 25 members (15 random + 10 dev)"
     echo "  $0 generate 100            Generate 110 members (100 random + 10 dev)"
     echo "  $0 generate 50 myseed123   Reproducible: same seed = same output"
-    echo "  $0 status                  Check current seed data file"
+    echo "  $0 status                  Check current working copy"
     echo ""
-    echo "After changing seed data, reset the database:"
-    echo "  docker compose -f docker-compose.yaml -f docker-compose.dev.yml down -v"
-    echo "  docker compose -f docker-compose.yaml -f docker-compose.dev.yml up --build -d"
+    echo "These commands only update the file. To apply to the running DB:"
+    echo "  ./dh_dev.sh reset"
 }
 
 cmd_static() {
@@ -59,11 +58,13 @@ cmd_static() {
         cp "$STATIC_SOURCE" "$SEED_DATA_FILE"
         local count
         count=$(grep -c "INSERT INTO member " "$SEED_DATA_FILE" || true)
-        echo "Copied static seed data: $count member inserts"
+        echo "Copied template: $count member inserts"
         echo "  From: $STATIC_SOURCE"
         echo "  To:   $SEED_DATA_FILE"
+        echo ""
+        echo "Run './dh_dev.sh reset' to apply this to the running DB."
     else
-        echo "Error: Static seed data not found at $STATIC_SOURCE"
+        echo "Error: Template not found at $STATIC_SOURCE"
         exit 1
     fi
 }
@@ -86,11 +87,14 @@ cmd_generate() {
     echo "Generating seed data: $count random + 10 dev users = $((count + 10)) total..."
     uv run "$GENERATOR" --count "$count" "${seed_args[@]}" --output "$SEED_DATA_FILE"
     echo "Wrote $SEED_DATA_FILE"
+    echo ""
+    echo "Run './dh_dev.sh reset' to apply this to the running DB."
 }
 
 cmd_status() {
     if [[ ! -f "$SEED_DATA_FILE" ]]; then
-        echo "No seed data file found at $SEED_DATA_FILE"
+        echo "No working copy found at $SEED_DATA_FILE"
+        echo "Run '$0 static' or '$0 generate' to create one."
         exit 0
     fi
 
@@ -98,7 +102,7 @@ cmd_status() {
     member_count=$(grep -c "INSERT INTO member (" "$SEED_DATA_FILE" || true)
     role_count=$(grep -c "INSERT INTO member_to_role" "$SEED_DATA_FILE" || true)
 
-    echo "Seed data file: $SEED_DATA_FILE"
+    echo "Working copy: $SEED_DATA_FILE"
     echo "  Members: $member_count"
     echo "  Role assignments: $role_count"
 


### PR DESCRIPTION
## Summary

Fixes #247. The dev seed data files used a non-standard naming convention that's been the source of real confusion:

- \`pg/sql/seed_data.sql\` (committed) — hand-crafted reference, **not** what Docker loads
- \`pg/sql/seed_data.local.sql\` (gitignored) — working copy, **is** what Docker mounts

The \`.local\` suffix is ambiguous, and the committed file's name implies it's what runs (it isn't). This has led to at least one doubled-load incident and repeated agent-confusion episodes.

## Change

Rename to match the repo-wide \`config.ini.example\` → \`config.ini\` pattern:

- \`pg/sql/seed_data.sql.example\` — committed hand-crafted reference
- \`pg/sql/seed_data.sql\` — gitignored working copy (what Docker mounts)

## Migration for existing dev envs

\`dh_dev.sh preflight\` auto-migrates: if \`seed_data.local.sql\` exists and \`seed_data.sql\` doesn't, it moves the file into place. No manual action needed on pull.

## Files touched

- git rename \`pg/sql/seed_data.sql\` → \`pg/sql/seed_data.sql.example\`
- \`.gitignore\` — flip entry
- \`docker-compose.dev.yml\` — mount path
- \`tools/seed_data.sh\` — path variables, help text, added "run \`./dh_dev.sh reset\` to apply" hints
- \`dh_dev.sh\` — preflight check, preflight migration helper, setup step, clean step
- \`pg/sql/seed_data.sql.example\` — header comment fixed to describe template role
- \`DEV_SETUP.md\` — seed data section
- \`code/DHAdminPortal/app.py\`, \`code/DHMemberPortal/app.py\` — inline comment references

## Test plan

Verified locally against the existing dev env (had the legacy \`seed_data.local.sql\` on disk):

- [x] Migration helper renames the legacy file transparently on next preflight
- [x] \`tools/seed_data.sh status\` reports correct state before and after migration
- [x] \`tools/seed_data.sh static\` correctly copies the .example to the working copy
- [x] \`tools/seed_data.sh generate\` correctly writes to the new working copy path
- [x] \`docker compose config\` shows the new mount path resolves correctly
- [x] Script help text updated and tells users to run \`./dh_dev.sh reset\` to apply

Script behavior improvements (drift detection, \`--apply\` flag, reset-preserves-seed docs, setup skip/wipe reconciliation) tracked in #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)