### PR TITLE
Member portal dashboard: replace Meetup social link with GitHub

### DIFF
--- a/code/DHMemberPortal/static/css/portal.css
+++ b/code/DHMemberPortal/static/css/portal.css
@@ -778,10 +778,10 @@ i.ic-help       { color: #2563eb !important; } /* Blue-600 */
 i.ic-blog       { color: #21759B !important; } /* WordPress brand */
 i.ic-bluesky    { color: #0085ff !important; } /* Bluesky brand */
 i.ic-facebook   { color: #1877F2 !important; } /* Facebook brand */
+i.ic-github     { color: #181717 !important; } /* GitHub brand */
 i.ic-instagram  { color: #E4405F !important; } /* Instagram brand */
 i.ic-linkedin   { color: #0A66C2 !important; } /* LinkedIn brand */
 i.ic-mastodon   { color: #6364FF !important; } /* Mastodon brand */
-i.ic-meetup     { color: #ED1C40 !important; } /* Meetup brand */
 i.ic-threads    { color: #EE1D52 !important; } /* Threads pink-red */
 i.ic-tiktok     { color: #69C9D0 !important; } /* TikTok cyan */
 i.ic-x          { color: #000000 !important; } /* X brand */

--- a/code/DHMemberPortal/templates/member_dashboard.html
+++ b/code/DHMemberPortal/templates/member_dashboard.html
@@ -71,10 +71,10 @@
                     <li><a href="https://pumpingstationone.org/blog" class="menu-item" target="_blank" rel="noopener noreferrer" title="Blog"><i class="fa-solid fa-newspaper ic-blog"></i></a></li>
                     <li><a href="https://bsky.app/profile/pumpingstationone.bsky.social" class="menu-item" target="_blank" rel="noopener noreferrer" title="Bluesky"><i class="fa-brands fa-bluesky ic-bluesky"></i></a></li>
                     <li><a href="https://www.facebook.com/PumpingStationOne" class="menu-item" target="_blank" rel="noopener noreferrer" title="Facebook"><i class="fa-brands fa-facebook ic-facebook"></i></a></li>
+                    <li><a href="https://github.com/pumpingstationone" class="menu-item" target="_blank" rel="noopener noreferrer" title="GitHub"><i class="fa-brands fa-github ic-github"></i></a></li>
                     <li><a href="https://www.instagram.com/pumpingstationone/" class="menu-item" target="_blank" rel="noopener noreferrer" title="Instagram"><i class="fa-brands fa-instagram ic-instagram"></i></a></li>
                     <li><a href="https://www.linkedin.com/company/pumping-station-one/" class="menu-item" target="_blank" rel="noopener noreferrer" title="LinkedIn"><i class="fa-brands fa-linkedin ic-linkedin"></i></a></li>
                     <li><a href="https://masto.hackers.town/@pumpingstationone" class="menu-item" target="_blank" rel="noopener noreferrer" title="Mastodon"><i class="fa-brands fa-mastodon ic-mastodon"></i></a></li>
-                    <li><a href="https://www.meetup.com/pumping-station-one/" class="menu-item" target="_blank" rel="noopener noreferrer" title="Meetup"><i class="fa-brands fa-meetup ic-meetup"></i></a></li>
                     <li><a href="https://www.threads.com/@pumpingstationone" class="menu-item" target="_blank" rel="noopener noreferrer" title="Threads"><i class="fa-brands fa-threads ic-threads"></i></a></li>
                     <li><a href="https://www.tiktok.com/@pumpingstationone" class="menu-item" target="_blank" rel="noopener noreferrer" title="TikTok"><i class="fa-brands fa-tiktok ic-tiktok"></i></a></li>
                     <li><a href="https://x.com/PumpingStation1" class="menu-item" target="_blank" rel="noopener noreferrer" title="X"><i class="fa-brands fa-x-twitter ic-x"></i></a></li>


### PR DESCRIPTION
## Summary
- Replaces the Meetup social-media link on the member dashboard with `https://github.com/pumpingstationone`, repositioned to keep the row alphabetical.
- Renames the brand-color CSS class accordingly (`ic-meetup` #ED1C40 → `ic-github` #181717).

## Test plan
- [x] Verified via chrome-devtools at `https://ps1-member.mime.starset.net/dashboard`: GitHub icon present, no Meetup icon, `title="GitHub"`, `href="https://github.com/pumpingstationone"`, computed color `rgb(24, 23, 23)`.
- [x] Spot-checked rendering on bubblegum/dark/midnight themes. Note: the GitHub brand black blends into dark/midnight backgrounds — same caveat that already exists for `ic-x` (#000000), left consistent here. Easy follow-up to swap to `#6e7681` if cross-theme contrast is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)