### PR TITLE
Tags need to be prepadded with zeros to make the full ten digits

### DIFF
--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -395,7 +395,7 @@ BEGIN
                      FROM   member m
                      WHERE  m.id = p_member_id
              )
-        SELECT   at.tag,
+        SELECT   lpad(at.tag::text, 10, '0') as tag,
                  converttowiegand(at.tag::BIGINT) WIEGAND_TAG_NUM,
                  CASE
                           WHEN EXISTS (    SELECT 1


### PR DESCRIPTION
DHAccess uses a plpgsql function, `get_all_tags_for_member()` that was not returning all the tags prepended with zeros, which was causing problems downstream in the RFID workers. This is a fix for the plplgsql function so that it always returns the list of tags for a member with the proper number of digits (10).