### PR TITLE
Username check should not be case sensitive

### DIFF
--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -501,7 +501,7 @@ def is_username_available(username: str) -> bool:
     with get_db_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT COUNT(1) FROM member WHERE identity->>'active_directory_username' = %s",
+                "SELECT COUNT(1) FROM member WHERE LOWER(identity->>'active_directory_username') = LOWER(%s)",
                 (username,),
             )
             result = cur.fetchone()


### PR DESCRIPTION
Had two users pick the same username, except one had a capital letter and the other did not. This caused the second one to not be created in B2C and AD because AD usernames are _not_ case-sensitive.