### PR TITLE
Remove unintentional duplicate emails from seed template

### DIFF
--- a/pg/sql/seed_data.sql.example
+++ b/pg/sql/seed_data.sql.example
@@ -411,11 +411,11 @@ INSERT INTO member (identity, connections, status, forms, access, authorizations
  * (no ID check), no RFID tags, no authorizations.
  * ===================================================================== */
 
-/* ID 26 - Rosalind Franklin, Pending — Stripe paid */
+/* ID 26 - Niels Bohr, Pending — Stripe paid */
 INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
-    '{"first_name": "Rosalind", "last_name": "Franklin", "nickname": "photo51", "birthday": "1990-07-25", "emails": [{"type": "primary", "email_address": "rosalind.franklin@example.com"}], "pronouns": "she/her"}'::jsonb,
-    '{"discord_username": "rfranklin_xray"}'::jsonb,
-    '{"membership_status": "pending", "membership_level": "Membership", "stripe_product_id": "prod_Tws7udZJSXI9DU", "stripe_subscription_id": "sub_fake_franklin"}'::jsonb,
+    '{"first_name": "Niels", "last_name": "Bohr", "nickname": "quantum_dane", "birthday": "1990-07-25", "emails": [{"type": "primary", "email_address": "niels.bohr@example.com"}], "pronouns": "he/him"}'::jsonb,
+    '{"discord_username": "nbohr_quantum"}'::jsonb,
+    '{"membership_status": "pending", "membership_level": "Membership", "stripe_product_id": "prod_Tws7udZJSXI9DU", "stripe_subscription_id": "sub_fake_bohr"}'::jsonb,
     '{"id_check_1": "", "id_check_2": "", "waiver_signed_date": "2026-03-28", "terms_of_use_accepted": "true", "essentials_form": "", "orientation_completed_date": "", "is_21_or_older": false}'::jsonb,
     '{"rfid_tags": []}'::jsonb,
     '{"authorizations": [], "computer_authorizations": []}'::jsonb,
@@ -435,9 +435,9 @@ INSERT INTO member (identity, connections, status, forms, access, authorizations
     '{"notes": [{"date": "2026-03-29", "author": "System", "text": "New signup via Stripe"}]}'::jsonb
 );
 
-/* ID 28 - Emmy Noether, Pending — NO Stripe (cash payment) */
+/* ID 28 - Lise Meitner, Pending — NO Stripe (cash payment) */
 INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
-    '{"first_name": "Emmy", "last_name": "Noether", "nickname": "symmetry_queen", "birthday": "1995-03-23", "emails": [{"type": "primary", "email_address": "emmy.noether@example.com"}]}'::jsonb,
+    '{"first_name": "Lise", "last_name": "Meitner", "nickname": "fission_pioneer", "birthday": "1995-03-23", "emails": [{"type": "primary", "email_address": "lise.meitner@example.com"}], "pronouns": "she/her"}'::jsonb,
     NULL,
     '{"membership_status": "pending", "membership_level": "Member - Cash Payment"}'::jsonb,
     '{"id_check_1": "", "id_check_2": "", "waiver_signed_date": "2026-03-30", "terms_of_use_accepted": "true", "essentials_form": "", "orientation_completed_date": "", "is_21_or_older": false}'::jsonb,


### PR DESCRIPTION
## Summary

Two pending test members in \`pg/sql/seed_data.sql.example\` shared primary email addresses with earlier active members:

- ID 7 (Rosalind Franklin, active) + ID 26 (Rosalind Franklin, pending) — both \`rosalind.franklin@example.com\`
- ID 12 (Emmy Noether, active) + ID 28 (Emmy Noether, pending) — both \`emmy.noether@example.com\`

These collisions were the trigger that surfaced #243 (DHService resolving target member by \`fetchone()\` over a non-unique email). The data-corruption vector is fixed in #244 and the session-lookup was fixed there too, but the dupes remained in the template. They weren't an intentional test fixture — primary email should be unique per member, and other code paths still key on email (dev login lookup, signup duplicate-email check).

## Change

Replace the two duplicate-email rows with distinct physicists who aren't already in the seed:

- ID 26 (pending, Stripe paid): **Niels Bohr** (\`niels.bohr@example.com\`)
- ID 28 (pending, cash payment): **Lise Meitner** (\`lise.meitner@example.com\`)

Biographical pattern preserved (nickname, birthday, pronouns, pending status, Stripe vs cash-payment marker) so the onboarding-workflow tests still exercise the same code paths.

## Test plan

\`\`\`
./dh_dev.sh reseed static
psql ... -c "SELECT identity->'emails'->0->>'email_address', count(*), array_agg(id)
             FROM member GROUP BY 1 HAVING count(*) > 1;"
# → 0 rows
\`\`\`

Verified:
- [x] Reseed ran cleanly via the new \`dh_dev.sh reseed\` wrapper from #250
- [x] Zero email duplicates in the resulting DB
- [x] Pending members 26, 27, 28 now: Niels Bohr, Alan Turing (unchanged), Lise Meitner — all distinct emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)