### PR TITLE
Tighten .gitignore for Backlog.md (root-anchored)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pg/sql/seed_data.sql
 .env.staging*
 .env.development*
 .env.*.production
+/backlog.config.yml
+/backlog/


### PR DESCRIPTION
## Summary
- Replace uncommitted broad `backlog*` glob with root-anchored entries: `/backlog.config.yml` and `/backlog/`
- Add the trailing newline that was missing at EOF

## Why
The Backlog.md CLI keeps its config file (`backlog.config.yml`) at the repo root, and its default new-install location for the task tree is a top-level `backlog/` directory. Both should stay untracked. Anchoring with a leading `/` keeps the patterns scoped to the repo root rather than matching anything starting with "backlog" anywhere in the tree.

## Test plan
- [ ] `git status` after pulling: `backlog.config.yml` shows untracked-but-ignored
- [ ] `git check-ignore -v backlog.config.yml` and `git check-ignore -v backlog/foo` both report a hit on the new lines
- [ ] `git check-ignore -v code/some-backlog-thing` does *not* match (root-anchoring confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)