### PR TITLE
DHService: server-side JSONB merge for partial member updates

### DIFF
--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -67,7 +67,14 @@ def _get_single_field(member_id: str, field: str):
     return None
 
 def _update_single_field(member_id: int, field: str, value, serialize=True, last_updated_by=None):
-    """Generic function to update a single field in the member table."""
+    """Generic function to REPLACE a single field in the member table.
+
+    Use this only for non-object JSONB columns (e.g. notes, which is an
+    array and is built-up in Python before write). For object-shaped JSONB
+    columns (identity, status, forms, access, extras, authorizations,
+    connections), use `_merge_jsonb_field` so partial POSTs don't wipe
+    keys the caller didn't supply.
+    """
     if field not in ALLOWED_MEMBER_FIELDS:
         raise ValueError(f"Invalid field: {field}")
     logger.debug(f"Updating member {field} for member ID: {member_id}")
@@ -89,6 +96,53 @@ def _update_single_field(member_id: int, field: str, value, serialize=True, last
             conn.commit()
     except Exception as e:
         error_message = f"Error updating member {field}: {e}"
+        logger.error(error_message)
+    return prepare_return_payload(member_id, error_message)
+
+def _merge_jsonb_field(member_id: int, field: str, value: dict, last_updated_by=None):
+    """Shallow-merge `value` into the existing JSONB column `field` on member.
+
+    Uses Postgres `||` operator for atomic single-statement merge. Top-level
+    keys in `value` overwrite matching keys in the existing column; keys not
+    present in `value` are preserved. Works correctly when the column is NULL
+    (treated as `{}`).
+
+    Caveats:
+    - Shallow merge only — array values inside the blob are replaced wholesale
+      (e.g. `emails`, `rfid_tags`). Every existing caller sends full arrays,
+      so this matches intent.
+    - Cannot remove keys. To delete a key, callers would need a dedicated
+      delete endpoint (none exists today; add when needed).
+    - Only valid for object-shaped JSONB columns. Do NOT call this for `notes`
+      (array): `||` on arrays concatenates instead of merging, which would
+      double-append since `add_update_notes` builds the full list.
+    """
+    if field not in ALLOWED_MEMBER_FIELDS:
+        raise ValueError(f"Invalid field: {field}")
+    logger.debug(f"Merging into member {field} for member ID: {member_id}")
+    error_message = "OK"
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                payload = json.dumps(value)
+                if last_updated_by is not None:
+                    cur.execute(
+                        f"UPDATE member "
+                        f"SET    {field} = COALESCE({field}, '{{}}'::jsonb) || %s::jsonb, "
+                        f"       last_updated_by = %s "
+                        f"WHERE  id = %s",
+                        (payload, last_updated_by, member_id),
+                    )
+                else:
+                    cur.execute(
+                        f"UPDATE member "
+                        f"SET    {field} = COALESCE({field}, '{{}}'::jsonb) || %s::jsonb "
+                        f"WHERE  id = %s",
+                        (payload, member_id),
+                    )
+            conn.commit()
+    except Exception as e:
+        error_message = f"Error merging member {field}: {e}"
         logger.error(error_message)
     return prepare_return_payload(member_id, error_message)
 
@@ -340,14 +394,24 @@ def add_update_identity(identity_dict, member_id=None):
         with get_db_connection() as conn:
             with conn.cursor() as cur:
                 if member_id is not None:
+                    # Shallow JSONB merge so a partial POST (e.g. just
+                    # `{"birthday": ...}`) doesn't wipe other identity
+                    # keys. See GH #263. The `emails` array key is
+                    # replaced wholesale on merge, which matches every
+                    # caller's intent (they always send full arrays).
                     if last_updated_by is not None:
                         cur.execute(
-                            "UPDATE member SET identity = %s, last_updated_by = %s WHERE id = %s",
+                            "UPDATE member "
+                            "SET    identity = COALESCE(identity, '{}'::jsonb) || %s::jsonb, "
+                            "       last_updated_by = %s "
+                            "WHERE  id = %s",
                             (json.dumps(identity_dict), last_updated_by, member_id),
                         )
                     else:
                         cur.execute(
-                            "UPDATE member SET identity = %s WHERE id = %s",
+                            "UPDATE member "
+                            "SET    identity = COALESCE(identity, '{}'::jsonb) || %s::jsonb "
+                            "WHERE  id = %s",
                             (json.dumps(identity_dict), member_id),
                         )
                     if cur.rowcount == 0:
@@ -355,7 +419,8 @@ def add_update_identity(identity_dict, member_id=None):
                         logger.warning(error_message)
                         return prepare_return_payload(None, error_message)
                 else:
-                    # Signup path: no caller member_id and email lookup found no match — INSERT
+                    # Signup path: no caller member_id and email lookup found
+                    # no match — INSERT the full blob. No row to merge into.
                     if last_updated_by is not None:
                         cur.execute(
                             "INSERT INTO member (identity, last_updated_by) VALUES (%s, %s) RETURNING id",
@@ -418,49 +483,23 @@ def change_email_address(email_change_dict):
     return prepare_return_payload(member_id, error_message)
 
 def add_update_connections(member_id, connections_dict):
-    logger.debug(f"Adding/updating connections for member ID: {member_id}")
-    
-    # Extract modified_by if present and connections_dict is a dictionary
-    last_updated_by = None
-    if isinstance(connections_dict, dict):
-        last_updated_by = connections_dict.pop("modified_by", None)
-    
-    error_message = "OK"
-    try:
-        with get_db_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT connections FROM member WHERE id = %s", (member_id,))
-                result = cur.fetchone()
-                existing = result[0] if result and result[0] else {}
-                existing.update(connections_dict)
-                if last_updated_by is not None:
-                    cur.execute(
-                        "UPDATE member SET connections = %s, last_updated_by = %s WHERE id = %s",
-                        (json.dumps(existing), last_updated_by, member_id),
-                    )
-                else:
-                    cur.execute(
-                        "UPDATE member SET connections = %s WHERE id = %s",
-                        (json.dumps(existing), member_id),
-                    )
-            conn.commit()
-    except Exception as e:
-        error_message = f"Error updating connections: {e}"
-        logger.error(error_message)
-    return prepare_return_payload(member_id, error_message)
+    last_updated_by = connections_dict.pop("modified_by", None) if isinstance(connections_dict, dict) else None
+    return _merge_jsonb_field(member_id, "connections", connections_dict, last_updated_by=last_updated_by)
 
-# Simple field update functions using the generic helper
+# Object-shaped JSONB update functions — use `_merge_jsonb_field` so partial
+# POSTs don't wipe keys the caller didn't supply. See GH #263 for the bug
+# class this prevents.
 def add_update_forms(member_id, forms_dict):
     last_updated_by = forms_dict.pop("modified_by", None) if isinstance(forms_dict, dict) else None
-    return _update_single_field(member_id, "forms", forms_dict, last_updated_by=last_updated_by)
+    return _merge_jsonb_field(member_id, "forms", forms_dict, last_updated_by=last_updated_by)
 
 def add_update_access(member_id, access_dict):
     last_updated_by = access_dict.pop("modified_by", None) if isinstance(access_dict, dict) else None
-    return _update_single_field(member_id, "access", access_dict, last_updated_by=last_updated_by)
+    return _merge_jsonb_field(member_id, "access", access_dict, last_updated_by=last_updated_by)
 
 def add_update_extras(member_id, extras_dict):
     last_updated_by = extras_dict.pop("modified_by", None) if isinstance(extras_dict, dict) else None
-    return _update_single_field(member_id, "extras", extras_dict, last_updated_by=last_updated_by)
+    return _merge_jsonb_field(member_id, "extras", extras_dict, last_updated_by=last_updated_by)
 
 def add_update_notes(member_id, notes_dict):
     last_updated_by = notes_dict.pop("modified_by", None) if isinstance(notes_dict, dict) else None
@@ -492,11 +531,11 @@ def add_update_notes(member_id, notes_dict):
 
 def add_update_status(member_id, status_dict):
     last_updated_by = status_dict.pop("modified_by", None) if isinstance(status_dict, dict) else None
-    return _update_single_field(member_id, "status", status_dict, last_updated_by=last_updated_by)
+    return _merge_jsonb_field(member_id, "status", status_dict, last_updated_by=last_updated_by)
 
 def add_update_authorizations(member_id, authorizations_dict):
     last_updated_by = authorizations_dict.pop("modified_by", None) if isinstance(authorizations_dict, dict) else None
-    return _update_single_field(member_id, "authorizations", authorizations_dict, last_updated_by=last_updated_by)
+    return _merge_jsonb_field(member_id, "authorizations", authorizations_dict, last_updated_by=last_updated_by)
 
 def get_member_authorization_changes(member_id: str) -> dict:
     logger.debug(f"Getting authorization changes for member ID: {member_id}")


### PR DESCRIPTION
## Summary

- Object-shaped JSONB update functions (`identity`, `status`, `forms`, `access`, `extras`, `authorizations`, `connections`) in `code/DHService/db.py` now do shallow `||` merge instead of full-blob replace via a new `_merge_jsonb_field` helper.
- `add_update_notes` keeps the replace path — `notes` is a JSONB array and `||` on arrays concatenates, which would double-append since `add_update_notes` already builds the full updated list in Python.
- `add_update_identity` UPDATE branch inlines the same merge SQL; INSERT branch (signup path) is unchanged because there's no row to merge into.

Fixes #263 — Onboard tab activation no longer wipes identity/status fields when posting `{birthday}` / `{membership_status: "active"}` / `{rfid_tags: [...]}`. This is the third occurrence of the same bug class (forms had it before, member portal profile had it via PR #246, now onboard activation), so the fix is at the API layer to prevent recurrence.

The merge SQL is `UPDATE member SET {field} = COALESCE({field}, '{}'::jsonb) || %s::jsonb` — atomic in a single statement (no read-modify-write race two concurrent partial POSTs would otherwise hit).

## Why server-side over client-side fetch-merge

- Atomicity: single-statement merge can't lose updates under concurrency. The previous `add_update_connections` did Python read-modify-write and had this race today.
- Smaller diff than adding fetch-then-merge dances to every partial-POST caller.
- Eliminates the entire footgun class — every existing partial-POST caller (admin Onboard, ST2DH webhook, future code) is now safe by construction.

## Behavior changes

- **Arrays inside the blob** (e.g. `emails`, `rfid_tags`, `authorizations.physical_authorizations`) still replace wholesale on shallow merge. Every caller already sends the full array, so this matches existing intent.
- **Cannot remove keys** via POST — the merge can only add or overwrite top-level keys. No caller needs key removal today.
- **No-op merges no longer fire spurious audit rows** because `IS DISTINCT FROM` correctly compares semantic JSONB equality. Bonus side-effect; previous full-replace could fire a `member_changes` row even when the data was unchanged.
- **Audit trigger unchanged** — `log_member_changes()` reads `OLD/NEW` row state, so it still emits per-column rows with the fully-merged blob, exactly as DHDispatcher expects.

## Test plan

- [x] End-to-end activation on Niels Bohr (member 28): identity preserves first/last/emails/nickname/pronouns/birthday; status preserves membership_level + Stripe IDs alongside flipped membership_status='active'.
- [x] API matrix — partial POST to each of identity/status/access/forms/extras/authorizations preserves all unmentioned keys; arrays inside (rfid_tags, authorizations) replace on shallow merge as intended.
- [x] Audit chain: `member_changes` rows carry the merged blob per column. Tested via `psql` against dev DB.
- [x] Edit→Save regression on Identity/Status/Forms tabs: full-dict POSTs round-trip correctly, no key loss.
- [ ] Verify on staging once available.

## Out of scope (follow-ups)

- The Onboard tab's `activateMember()` forms branch still does a client-side fetch-then-merge. It's harmless under server merge (sending a full dict to a merger yields the same dict), but it's now redundant. Will simplify in a follow-up to keep this PR narrowly scoped to the bug fix.
- Member portal `member_update_profile` and ST2DH `update_membership` similarly do client-side fetch-merges that are now redundant. Same follow-up.
- Project CLAUDE.md gotcha for "Forms POST replaces the JSONB blob" needs to be inverted; doing locally and will land alongside the related work on `new-member-onboard-flow`.

## Schema deployment

Trigger unchanged. No `pg/sql/` SQL migration. Deploys with a DHService rebuild only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)