### PR TITLE
Admin portal: Systems → API Clients tab for managing OAuth2 credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Each portal and external service authenticates to DHService using OAuth2 client 
 
 Set `api_base_url` to `http://gateway/dh/service` (the internal nginx gateway route) for services on the Docker bridge network, or `http://localhost/dh/service` for services using host networking.
 
+**Provisioning additional API clients:** after the initial bootstrap clients above are configured, all subsequent OAuth2 client credentials should be provisioned through **Admin Portal → Systems → API Clients** (permission `systems.api_clients` required). The admin UI generates the secret server-side, displays the plaintext exactly once, and writes the bcrypt hash to `oauth2_users`. `tools/generate_secret.sh` is retained as a fallback for the initial bootstrap-from-empty-DB scenario only.
+
 ### Step 4: Configure Azure B2C Authentication
 
 Both portals require Azure B2C for user authentication. Fill in the `[b2c]` section in each portal's `config.ini`:

--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -1657,7 +1657,8 @@ def api_list_api_clients():
         access_token = dhservices.get_access_token(
             dhservices.DH_CLIENT_ID, dhservices.DH_CLIENT_SECRET,
         )
-        return dhservices.list_api_clients(access_token)
+        response = dhservices.list_api_clients(access_token)
+        return _proxy_dhservice_response(response)
     except Exception as e:
         logger.error(f"Error listing api_clients: {e}")
         return {"error": str(e)}, 500
@@ -1670,7 +1671,8 @@ def api_get_api_client(client_id):
         access_token = dhservices.get_access_token(
             dhservices.DH_CLIENT_ID, dhservices.DH_CLIENT_SECRET,
         )
-        return dhservices.get_api_client(access_token, client_id)
+        response = dhservices.get_api_client(access_token, client_id)
+        return _proxy_dhservice_response(response)
     except Exception as e:
         logger.error(f"Error fetching api_client {client_id}: {e}")
         return {"error": str(e)}, 500

--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -64,6 +64,42 @@ FIELD_VALIDATORS = {
     "id_check_by": (r'^[1-9]\d*$', 10, "Onboarder must be a valid member"),
 }
 
+###############################################################################
+# API client validation
+###############################################################################
+# Mirrors the Pydantic regex on ApiClientCreateIn in code/DHService/models.py.
+# Defense-in-depth — DHService re-validates, but failing here returns a 400
+# with a friendlier message than FastAPI's auto-generated 422.
+
+_API_CLIENT_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9_-]*[a-z0-9]$')
+
+
+def validate_api_client_name(value):
+    """Returns (ok: bool, normalized_or_error: str)."""
+    if not isinstance(value, str):
+        return False, "client_name must be a string"
+    name = value.strip()
+    if not (3 <= len(name) <= 64):
+        return False, "client_name must be 3-64 characters"
+    if not _API_CLIENT_NAME_RE.match(name):
+        return False, (
+            "client_name may contain only lowercase letters, digits, dashes, "
+            "and underscores; must start and end with a letter or digit"
+        )
+    return True, name
+
+
+def validate_api_client_description(value):
+    """Returns (ok: bool, normalized_or_error: str)."""
+    if value is None:
+        return True, None
+    if not isinstance(value, str):
+        return False, "client_description must be a string"
+    desc = value.strip()
+    if len(desc) > 512:
+        return False, "client_description must be 512 characters or fewer"
+    return True, (desc or None)
+
 ID_CHECK_ACTIVATION_PAST_DAYS = 7
 ID_CHECK_ACTIVATION_FUTURE_DAYS = 1  # Allows up to 24h of clock skew
 
@@ -1580,4 +1616,152 @@ def api_remove_role():
         return dhservices.remove_role_from_member(access_token, data["member_id"])
     except Exception as e:
         logger.error(f"Error removing role: {e}")
+        return {"error": str(e)}, 500
+
+
+###############################################################################
+# Admin API routes (API client management)
+###############################################################################
+
+def _acting_admin(access_token: str) -> tuple[str | None, int | None]:
+    """Resolve the current admin's email + member_id for audit logging."""
+    user = session.get("user") or {}
+    email = user.get("email") or user.get("preferred_username")
+    member_id = None
+    if email:
+        try:
+            data = dhservices.get_member_id(access_token, email) or {}
+            member_id = data.get("member_id")
+        except Exception as e:
+            logger.error(f"_acting_admin: failed to resolve member_id for {email}: {e}")
+    return email, member_id
+
+
+def _proxy_dhservice_response(response):
+    """Pass a DHService response (success or 4xx) through to the browser, preserving
+    the status code so the UI can branch on 409 vs 400 vs 422."""
+    if response.status_code >= 500:
+        logger.error(f"DHService returned {response.status_code}: {response.text}")
+        return {"error": "Upstream service error"}, 502
+    try:
+        body = response.json()
+    except ValueError:
+        body = {"error": response.text or "Unknown error"}
+    return body, response.status_code
+
+
+@app.route("/api/admin/api_clients")
+@requires_view_permission("systems.api_clients")
+def api_list_api_clients():
+    try:
+        access_token = dhservices.get_access_token(
+            dhservices.DH_CLIENT_ID, dhservices.DH_CLIENT_SECRET,
+        )
+        return dhservices.list_api_clients(access_token)
+    except Exception as e:
+        logger.error(f"Error listing api_clients: {e}")
+        return {"error": str(e)}, 500
+
+
+@app.route("/api/admin/api_clients/<int:client_id>")
+@requires_view_permission("systems.api_clients")
+def api_get_api_client(client_id):
+    try:
+        access_token = dhservices.get_access_token(
+            dhservices.DH_CLIENT_ID, dhservices.DH_CLIENT_SECRET,
+        )
+        return dhservices.get_api_client(access_token, client_id)
+    except Exception as e:
+        logger.error(f"Error fetching api_client {client_id}: {e}")
+        return {"error": str(e)}, 500
+
+
+@app.route("/api/admin/api_clients", methods=["POST"])
+@requires_change_permission("systems.api_clients")
+def api_create_api_client():
+    data = request.get_json() or {}
+    ok_name, name_or_err = validate_api_client_name(data.get("client_name", ""))
+    if not ok_name:
+        return {"error": name_or_err}, 400
+    ok_desc, desc_or_err = validate_api_client_description(data.get("client_description"))
+    if not ok_desc:
+        return {"error": desc_or_err}, 400
+    try:
+        access_token = dhservices.get_access_token(
+            dhservices.DH_CLIENT_ID, dhservices.DH_CLIENT_SECRET,
+        )
+        admin_email, admin_member_id = _acting_admin(access_token)
+        response = dhservices.create_api_client(
+            access_token, name_or_err, desc_or_err, admin_member_id,
+        )
+        body, status = _proxy_dhservice_response(response)
+        if status == 200 and isinstance(body, dict) and body.get("id"):
+            logger.info(
+                "API client created via admin portal: id=%s name=%s by_admin=%s member_id=%s",
+                body.get("id"), name_or_err, admin_email, admin_member_id,
+            )
+        return body, status
+    except Exception as e:
+        logger.error(f"Error creating api_client: {e}")
+        return {"error": str(e)}, 500
+
+
+@app.route("/api/admin/api_clients/<int:client_id>/rotate", methods=["POST"])
+@requires_change_permission("systems.api_clients")
+def api_rotate_api_client(client_id):
+    try:
+        access_token = dhservices.get_access_token(
+            dhservices.DH_CLIENT_ID, dhservices.DH_CLIENT_SECRET,
+        )
+        admin_email, admin_member_id = _acting_admin(access_token)
+        response = dhservices.rotate_api_client(access_token, client_id)
+        body, status = _proxy_dhservice_response(response)
+        if status == 200 and isinstance(body, dict) and body.get("id"):
+            logger.info(
+                "API client rotated via admin portal: id=%s name=%s by_admin=%s member_id=%s",
+                body.get("id"), body.get("client_name"), admin_email, admin_member_id,
+            )
+        return body, status
+    except Exception as e:
+        logger.error(f"Error rotating api_client {client_id}: {e}")
+        return {"error": str(e)}, 500
+
+
+@app.route("/api/admin/api_clients/<int:client_id>", methods=["PATCH"])
+@requires_change_permission("systems.api_clients")
+def api_patch_api_client(client_id):
+    data = request.get_json() or {}
+    allowed = {"disabled", "client_description"}
+    unknown = set(data.keys()) - allowed
+    if unknown:
+        return {"error": f"unsupported field(s): {sorted(unknown)}"}, 400
+    disabled = data.get("disabled")
+    if disabled is not None and not isinstance(disabled, bool):
+        return {"error": "disabled must be a boolean"}, 400
+    description = data.get("client_description")
+    if "client_description" in data:
+        ok_desc, desc_or_err = validate_api_client_description(description)
+        if not ok_desc:
+            return {"error": desc_or_err}, 400
+        description = desc_or_err
+    try:
+        access_token = dhservices.get_access_token(
+            dhservices.DH_CLIENT_ID, dhservices.DH_CLIENT_SECRET,
+        )
+        admin_email, admin_member_id = _acting_admin(access_token)
+        response = dhservices.patch_api_client(
+            access_token, client_id,
+            disabled=disabled,
+            client_description=description if "client_description" in data else None,
+        )
+        body, status = _proxy_dhservice_response(response)
+        if status == 200 and isinstance(body, dict) and body.get("id"):
+            logger.info(
+                "API client patched via admin portal: id=%s name=%s disabled=%s desc_changed=%s by_admin=%s member_id=%s",
+                body.get("id"), body.get("client_name"), disabled,
+                "client_description" in data, admin_email, admin_member_id,
+            )
+        return body, status
+    except Exception as e:
+        logger.error(f"Error patching api_client {client_id}: {e}")
         return {"error": str(e)}, 500

