### PR TITLE
Validate admin portal dev_login_select member_id as int

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -453,6 +453,12 @@ def dev_login_select():
         return redirect(url_for("dev_login"))
 
     try:
+        member_id = int(member_id)
+    except (ValueError, TypeError):
+        flash("Invalid member ID.", "error")
+        return redirect(url_for("dev_login"))
+
+    try:
         # Get DHService access token — same as the B2C callback does
         access_token = dhservices.get_access_token(
             dhservices.DH_CLIENT_ID,

--- a/code/DHAdminPortal/templates/dev_login.html
+++ b/code/DHAdminPortal/templates/dev_login.html
@@ -4,6 +4,17 @@
 
 <h1><span class="title-org">Pumping Station: One</span> <span class="title-sub">Administration Portal</span></h1>
 
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+        <div class="alert alert-{{ 'danger' if category == 'error' else 'info' }} alert-dismissible fade show" role="alert">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
 <div class="row justify-content-center">
     <div class="col-md-8">
         <h3 class="text-center mb-4">Select a Dev User</h3>


### PR DESCRIPTION
## Summary

- Admin portal `dev_login_select` now casts `member_id` to `int` inside `try/except ValueError/TypeError`, flashing "Invalid member ID." and redirecting back to `/dev-login` on failure — mirrors the member portal pattern from PR #191.
- Adds a Bootstrap flash-message block to `DHAdminPortal/templates/dev_login.html` so the flash actually renders (the admin `base.html` has no flash block, so without this the flash would be consumed silently).

Closes #257.

## Why

Previously a non-integer `member_id` was forwarded to DHService as a query param, FastAPI returned 422, and the admin portal surfaced a generic "Whoops" error page. Severity is low (`/dev-login/select` is guarded by `AUTH_MODE != "dev"` and dead in production), but this is a defense-in-depth + UX gap the member portal already closed months ago.

## Test plan

Verified via Chrome DevTools MCP against `https://ps1-admin.mime.starset.net/` on the dev stack:

**Baseline (pre-fix)**
- [x] POST `member_id=abc-not-an-int` → 200 `Whoops` page; `dhadminportal` logs show `Dev login error: 422 Client Error: Unprocessable Content`.

**Validation matrix (all should flash + redirect)**
- [x] `abc-not-an-int`, `' OR 1=1 --`, `1.5`, `1e3`, `0x10`, `½`, `"   "`, `abc\nFAKE LOG ENTRY`, `<script>alert(1)</script>`, `"1\0"` — all graceful flash, zero DHService 422s.

**Accepted by Python int() (login succeeds — intentional)**
- [x] `+1` and `" 1 "` — `int()` strips whitespace / accepts leading sign; treated as 1. Matches member portal behavior.

**Pre-existing Whoops path (out of scope)**
- [x] `-1`, `0`, huge number — pass int() cast; DHService returns null body and the outer handler surfaces "Dev Login Error". Identical behavior in the member portal. Not introduced or worsened by this PR.

**Empty/missing**
- [x] `member_id=""` → silent redirect (pre-existing empty-guard branch, regression check).

**Flash UI**
- [x] Renders as `alert alert-danger alert-dismissible fade show` with close button (Bootstrap red).
- [x] Two queued flashes render side-by-side.
- [x] Dismiss button removes the alert.
- [x] Page reload clears the session flash (one-shot).

**Happy paths**
- [x] Ada (id=1) via preset card → admin homepage.
- [x] Tesla (id=3) via manual-entry form → admin homepage.
- [x] Hopper (id=5) via preset card → admin homepage.

**Logs / console**
- [x] Zero `422 Unprocessable Content` entries after the fix.
- [x] No new JS console errors introduced by the template change (pre-existing CSP `.map` warnings unchanged).