### PR TITLE
DHService: guard v_member_info.birthday against malformed strings

### DIFF
--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -139,7 +139,12 @@ json_build_object(
         'last_name', m.identity ->> 'last_name'::TEXT,
         'primary_email', jsonb_path_query_first( m.identity, '$.emails[*] ? (@.type == "primary").email_address' )#>>'{}',
         'nickname', m.identity ->> 'nickname'::TEXT,
-        'birthday', to_date(m.identity ->> 'birthday'::TEXT, 'YYYY-MM-DD' ),
+        -- Same shape-check pattern as id_check_date below: a malformed
+        -- birthday string (anything not YYYY-MM-DD) would otherwise raise
+        -- "invalid value for YYYY" and poison the entire v_member_info row.
+        'birthday', CASE WHEN m.identity ->> 'birthday' ~ '^\d{4}-\d{2}-\d{2}$'
+                         THEN to_date(m.identity ->> 'birthday', 'YYYY-MM-DD')
+                         ELSE NULL END,
         'active_directory_username', m.identity ->> 'active_directory_username'::TEXT,
         'pronouns', m.identity ->> 'pronouns'::TEXT,
         'nametag_subtitle', m.identity ->> 'nametag_subtitle'::TEXT,


### PR DESCRIPTION
## Summary
- Wraps the `birthday` cast in `v_member_info` with the same `CASE … ~ '^\d{4}-\d{2}-\d{2}$'` shape-check pattern already used for `forms.id_check_date` a few lines below.
- A non-empty birthday string that isn't `YYYY-MM-DD` (e.g. `"not-a-date"`) made `to_date()` raise `invalid value for YYYY` and 500'd every read of the view — and through it `/v1/member/full_info/` and the member portal dashboard's banned-gate.
- Caught during heavy ad-hoc testing of the freshly-merged main → dev catch-up. Seed data happens to be clean; the regression would surface the first time an admin or signup form saved a malformed date.

## Test plan
- [x] Re-injected null / empty / `"not-a-date"` into seed members 1/2/3 → `SELECT count(*) FROM v_member_info` succeeds.
- [x] Poisoned rows return `birthday: null` instead of crashing; valid rows still parse (e.g. member 1 = `1985-12-10`).
- [x] HTTP path: `GET /v1/member/full_info/?member_id=3` with malformed birthday → 200 with `birthday: null` (was 500).
- [x] All injected test data restored.
- [ ] Production schema rollout: tracked in separate issue (manual `CREATE OR REPLACE VIEW`, per project rule that `pgsql_schema.sql` only fires on fresh init).

## Notes
- Other unguarded date columns in the same view (`waiver_signed_date`, `orientation_completed_date`, `member_since`) are pre-existing and not introduced by #273; left out of this fix to keep the diff narrowly scoped.