--- a/code/DHAdminPortal/dhservices.py
+++ b/code/DHAdminPortal/dhservices.py
@@ -382,6 +382,73 @@ def remove_role_from_member(access_token: str, member_id: int):
     return response.json()
 
 ###############################################################################
+# Admin endpoints (API client management)
+###############################################################################
+# These wrappers intentionally do NOT call raise_for_status() on 4xx — we want
+# the Flask route to surface 400/404/409/422 detail back to the UI verbatim so
+# the create modal can show "client_name already exists" inline.
+
+def _api_clients_url(suffix: str = "") -> str:
+    return f"{DH_API_BASE_URL}/v1/admin/api_clients{suffix}"
+
+
+def list_api_clients(access_token: str):
+    headers = {"Authorization": f"Bearer {access_token}"}
+    response = requests.get(_api_clients_url("/"), headers=headers, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_api_client(access_token: str, client_id: int):
+    headers = {"Authorization": f"Bearer {access_token}"}
+    response = requests.get(_api_clients_url(f"/{client_id}"), headers=headers, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def create_api_client(
+    access_token: str,
+    client_name: str,
+    client_description: str | None,
+    created_by_member_id: int | None,
+):
+    headers = {"Authorization": f"Bearer {access_token}"}
+    body = {
+        "client_name": client_name,
+        "client_description": client_description,
+        "created_by_member_id": created_by_member_id,
+    }
+    response = requests.post(_api_clients_url("/"), headers=headers, json=body, timeout=10)
+    return response
+
+
+def rotate_api_client(access_token: str, client_id: int):
+    headers = {"Authorization": f"Bearer {access_token}"}
+    response = requests.post(
+        _api_clients_url(f"/{client_id}/rotate"), headers=headers, timeout=10,
+    )
+    return response
+
+
+def patch_api_client(
+    access_token: str,
+    client_id: int,
+    disabled: bool | None = None,
+    client_description: str | None = None,
+):
+    headers = {"Authorization": f"Bearer {access_token}"}
+    body: dict = {}
+    if disabled is not None:
+        body["disabled"] = disabled
+    if client_description is not None:
+        body["client_description"] = client_description
+    response = requests.patch(
+        _api_clients_url(f"/{client_id}"), headers=headers, json=body, timeout=10,
+    )
+    return response
+
+
+###############################################################################
 # Contacts endpoints
 # These endpoints manage contacts that are not members (i.e. no member ID)
 ###############################################################################

--- a/code/DHAdminPortal/dhservices.py
+++ b/code/DHAdminPortal/dhservices.py
@@ -395,15 +395,13 @@ def _api_clients_url(suffix: str = "") -> str:
 def list_api_clients(access_token: str):
     headers = {"Authorization": f"Bearer {access_token}"}
     response = requests.get(_api_clients_url("/"), headers=headers, timeout=10)
-    response.raise_for_status()
-    return response.json()
+    return response
 
 
 def get_api_client(access_token: str, client_id: int):
     headers = {"Authorization": f"Bearer {access_token}"}
     response = requests.get(_api_clients_url(f"/{client_id}"), headers=headers, timeout=10)
-    response.raise_for_status()
-    return response.json()
+    return response
 
 
 def create_api_client(

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -2072,6 +2072,12 @@ body.sidebar-resizing .details-sidebar {
     border-color: #3f3f46;
 }
 
+/* Bootstrap's .form-text defaults to near-black which disappears against the
+   dark modal body — restore a muted-but-visible variant of the theme text. */
+[data-theme="dark"] .form-text {
+    color: rgba(228, 228, 231, 0.65);
+}
+
 [data-theme="dark"] .modal-footer {
     border-color: #3f3f46;
 }
@@ -2665,6 +2671,10 @@ body.sidebar-resizing .details-sidebar {
 
 [data-theme="midnight"] .modal-header {
     border-color: #243356;
+}
+
+[data-theme="midnight"] .form-text {
+    color: rgba(200, 214, 229, 0.65);
 }
 
 [data-theme="midnight"] .modal-footer {
@@ -3383,6 +3393,19 @@ body.sidebar-resizing .details-sidebar {
 
 [data-theme="hacker"] .modal-footer {
     border-color: #1a3a1a;
+}
+
+[data-theme="hacker"] .form-text {
+    color: rgba(0, 255, 65, 0.7);
+}
+
+/* The secret-reveal modal uses bg-warning-subtle (light yellow) on its header.
+   In dark themes the header heading inherits the theme's light text color,
+   producing light-on-light. Force dark amber so the "Copy this secret now"
+   title is readable in every theme — light themes already had dark text. */
+.modal-header.bg-warning-subtle,
+.modal-header.bg-warning-subtle .modal-title {
+    color: #664d03;
 }
 
 [data-theme="hacker"] .btn-close {

--- a/code/DHAdminPortal/templates/base.html
+++ b/code/DHAdminPortal/templates/base.html
@@ -86,6 +86,7 @@
                         <ul class="dropdown-menu" aria-labelledby="systemsDropdown">
                             <li><a class="dropdown-item" id="nav-roles" href="#" onclick="showSection('roles'); return false;">Roles</a></li>
                             <li><a class="dropdown-item" id="nav-assign-roles" href="#" onclick="showSection('assignRoles'); return false;">Assign Roles</a></li>
+                            <li><a class="dropdown-item" id="nav-api-clients" href="#" onclick="showSection('apiClients'); return false;">API Clients</a></li>
                         </ul>
                     </li>
                 </ul>

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -557,6 +557,121 @@
     </div>
 </div>
 
+<!-- ========================================================================
+     API Clients section (Systems → API Clients)
+     ======================================================================== -->
+<div id="apiClientsSection" style="display:none;">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="mb-0">API Clients</h3>
+        <button class="btn btn-primary" id="apiClientsCreateBtn" onclick="openApiClientCreateModal()">
+            <i class="fa-solid fa-plus"></i> New API Client
+        </button>
+    </div>
+    <div class="text-muted small mb-3">
+        OAuth2 client credentials for applications that need to access the Deep Harbor API.
+        Plaintext secrets are shown <strong>once</strong> on creation or rotation and cannot be retrieved later.
+    </div>
+    <div id="apiClientsLoading" class="text-center py-3" style="display:none;">
+        <div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div>
+    </div>
+    <div id="apiClientsContent"></div>
+</div>
+
+<!-- Create / Edit Description modal -->
+<div class="modal fade" id="apiClientModal" tabindex="-1" aria-labelledby="apiClientModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="apiClientForm" novalidate>
+                <div class="modal-header">
+                    <h5 class="modal-title" id="apiClientModalLabel">New API Client</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <!-- Section: Basics -->
+                    <div class="mb-3">
+                        <label for="apiClientNameInput" class="form-label">Client name</label>
+                        <input type="text" class="form-control" id="apiClientNameInput" name="client_name"
+                               required minlength="3" maxlength="64"
+                               pattern="^[a-z0-9][a-z0-9_\-]{1,62}[a-z0-9]$"
+                               autocomplete="off" autocapitalize="off" spellcheck="false">
+                        <div class="form-text">
+                            Lowercase letters, digits, dashes, and underscores. 3–64 characters.
+                            Must start and end with a letter or digit.
+                        </div>
+                        <div class="invalid-feedback" id="apiClientNameError"></div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="apiClientDescriptionInput" class="form-label">Description <span class="text-muted">(optional)</span></label>
+                        <textarea class="form-control" id="apiClientDescriptionInput" name="client_description"
+                                  rows="2" maxlength="512"></textarea>
+                    </div>
+                    <!-- TODO (goal #2): a "Scopes" section drops in here when per-client scopes ship. -->
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary" id="apiClientSubmitBtn">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- One-time secret reveal modal -->
+<div class="modal fade" id="apiClientSecretRevealModal" tabindex="-1" data-bs-backdrop="static" data-bs-keyboard="false" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header bg-warning-subtle">
+                <h5 class="modal-title"><i class="fa-solid fa-triangle-exclamation"></i> Copy this secret now</h5>
+            </div>
+            <div class="modal-body">
+                <div class="mb-2">
+                    The plaintext client secret for <code id="apiClientSecretRevealName"></code> is shown below.
+                    <strong>This is the only time it will ever be displayed.</strong> If you lose it, you must rotate the secret.
+                </div>
+                <div class="input-group mb-3">
+                    <input type="text" class="form-control font-monospace" id="apiClientSecretRevealField" readonly>
+                    <button class="btn btn-outline-secondary" type="button" onclick="copyApiClientSecret()">
+                        <i class="fa-regular fa-copy"></i> Copy
+                    </button>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="apiClientSecretRevealAck">
+                    <label class="form-check-label" for="apiClientSecretRevealAck">
+                        I have copied this secret to a safe location.
+                    </label>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" id="apiClientSecretRevealCloseBtn"
+                        data-bs-dismiss="modal" disabled>Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Reusable "type your email to confirm" modal -->
+<div class="modal fade" id="confirmEmailModal" tabindex="-1" data-bs-backdrop="static" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Confirm action</h5>
+                <button type="button" class="btn-close" id="confirmEmailCancelX" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-2">You're about to: <strong id="confirmEmailAction"></strong></div>
+                <div class="small text-muted mb-2">
+                    To confirm, type your email address (<code id="confirmEmailExpected"></code>) below.
+                </div>
+                <input type="email" class="form-control" id="confirmEmailInput" autocomplete="off">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" id="confirmEmailSubmitBtn" disabled>Confirm</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Role Selection Popup (shared for new assign + edit) -->
 <div class="modal fade" id="roleSelectModal" tabindex="-1" aria-labelledby="roleSelectModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-sm">
@@ -588,6 +703,13 @@ const loggedInUserName = {{ (
     or user.get('email')
     or 'Logged in user'
 )|trim|tojson }} + ' via Admin Portal';
+
+// Admin's email for "type your email to confirm" gating. Case-insensitive compare.
+const adminEmail = {{ (
+    user.get('email')
+    or user.get('preferred_username')
+    or ''
+)|tojson }};
 
 // Hint toast when clicking a readonly/disabled field that could be edited
 document.addEventListener('click', function(e) {
@@ -3095,12 +3217,13 @@ document.getElementById('assignRoleMemberSearch').addEventListener('keypress', f
 // Section navigation
 // ============================================================================
 
-const SECTIONS = ['member', 'accessLogs', 'roles', 'assignRoles'];
+const SECTIONS = ['member', 'accessLogs', 'roles', 'assignRoles', 'apiClients'];
 const SECTION_EL_IDS = {
     member: 'memberSection',
     accessLogs: 'accessLogsSection',
     roles: 'rolesSection',
     assignRoles: 'assignRolesSection',
+    apiClients: 'apiClientsSection',
 };
 
 let accessLogsAutoRefreshTimer = null;
@@ -3111,6 +3234,7 @@ const SECTION_PERM_MAP = {
     accessLogs:  'space.access_logs',
     roles:       'systems.roles',
     assignRoles: 'systems.assign_roles',
+    apiClients:  'systems.api_clients',
 };
 
 function showSection(name) {
@@ -3147,6 +3271,8 @@ function showSection(name) {
         loadRoles();
     } else if (name === 'assignRoles') {
         initAssignRoles();
+    } else if (name === 'apiClients') {
+        loadApiClients();
     }
 }
 
@@ -3160,18 +3286,21 @@ function filterNavbarByPermissions() {
     const navAccessLogs  = document.getElementById('nav-access-logs');
     const navRoles       = document.getElementById('nav-roles');
     const navAssignRoles = document.getElementById('nav-assign-roles');
+    const navApiClients  = document.getElementById('nav-api-clients');
 
     const canAccessLogs  = canViewTab('space.access_logs',     permissions);
     const canRoles       = canViewTab('systems.roles',         permissions);
     const canAssignRoles = canViewTab('systems.assign_roles',  permissions);
+    const canApiClients  = canViewTab('systems.api_clients',   permissions);
 
     if (navAccessLogs)  navAccessLogs.closest('li').style.display  = canAccessLogs  ? '' : 'none';
     if (navRoles)       navRoles.closest('li').style.display        = canRoles       ? '' : 'none';
     if (navAssignRoles) navAssignRoles.closest('li').style.display  = canAssignRoles ? '' : 'none';
+    if (navApiClients)  navApiClients.closest('li').style.display   = canApiClients  ? '' : 'none';
 
     // Hide parent dropdown if all its children are hidden
-    if (spaceNavItem)   spaceNavItem.style.display   = canAccessLogs            ? '' : 'none';
-    if (systemsNavItem) systemsNavItem.style.display  = (canRoles || canAssignRoles) ? '' : 'none';
+    if (spaceNavItem)   spaceNavItem.style.display   = canAccessLogs                                ? '' : 'none';
+    if (systemsNavItem) systemsNavItem.style.display  = (canRoles || canAssignRoles || canApiClients) ? '' : 'none';
 }
 
 // ============================================================================
@@ -3288,6 +3417,7 @@ const PERMISSION_SECTIONS = [
     { area: 'Space',   key: 'space.access_logs',     changeAllowed: false },
     { area: 'Systems', key: 'systems.roles',         changeAllowed: true  },
     { area: 'Systems', key: 'systems.assign_roles',  changeAllowed: true  },
+    { area: 'Systems', key: 'systems.api_clients',   changeAllowed: true  },
 ];
 let rolesCache = [];
 let roleModalObj = null;
@@ -3588,6 +3718,345 @@ function searchAssignRoleMembers() {
             document.getElementById('assignRoleMemberResults').style.display = '';
         })
         .catch(err => alert('Search error: ' + err));
+}
+
+// ============================================================================
+// API Clients (Systems → API Clients)
+// ============================================================================
+
+let apiClientsCache = [];
+let apiClientModalObj = null;
+let apiClientSecretModalObj = null;
+let confirmEmailModalObj = null;
+let _apiClientEditingId = null;  // null = create mode; integer = edit-description mode
+
+function _ensureApiClientModals() {
+    if (!apiClientModalObj) apiClientModalObj = new bootstrap.Modal(document.getElementById('apiClientModal'));
+    if (!apiClientSecretModalObj) apiClientSecretModalObj = new bootstrap.Modal(document.getElementById('apiClientSecretRevealModal'));
+    if (!confirmEmailModalObj) confirmEmailModalObj = new bootstrap.Modal(document.getElementById('confirmEmailModal'));
+}
+
+function loadApiClients() {
+    document.getElementById('apiClientsLoading').style.display = '';
+    document.getElementById('apiClientsContent').innerHTML = '';
+    fetch('/api/admin/api_clients')
+        .then(r => r.json())
+        .then(data => {
+            document.getElementById('apiClientsLoading').style.display = 'none';
+            apiClientsCache = data.api_clients || [];
+            renderApiClientsTable(apiClientsCache);
+        })
+        .catch(err => {
+            document.getElementById('apiClientsLoading').style.display = 'none';
+            document.getElementById('apiClientsContent').innerHTML =
+                `<div class="alert alert-danger">Error loading API clients: ${escapeHtml(String(err))}</div>`;
+        });
+}
+
+function _fmtDate(value) {
+    if (!value) return '<span class="text-muted">—</span>';
+    try { return escapeHtml(new Date(value).toLocaleString()); }
+    catch { return escapeHtml(String(value)); }
+}
+
+function renderApiClientsTable(rows) {
+    const container = document.getElementById('apiClientsContent');
+    if (!rows.length) {
+        container.innerHTML = '<div class="alert alert-secondary text-center">No API clients yet. Click "New API Client" to create one.</div>';
+        return;
+    }
+    const body = rows.map(c => {
+        const pill = c.disabled
+            ? '<span class="badge bg-danger">Disabled</span>'
+            : '<span class="badge bg-success">Active</span>';
+        const toggleLabel = c.disabled ? 'Re-enable' : 'Disable';
+        const toggleClass = c.disabled ? 'btn-outline-success' : 'btn-outline-warning';
+        const createdBy = c.created_by_member_id
+            ? `<a href="#" onclick="loadMember(${c.created_by_member_id}); return false;">#${c.created_by_member_id}</a>`
+            : '<span class="text-muted">—</span>';
+        return `<tr>
+            <td>${c.id}</td>
+            <td><code>${escapeHtml(c.client_name)}</code></td>
+            <td>${escapeHtml(c.client_description || '')}</td>
+            <td>${pill}</td>
+            <td>${createdBy}</td>
+            <td class="small">${_fmtDate(c.date_added)}</td>
+            <td class="small">${_fmtDate(c.last_used_at)}</td>
+            <td class="small">${_fmtDate(c.rotated_at)}</td>
+            <td class="text-nowrap">
+                <button class="btn btn-sm btn-outline-secondary" onclick="openApiClientEditDescModal(${c.id})" title="Edit description">
+                    <i class="fa-regular fa-pen-to-square"></i>
+                </button>
+                <button class="btn btn-sm btn-outline-primary" onclick="rotateApiClient(${c.id})" title="Rotate secret">
+                    <i class="fa-solid fa-rotate"></i>
+                </button>
+                <button class="btn btn-sm ${toggleClass}" onclick="toggleApiClientDisabled(${c.id})" title="${toggleLabel}">
+                    <i class="fa-solid fa-${c.disabled ? 'play' : 'ban'}"></i>
+                </button>
+            </td>
+        </tr>`;
+    }).join('');
+    container.innerHTML = `
+        <div class="table-responsive">
+            <table class="table table-striped table-hover table-sm align-middle">
+                <thead class="sticky-top bg-white">
+                    <tr>
+                        <th>ID</th><th>Name</th><th>Description</th><th>Status</th>
+                        <th>Created by</th><th>Created</th><th>Last used</th><th>Rotated</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>${body}</tbody>
+            </table>
+        </div>
+        <div class="text-muted text-end small">${rows.length} client(s)</div>`;
+}
+
+function _getApiClientById(id) {
+    return apiClientsCache.find(c => c.id === id);
+}
+
+function _resetApiClientForm() {
+    document.getElementById('apiClientForm').reset();
+    const nameInput = document.getElementById('apiClientNameInput');
+    nameInput.classList.remove('is-invalid');
+    document.getElementById('apiClientNameError').textContent = '';
+}
+
+function openApiClientCreateModal() {
+    _ensureApiClientModals();
+    _apiClientEditingId = null;
+    _resetApiClientForm();
+    document.getElementById('apiClientModalLabel').textContent = 'New API Client';
+    document.getElementById('apiClientNameInput').readOnly = false;
+    document.getElementById('apiClientSubmitBtn').textContent = 'Create';
+    apiClientModalObj.show();
+}
+
+function openApiClientEditDescModal(id) {
+    _ensureApiClientModals();
+    const row = _getApiClientById(id);
+    if (!row) { alert('Client not found in cache; reload the page.'); return; }
+    _apiClientEditingId = id;
+    _resetApiClientForm();
+    document.getElementById('apiClientModalLabel').textContent = `Edit "${row.client_name}"`;
+    const nameInput = document.getElementById('apiClientNameInput');
+    nameInput.value = row.client_name;
+    nameInput.readOnly = true;  // name is immutable post-creation in this PR
+    document.getElementById('apiClientDescriptionInput').value = row.client_description || '';
+    document.getElementById('apiClientSubmitBtn').textContent = 'Save';
+    apiClientModalObj.show();
+}
+
+// Form submit handler — wires browser-validation feedback into the confirm-email gate.
+document.getElementById('apiClientForm').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const form = this;
+    const nameInput = document.getElementById('apiClientNameInput');
+    const errEl = document.getElementById('apiClientNameError');
+    nameInput.classList.remove('is-invalid');
+    errEl.textContent = '';
+
+    if (!form.checkValidity()) {
+        nameInput.classList.add('is-invalid');
+        errEl.textContent = 'Client name must be 3–64 chars, lowercase letters/digits/dashes/underscores, starting and ending with a letter or digit.';
+        return;
+    }
+
+    const name = nameInput.value.trim();
+    const desc = document.getElementById('apiClientDescriptionInput').value.trim() || null;
+
+    if (_apiClientEditingId === null) {
+        // Create. The form modal is hidden by withEmailConfirm; we re-show it
+        // on validation failure so the user can fix the name + retry.
+        withEmailConfirm(`Create API client "${name}"`, () => {
+            return fetch('/api/admin/api_clients', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
+                body: JSON.stringify({ client_name: name, client_description: desc }),
+            }).then(async resp => {
+                const body = await resp.json().catch(() => ({}));
+                if (resp.status === 409 || (resp.status === 400 && body.error)) {
+                    nameInput.classList.add('is-invalid');
+                    errEl.textContent = body.error || body.detail || 'Create failed.';
+                    apiClientModalObj.show();
+                    return;
+                }
+                if (!resp.ok) {
+                    alert('Create failed: ' + (body.error || body.detail || resp.statusText));
+                    apiClientModalObj.show();
+                    return;
+                }
+                _showApiClientSecret(body.client_name, body.plaintext_secret);
+                loadApiClients();
+            });
+        }, apiClientModalObj);
+    } else {
+        // Edit description
+        const id = _apiClientEditingId;
+        const row = _getApiClientById(id);
+        const oldDesc = row ? (row.client_description || null) : null;
+        if (oldDesc === desc) {
+            apiClientModalObj.hide();
+            return;
+        }
+        withEmailConfirm(`Edit description for "${name}"`, () => {
+            return fetch(`/api/admin/api_clients/${id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
+                body: JSON.stringify({ client_description: desc }),
+            }).then(async resp => {
+                const body = await resp.json().catch(() => ({}));
+                if (!resp.ok) {
+                    alert('Update failed: ' + (body.error || body.detail || resp.statusText));
+                    apiClientModalObj.show();
+                    return;
+                }
+                loadApiClients();
+            });
+        }, apiClientModalObj);
+    }
+});
+
+function rotateApiClient(id) {
+    _ensureApiClientModals();
+    const row = _getApiClientById(id);
+    if (!row) return;
+    withEmailConfirm(`Rotate secret for "${row.client_name}"`, () => {
+        return fetch(`/api/admin/api_clients/${id}/rotate`, {
+            method: 'POST',
+            headers: { 'X-CSRFToken': csrfToken },
+        }).then(async resp => {
+            const body = await resp.json().catch(() => ({}));
+            if (!resp.ok) {
+                alert('Rotate failed: ' + (body.error || body.detail || resp.statusText));
+                return;
+            }
+            _showApiClientSecret(body.client_name, body.plaintext_secret);
+            loadApiClients();
+        });
+    });
+}
+
+function toggleApiClientDisabled(id) {
+    _ensureApiClientModals();
+    const row = _getApiClientById(id);
+    if (!row) return;
+    const target = !row.disabled;
+    const label = target ? 'Disable' : 'Re-enable';
+    withEmailConfirm(`${label} API client "${row.client_name}"`, () => {
+        return fetch(`/api/admin/api_clients/${id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
+            body: JSON.stringify({ disabled: target }),
+        }).then(async resp => {
+            const body = await resp.json().catch(() => ({}));
+            if (!resp.ok) {
+                alert(`${label} failed: ` + (body.error || body.detail || resp.statusText));
+                return;
+            }
+            loadApiClients();
+        });
+    });
+}
+
+function _showApiClientSecret(name, plaintext) {
+    document.getElementById('apiClientSecretRevealName').textContent = name;
+    document.getElementById('apiClientSecretRevealField').value = plaintext;
+    const ack = document.getElementById('apiClientSecretRevealAck');
+    const closeBtn = document.getElementById('apiClientSecretRevealCloseBtn');
+    ack.checked = false;
+    closeBtn.disabled = true;
+    ack.onchange = () => { closeBtn.disabled = !ack.checked; };
+    apiClientSecretModalObj.show();
+}
+
+function copyApiClientSecret() {
+    const field = document.getElementById('apiClientSecretRevealField');
+    const text = field.value;
+    if (!text) return;
+    navigator.clipboard.writeText(text).then(() => {
+        // Reuse the existing dh-validation-toast
+        const toastEl = document.getElementById('dh-validation-toast');
+        if (toastEl) {
+            const msgEl = toastEl.querySelector('.toast-body');
+            if (msgEl) msgEl.textContent = 'Secret copied to clipboard';
+            const toast = bootstrap.Toast.getOrCreateInstance(toastEl);
+            toast.show();
+        }
+    }).catch(() => {
+        // Fallback: select the field so the user can manually copy
+        field.select();
+    });
+}
+
+// Reusable "type your email to confirm" gate.
+// actionLabel: human-readable description of the action.
+// onConfirm: function returning a Promise (or void). Called only when typed
+//   value (case-insensitive trim) matches the admin's session email.
+//   If onConfirm wants the previous modal to reappear (e.g. for a 409 with
+//   inline error), it should call replacingModal.show() itself.
+// replacingModal: an optional bootstrap.Modal instance to hide before the
+//   confirm dialog appears, and to re-show automatically if the user cancels.
+function withEmailConfirm(actionLabel, onConfirm, replacingModal = null) {
+    _ensureApiClientModals();
+    document.getElementById('confirmEmailAction').textContent = actionLabel;
+    document.getElementById('confirmEmailExpected').textContent = adminEmail || '(unknown)';
+    const input = document.getElementById('confirmEmailInput');
+    const submit = document.getElementById('confirmEmailSubmitBtn');
+    input.value = '';
+    submit.disabled = true;
+
+    const expected = (adminEmail || '').trim().toLowerCase();
+    const onInput = () => {
+        submit.disabled = !(expected && input.value.trim().toLowerCase() === expected);
+    };
+    input.addEventListener('input', onInput);
+
+    let confirmed = false;
+
+    const handler = () => {
+        confirmed = true;
+        submit.removeEventListener('click', handler);
+        input.removeEventListener('input', onInput);
+        confirmEmailModalObj.hide();
+        Promise.resolve(onConfirm()).catch(err => {
+            alert('Action failed: ' + err);
+            if (replacingModal) replacingModal.show();
+        });
+    };
+    submit.addEventListener('click', handler);
+
+    const modalEl = document.getElementById('confirmEmailModal');
+    const cleanup = () => {
+        submit.removeEventListener('click', handler);
+        input.removeEventListener('input', onInput);
+        modalEl.removeEventListener('hidden.bs.modal', cleanup);
+        if (!confirmed && replacingModal) {
+            replacingModal.show();
+        }
+    };
+    modalEl.addEventListener('hidden.bs.modal', cleanup);
+
+    const showConfirm = () => {
+        confirmEmailModalObj.show();
+        setTimeout(() => input.focus(), 200);
+    };
+
+    if (replacingModal) {
+        // Wait for the replacing modal's hide animation to finish before
+        // showing the confirm modal — otherwise Bootstrap's backdrop handling
+        // ends up out of sync and the page stays partially obscured.
+        const replacingEl = replacingModal._element;
+        const onHidden = () => {
+            replacingEl.removeEventListener('hidden.bs.modal', onHidden);
+            showConfirm();
+        };
+        replacingEl.addEventListener('hidden.bs.modal', onHidden);
+        replacingModal.hide();
+    } else {
+        showConfirm();
+    }
 }
 </script>
 

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -4019,11 +4019,10 @@ function withEmailConfirm(actionLabel, onConfirm, replacingModal = null) {
         confirmed = true;
         submit.removeEventListener('click', handler);
         input.removeEventListener('input', onInput);
+        // Just kick off the hide. onConfirm runs in cleanup (below) once the
+        // hide animation completes, so any modal opened by onConfirm (e.g. the
+        // secret reveal) doesn't stack on top of the still-fading confirm modal.
         confirmEmailModalObj.hide();
-        Promise.resolve(onConfirm()).catch(err => {
-            alert('Action failed: ' + err);
-            if (replacingModal) replacingModal.show();
-        });
     };
     submit.addEventListener('click', handler);
 
@@ -4032,7 +4031,12 @@ function withEmailConfirm(actionLabel, onConfirm, replacingModal = null) {
         submit.removeEventListener('click', handler);
         input.removeEventListener('input', onInput);
         modalEl.removeEventListener('hidden.bs.modal', cleanup);
-        if (!confirmed && replacingModal) {
+        if (confirmed) {
+            Promise.resolve(onConfirm()).catch(err => {
+                alert('Action failed: ' + err);
+                if (replacingModal) replacingModal.show();
+            });
+        } else if (replacingModal) {
             replacingModal.show();
         }
     };

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -3771,9 +3771,18 @@ function renderApiClientsTable(rows) {
             : '<span class="badge bg-success">Active</span>';
         const toggleLabel = c.disabled ? 'Re-enable' : 'Disable';
         const toggleClass = c.disabled ? 'btn-outline-success' : 'btn-outline-warning';
-        const createdBy = c.created_by_member_id
-            ? `<a href="#" onclick="loadMember(${c.created_by_member_id}); return false;">#${c.created_by_member_id}</a>`
-            : '<span class="text-muted">—</span>';
+        // "First Last (#id)" with the id linking to the member detail view.
+        // Falls back to just "#id" if the creator's identity is missing
+        // (member deleted, or pre-existing rows that have no creator).
+        let createdBy;
+        if (c.created_by_member_id) {
+            const name = [c.created_by_first_name, c.created_by_last_name]
+                .filter(Boolean).join(' ').trim();
+            const idLink = `<a href="#" onclick="loadMember(${c.created_by_member_id}); return false;">#${c.created_by_member_id}</a>`;
+            createdBy = name ? `${escapeHtml(name)} (${idLink})` : idLink;
+        } else {
+            createdBy = '<span class="text-muted">—</span>';
+        }
         return `<tr>
             <td>${c.id}</td>
             <td><code>${escapeHtml(c.client_name)}</code></td>

--- a/code/DHService/auth.py
+++ b/code/DHService/auth.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from config import config
 from models import Client
+import db
 from db import get_client_by_client_name
 
 from dhs_logging import logger
@@ -65,6 +66,7 @@ def authenticate_client(client_name: str, password: str):
         return False
     if not verify_password(password, client.hashed_password):
         return False
+    db.touch_last_used(client.client_name)
     return client
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None):

--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -154,19 +154,154 @@ def get_client_by_client_name(client_name: str) -> Client | None:
     with get_db_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """SELECT client_name, client_secret, client_description 
+                """SELECT id, client_name, client_secret, client_description, disabled
                    FROM oauth2_users WHERE client_name = %s""",
                 (client_name,),
             )
-            client = cur.fetchone()
-    if client is None:
+            row = cur.fetchone()
+    if row is None:
         return None
     return Client(
-        client_name=client[0],
-        description=client[2],
-        enabled=False,
-        hashed_password=client[1],
+        id=row[0],
+        client_name=row[1],
+        hashed_password=row[2],
+        description=row[3],
+        disabled=row[4],
     )
+
+
+###############################################################################
+# Oauth2 admin functions (API client management)
+###############################################################################
+
+def _row_to_api_client(row) -> dict:
+    return {
+        "id": row[0],
+        "client_name": row[1],
+        "client_description": row[2],
+        "disabled": row[3],
+        "date_added": row[4],
+        "created_by_member_id": row[5],
+        "last_used_at": row[6],
+        "rotated_at": row[7],
+    }
+
+
+_API_CLIENT_COLS = """
+    id, client_name, client_description, disabled,
+    date_added, created_by_member_id, last_used_at, rotated_at
+"""
+
+
+def list_api_clients() -> list[dict]:
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {_API_CLIENT_COLS} FROM oauth2_users ORDER BY client_name"
+            )
+            rows = cur.fetchall()
+    return [_row_to_api_client(r) for r in rows]
+
+
+def get_api_client(client_id: int) -> dict | None:
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {_API_CLIENT_COLS} FROM oauth2_users WHERE id = %s",
+                (client_id,),
+            )
+            row = cur.fetchone()
+    return _row_to_api_client(row) if row else None
+
+
+def create_api_client(
+    client_name: str,
+    client_secret_hash: str,
+    client_description: str | None,
+    created_by_member_id: int | None,
+) -> dict:
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO oauth2_users
+                       (client_name, client_secret, client_description, created_by_member_id)
+                       VALUES (%s, %s, %s, %s) RETURNING id""",
+                    (client_name, client_secret_hash, client_description, created_by_member_id),
+                )
+                new_id = cur.fetchone()[0]
+                conn.commit()
+        return {"id": new_id, "message": "OK"}
+    except psycopg2.errors.UniqueViolation:
+        logger.info(f"create_api_client rejected duplicate client_name: {client_name}")
+        return {"id": None, "message": "client_name already exists"}
+    except Exception as e:
+        logger.error(f"create_api_client failed for {client_name}: {e}")
+        return {"id": None, "message": f"create failed: {e}"}
+
+
+def update_api_client_secret(client_id: int, client_secret_hash: str) -> dict:
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """UPDATE oauth2_users
+                   SET client_secret = %s, rotated_at = NOW()
+                 WHERE id = %s""",
+                (client_secret_hash, client_id),
+            )
+            updated = cur.rowcount
+            conn.commit()
+    return {"id": client_id, "updated": updated}
+
+
+# Allowlist for patch_api_client — mirrors the FIELD_VALIDATORS allowlist pattern
+# used elsewhere in the codebase (CLAUDE.md: "always use the allowlist pattern
+# for SQL column interpolation").
+_API_CLIENT_PATCH_COLUMNS = {"disabled", "client_description"}
+
+
+def patch_api_client(
+    client_id: int,
+    disabled: bool | None,
+    client_description: str | None,
+) -> dict:
+    updates: dict[str, object] = {}
+    if disabled is not None:
+        updates["disabled"] = disabled
+    if client_description is not None:
+        updates["client_description"] = client_description
+    if not updates:
+        return {"id": client_id, "updated": 0}
+    for col in updates:
+        if col not in _API_CLIENT_PATCH_COLUMNS:
+            raise ValueError(f"column {col!r} is not patchable")
+    set_clause = ", ".join(f"{col} = %s" for col in updates)
+    params = list(updates.values()) + [client_id]
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"UPDATE oauth2_users SET {set_clause} WHERE id = %s",
+                params,
+            )
+            updated = cur.rowcount
+            conn.commit()
+    return {"id": client_id, "updated": updated}
+
+
+def touch_last_used(client_name: str) -> None:
+    """Best-effort UPDATE of last_used_at on /token success.
+    Must not raise — it sits in the hot path of authentication.
+    """
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE oauth2_users SET last_used_at = NOW() WHERE client_name = %s",
+                    (client_name,),
+                )
+                conn.commit()
+    except Exception as e:
+        logger.error(f"touch_last_used failed for {client_name}: {e}")
 
 ###############################################################################
 # Member Database Functions

--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -184,21 +184,27 @@ def _row_to_api_client(row) -> dict:
         "created_by_member_id": row[5],
         "last_used_at": row[6],
         "rotated_at": row[7],
+        "created_by_first_name": row[8],
+        "created_by_last_name": row[9],
     }
 
 
-_API_CLIENT_COLS = """
-    id, client_name, client_description, disabled,
-    date_added, created_by_member_id, last_used_at, rotated_at
+# LEFT JOIN against member so a deleted/missing creator still returns the row
+# with null name fields rather than dropping it from the listing.
+_API_CLIENT_SELECT = """
+    SELECT o.id, o.client_name, o.client_description, o.disabled,
+           o.date_added, o.created_by_member_id, o.last_used_at, o.rotated_at,
+           m.identity->>'first_name' AS created_by_first_name,
+           m.identity->>'last_name'  AS created_by_last_name
+      FROM oauth2_users o
+      LEFT JOIN member m ON m.id = o.created_by_member_id
 """
 
 
 def list_api_clients() -> list[dict]:
     with get_db_connection() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {_API_CLIENT_COLS} FROM oauth2_users ORDER BY client_name"
-            )
+            cur.execute(f"{_API_CLIENT_SELECT} ORDER BY o.client_name")
             rows = cur.fetchall()
     return [_row_to_api_client(r) for r in rows]
 
@@ -206,10 +212,7 @@ def list_api_clients() -> list[dict]:
 def get_api_client(client_id: int) -> dict | None:
     with get_db_connection() as conn:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {_API_CLIENT_COLS} FROM oauth2_users WHERE id = %s",
-                (client_id,),
-            )
+            cur.execute(f"{_API_CLIENT_SELECT} WHERE o.id = %s", (client_id,))
             row = cur.fetchone()
     return _row_to_api_client(row) if row else None
 

--- a/code/DHService/models.py
+++ b/code/DHService/models.py
@@ -41,6 +41,8 @@ class ApiClientOut(BaseModel):
     disabled: bool
     date_added: datetime | None = None
     created_by_member_id: int | None = None
+    created_by_first_name: str | None = None
+    created_by_last_name: str | None = None
     last_used_at: datetime | None = None
     rotated_at: datetime | None = None
 

--- a/code/DHService/models.py
+++ b/code/DHService/models.py
@@ -1,8 +1,63 @@
-from pydantic import BaseModel
+from datetime import datetime
+from typing import Annotated
 
-# This is for ouath2 clients
+from pydantic import BaseModel, Field, StringConstraints
+
+###############################################################################
+# Internal auth model (used by auth.py + db.get_client_by_client_name)
+###############################################################################
+
 class Client(BaseModel):
+    id: int | None = None
     client_name: str
     hashed_password: str
     description: str | None = None
+    disabled: bool = False
+
+
+###############################################################################
+# Admin API: API client management
+###############################################################################
+
+# client_name shape: lowercase letters, digits, dash, underscore.
+# Must start and end with [a-z0-9] (no leading/trailing dash or underscore).
+# Length 3-64. See plan section "Validation rules for client_name".
+ApiClientName = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=3,
+        max_length=64,
+        pattern=r"^[a-z0-9][a-z0-9_-]*[a-z0-9]$",
+    ),
+]
+
+
+class ApiClientOut(BaseModel):
+    """Metadata-only client representation. Never contains client_secret."""
+    id: int
+    client_name: str
+    client_description: str | None = None
+    disabled: bool
+    date_added: datetime | None = None
+    created_by_member_id: int | None = None
+    last_used_at: datetime | None = None
+    rotated_at: datetime | None = None
+
+
+class ApiClientCreateIn(BaseModel):
+    client_name: ApiClientName
+    client_description: str | None = Field(default=None, max_length=512)
+    created_by_member_id: int | None = None
+
+
+class ApiClientPatchIn(BaseModel):
     disabled: bool | None = None
+    client_description: str | None = Field(default=None, max_length=512)
+
+
+class ApiClientSecretOut(BaseModel):
+    """One-time response for create + rotate. Plaintext returned ONCE."""
+    id: int
+    client_name: str
+    plaintext_secret: str

--- a/code/DHService/v1.py
+++ b/code/DHService/v1.py
@@ -2,15 +2,19 @@
 # This file contains all the v1 services
 # *******************************************************************************
 
+import secrets
 from datetime import datetime
 from time import time
 from typing import Annotated
-from fastapi import Depends, Request, Header
+
+import bcrypt
+from fastapi import Depends, HTTPException, Request, Header
 
 from fastapiapp import app
 import auth
 from dhs_logging import logger
 import db
+from models import ApiClientCreateIn, ApiClientPatchIn
 
 # Type alias for authenticated client dependency
 AuthenticatedClient = Annotated[auth.Client, Depends(auth.get_current_active_client)]
@@ -426,3 +430,98 @@ async def remove_role_from_member(
     """Remove a member's role assignment."""
     data = await request.json()
     return db.remove_role_from_member(data["member_id"])
+
+###############################################################################
+# Admin endpoints (API client management)
+###############################################################################
+
+def _generate_client_secret() -> tuple[str, str]:
+    plaintext = secrets.token_urlsafe(32)
+    hashed = bcrypt.hashpw(plaintext.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    return plaintext, hashed
+
+
+@app.get("/v1/admin/api_clients/")
+async def list_api_clients(current_client: AuthenticatedClient):
+    """List all OAuth2 API clients (metadata only — never includes secrets)."""
+    return {"api_clients": db.list_api_clients()}
+
+
+@app.get("/v1/admin/api_clients/{client_id}")
+async def get_api_client(current_client: AuthenticatedClient, client_id: int):
+    """Get a single API client's metadata."""
+    row = db.get_api_client(client_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="API client not found")
+    return row
+
+
+@app.post("/v1/admin/api_clients/")
+async def create_api_client(
+    current_client: AuthenticatedClient,
+    body: ApiClientCreateIn,
+):
+    """Create a new API client. Returns plaintext secret ONCE."""
+    plaintext, hashed = _generate_client_secret()
+    result = db.create_api_client(
+        body.client_name,
+        hashed,
+        body.client_description,
+        body.created_by_member_id,
+    )
+    if result.get("id") is None:
+        msg = result.get("message") or "create failed"
+        if msg == "client_name already exists":
+            raise HTTPException(status_code=409, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
+    logger.info(
+        "API client created: id=%s name=%s by_member_id=%s acting_client=%s",
+        result["id"], body.client_name, body.created_by_member_id,
+        current_client.client_name,
+    )
+    return {
+        "id": result["id"],
+        "client_name": body.client_name,
+        "plaintext_secret": plaintext,
+    }
+
+
+@app.post("/v1/admin/api_clients/{client_id}/rotate")
+async def rotate_api_client(
+    current_client: AuthenticatedClient,
+    client_id: int,
+):
+    """Generate a new secret for an existing API client. Returns plaintext ONCE."""
+    existing = db.get_api_client(client_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="API client not found")
+    plaintext, hashed = _generate_client_secret()
+    db.update_api_client_secret(client_id, hashed)
+    logger.info(
+        "API client secret rotated: id=%s name=%s acting_client=%s",
+        client_id, existing["client_name"], current_client.client_name,
+    )
+    return {
+        "id": client_id,
+        "client_name": existing["client_name"],
+        "plaintext_secret": plaintext,
+    }
+
+
+@app.patch("/v1/admin/api_clients/{client_id}")
+async def patch_api_client(
+    current_client: AuthenticatedClient,
+    client_id: int,
+    body: ApiClientPatchIn,
+):
+    """Toggle `disabled` and/or update `client_description`."""
+    existing = db.get_api_client(client_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="API client not found")
+    db.patch_api_client(client_id, body.disabled, body.client_description)
+    logger.info(
+        "API client patched: id=%s name=%s disabled=%s desc_changed=%s acting_client=%s",
+        client_id, existing["client_name"], body.disabled,
+        body.client_description is not None, current_client.client_name,
+    )
+    return db.get_api_client(client_id)

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -187,20 +187,33 @@ json_build_object(
 FROM   member m;
 COMMENT ON VIEW v_member_info IS 'This view provides a structured JSON representation of member information, including identity, connections, forms, status, access, authorizations, and extras from the member table.';
 
-/* 
+/*
  * OAuth2 Clients table - this holds the client credentials
  * for any OAuth2 clients that need to access the API.
+ *
+ * Primary key is the surrogate `id` so that `client_name` can be renamed
+ * without losing referential history. `client_name` is still the value
+ * external services present at /token (alongside `client_secret`); it is
+ * NOT a secret but is constrained to a lowercase/digit/dash/underscore
+ * shape via Pydantic + Flask validators (see code/DHService/models.py
+ * ApiClientCreateIn and code/DHAdminPortal/app.py validate_api_client_name).
  */
-CREATE TABLE 
-    oauth2_users 
-    ( 
-                client_name        TEXT NOT NULL, 
-                client_secret      TEXT NOT NULL, 
-                date_added         TIMESTAMP(6) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, 
-                client_description TEXT, 
-                PRIMARY KEY (client_name) 
-    );
-COMMENT ON TABLE oauth2_users IS 'This table holds the OAuth2 client credentials for applications that need to access the Deep Harbor API.';
+CREATE TABLE IF NOT EXISTS oauth2_users (
+    id                   SERIAL PRIMARY KEY,
+    client_name          TEXT NOT NULL UNIQUE,
+    client_secret        TEXT NOT NULL,
+    client_description   TEXT,
+    disabled             BOOLEAN NOT NULL DEFAULT FALSE,
+    date_added           TIMESTAMP(6) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    created_by_member_id INT REFERENCES member(id) ON DELETE SET NULL NULL,
+    last_used_at         TIMESTAMPTZ NULL,
+    rotated_at           TIMESTAMPTZ NULL
+);
+COMMENT ON TABLE oauth2_users IS 'OAuth2 client credentials for applications that need to access the Deep Harbor API.';
+COMMENT ON COLUMN oauth2_users.disabled IS 'Soft-revoke flag; auth.get_current_active_client() rejects when TRUE.';
+COMMENT ON COLUMN oauth2_users.created_by_member_id IS 'Admin who provisioned this client via the admin portal.';
+COMMENT ON COLUMN oauth2_users.last_used_at IS 'Touched on successful /token exchange.';
+COMMENT ON COLUMN oauth2_users.rotated_at IS 'Touched on secret rotation.';
 
 /* HEY! Update these with real client secrets using the generate_secret.sh tool! */
 /* Our initial OAuth2 client for dev web services */


### PR DESCRIPTION
> There's a tab where the secrets are born,
> With a button you click when you've sworn:
> "I've **copied!**" - tick the box,
> Or you'll fumble the locks,
> 'Cause once shown, that key's never reborn.

## Summary

Replaces the "run `tools/generate_secret.sh` on the host, hand the plaintext over Discord, then `psql -c "INSERT INTO oauth2_users …"`" provisioning workflow with an admin-portal UI. Adds a new **Systems → API Clients** tab (permission `systems.api_clients`) that lets admins list, create, rotate, disable / re-enable, and edit-description for OAuth2 clients without leaving the browser. Plaintext secrets are shown exactly once on create + rotate; every mutating action goes through a "type your email to confirm" gate.

Also tightens the underlying `oauth2_users` table with the audit columns the code already half-expected — `disabled`, `created_by_member_id`, `last_used_at`, `rotated_at` — and fixes a latent bug where `DHService/db.py:get_client_by_client_name` was returning an invalid `Client(enabled=False, …)`.

## Why now

The existing flow has three operational pain points:
1. **Plaintext shared out of band.** Every credential round-trips through Discord / email.
2. **No revocation.** Disabling a client meant `DELETE FROM oauth2_users` — no audit, no undo. `auth.py:102` already checked `current_client.disabled` but the column didn't exist, so the soft-revoke path was unreachable.
3. **No "who provisioned this" record.** Every shipped client in prod has unknown provenance.

## What's in scope (this PR)

- **Schema**: `oauth2_users` gets `id SERIAL PRIMARY KEY` (was `client_name`), `client_name UNIQUE NOT NULL`, `disabled BOOLEAN`, `created_by_member_id INT REFERENCES member`, `last_used_at TIMESTAMPTZ`, `rotated_at TIMESTAMPTZ`. The five existing dev clients keep their `client_name` and `client_secret` untouched — external services need **no config change**.
- **DHService endpoints** under `/v1/admin/api_clients/*` (`GET` list/detail, `POST` create, `POST /:id/rotate`, `PATCH /:id`) mirroring the existing `/v1/admin/roles/*` pattern. `last_used_at` is best-effort touched inside `authenticate_client` on a successful `/token`.
- **Admin-portal Flask routes** at `/api/admin/api_clients/*`, gated by `@requires_view_permission("systems.api_clients")` / `@requires_change_permission(...)`. CSRF via `X-CSRFToken` per existing convention.
- **Validation on `client_name`** at four layers (HTML5 `pattern`, Flask `FIELD_VALIDATORS`, Pydantic `constr`, DB UNIQUE): regex `^[a-z0-9][a-z0-9_\-]{1,62}[a-z0-9]$`, 3–64 chars, lowercase + digits + dash + underscore, no leading/trailing punctuation, no spaces, no unicode. Duplicates surface as inline 409 error on the create modal's name field.
- **UI**: API Clients list table (ID, Name, Description, Status pill, Created by, Created/Last used/Rotated timestamps, row actions). Three modals:
  - **Create / Edit description** (Bootstrap)
  - **Secret reveal** — one-time plaintext display with "I have copied this secret" gate on Close
  - **Confirm-by-email** — every mutating action requires the admin to type their session email (case-insensitive); cancel restores the previous modal with form data intact
- **"Created by" column** resolves `created_by_member_id` to `First Last (#id)` via a `LEFT JOIN member`, with `#id` linking to the member detail view. Orphaned rows (deleted creator) fall back to bare `#id`.

## Out of scope / future work

- **Per-client scopes.** Today every authenticated client is effectively root on the API. A follow-up will let an admin pick which `v1` endpoints (or which permission bundle) a given client can hit, so e.g. the Stripe integration can `member.status:change` but not `member.identity:change`. This PR keeps the schema additive (a future `ALTER TABLE oauth2_users ADD COLUMN scopes JSONB` is unobstructed) and the create modal sectioned so a "Scopes" panel can drop in without rewriting the form. Open design questions for that PR: reuse the `roles` table or a separate `client_scopes` catalog; how to classify every existing `v1` endpoint.
- **Dedicated `api_client_audit` table.** Current posture is INFO-level `logger.info` lines in both DHService and admin portal — same as the existing roles endpoints, which also lack an audit table. Filing a unified audit pass for both as a follow-up.
- **DHService Pydantic strictness on `bool` fields.** `ApiClientPatchIn.disabled` accepts `"true"` / `1` via Pydantic's default lenient coercion. The Flask admin-portal layer (the only intended caller) catches it with `isinstance(disabled, bool)` and returns 400, so the practical surface is zero. Worth a future "tighten DHService Pydantic across the board" pass, but inconsistent to fix in just this one model.

## Production rollout

Schema changes don't apply to existing DBs on init — they only run on fresh init via `pgsql_schema.sql`. The prod operator should apply this in a separate deployment step:

```sql
BEGIN;
ALTER TABLE oauth2_users ADD COLUMN id SERIAL;
ALTER TABLE oauth2_users DROP CONSTRAINT oauth2_users_pkey;
ALTER TABLE oauth2_users ADD PRIMARY KEY (id);
ALTER TABLE oauth2_users ADD CONSTRAINT oauth2_users_client_name_key UNIQUE (client_name);
ALTER TABLE oauth2_users ADD COLUMN disabled BOOLEAN NOT NULL DEFAULT FALSE;
ALTER TABLE oauth2_users ADD COLUMN created_by_member_id INT REFERENCES member(id) ON DELETE SET NULL NULL;
ALTER TABLE oauth2_users ADD COLUMN last_used_at TIMESTAMPTZ NULL;
ALTER TABLE oauth2_users ADD COLUMN rotated_at TIMESTAMPTZ NULL;
COMMIT;
```

Post-deploy, an Administrator must grant themselves `systems.api_clients` view+change via the Roles UI before the tab appears — the seed roles are intentionally NOT updated in this PR (sensitive new permission, explicit opt-in is safer).

## Notable behavior

- **Disabled clients still get a JWT from `/token`** — `authenticate_client` only checks the password. The next authenticated request returns **400 "Inactive client"** at the `get_current_active_client` gate. Disable is a soft revoke; for hard revoke, rotate the secret (which 401s every existing copy).
- **`last_used_at` updates on any successful `/token` exchange, including for disabled clients.** This is useful telemetry (someone is still trying that credential) — not changed.

## Test plan

- [x] On a fresh dev stack (`./dh_dev.sh stop && reset && start`), `\d oauth2_users` shows the new columns + PK
- [x] Grant `systems.api_clients` to Administrator role; tab appears in Systems dropdown
- [x] Create a client; secret displays once, copy works, Close gated by acknowledgment checkbox
- [x] Use the new client's plaintext via `code/DHService/client_test/` — `/token` 200, downstream calls 200
- [x] Validation: `Dev-Stripe`, `-leading`, `trailing_`, `ab` all rejected browser-side; duplicate name → 409 inline on the create modal
- [x] Disable client → `/token` still 200 but next `/v1/…` call → 400 "Inactive client"
- [x] Rotate → old secret 401, new secret 200; `rotated_at` updated
- [x] Edit description; `rotated_at` unchanged
- [x] Dev-login as Authorizer (no perm): tab hidden, `curl /api/admin/api_clients` → 403
- [x] CSRF: PATCH without `X-CSRFToken` → 400
- [x] No modal stacking on create→reveal, rotate→reveal, edit→confirm, disable→confirm
- [x] `Created by` resolves to `First Last (#id)`; orphan rows fall back gracefully
- [ ] Mobile viewport: modals don't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)