### PR TITLE
Member portal landing: add Reactivate card linking to Stripe payment

### DIFF
--- a/code/DHMemberPortal/static/css/portal.css
+++ b/code/DHMemberPortal/static/css/portal.css
@@ -729,6 +729,18 @@ body {
     --bs-btn-hover-border-color: #b91c1c;
 }
 
+.btn-ps1-red {
+    --bs-btn-color: #fff;
+    --bs-btn-bg: #d11242;
+    --bs-btn-border-color: #d11242;
+    --bs-btn-hover-color: #fff;
+    --bs-btn-hover-bg: #a80e35;
+    --bs-btn-hover-border-color: #a80e35;
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: #a80e35;
+    --bs-btn-active-border-color: #a80e35;
+}
+
 /* Responsive social grid */
 @media (max-width: 575.98px) {
     .social-grid {

--- a/code/DHMemberPortal/templates/landing.html
+++ b/code/DHMemberPortal/templates/landing.html
@@ -2,7 +2,7 @@
 {% block title %}Member Portal - Pumping Station: One{% endblock %}
 {% block page_title %}Member Portal{% endblock %}
 {% block content %}
-            <div class="col-sm-6 col-lg-5">
+            <div class="col-md-6 col-lg-4">
                 <div class="card h-100">
                     <div class="card-body d-flex flex-column">
                         <h2 class="card-title">Already a Member?</h2>
@@ -12,12 +12,22 @@
                 </div>
             </div>
 
-            <div class="col-sm-6 col-lg-5">
+            <div class="col-md-6 col-lg-4">
                 <div class="card h-100">
                     <div class="card-body d-flex flex-column">
                         <h2 class="card-title">New to Pumping Station: One?</h2>
                         <p class="card-text text-muted flex-grow-1">Join our community and start your membership journey.</p>
                         <a href="{{ url_for('signup_start') }}" class="btn btn-secondary w-100">Sign Up</a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 col-lg-4">
+                <div class="card h-100">
+                    <div class="card-body d-flex flex-column">
+                        <h2 class="card-title">Coming Back?</h2>
+                        <p class="card-text text-muted flex-grow-1">Reactivate your lapsed membership and pick up where you left off.</p>
+                        <a href="{{ url_for('signup_payment') }}" class="btn btn-ps1-red w-100">Reactivate</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Adds a third card ("Coming Back?") to the member portal landing page for inactive members to reactivate, linking to the existing `/signup/payment` Stripe pricing table route.
- Resizes the row to `col-md-6 col-lg-4` so three cards fit on desktop and stack/wrap cleanly on tablet/mobile.
- Adds a `.btn-ps1-red` button variant using the logo red `#d11242`.

## Test plan
- [x] Three cards render side-by-side on desktop (1280×800), 2-up + centered third on tablet (768), single-column on mobile (375). Verified via Chrome DevTools MCP at https://ps1-member.mime.starset.net/.
- [x] Reactivate button click navigates to `/signup/payment` and the Stripe pricing table iframe loads (`js.stripe.com/v3/pricing-table.js` 200).
- [x] Log In and Sign Up buttons unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)