### PR TITLE
Admin portal: return {} when member has no connections

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -920,6 +920,9 @@ def api_member_connections():
             dhservices.DH_CLIENT_SECRET
         )
         connections = dhservices.get_member_connections(access_token, member_id)
+        # They may not have any connections, so return empty dict instead of null
+        if connections is None:
+            connections = {}
         return connections
     except Exception as e:
         print(f"Error getting member connections: {e}")


### PR DESCRIPTION
## Summary
- `/api/member/connections` was returning `None` to Flask when a member's `connections` JSONB column was NULL, tripping `"view function … did not return a valid response"` and a 500.
- Adds the same `if connections is None: connections = {}` guard already used by `api_member_extras` and `api_member_authorizations` a few lines below.
- Pure handler-layer fix in the admin portal — no schema change, no production DB rollout needed.

## Symptom
UI silently showed an empty Connections panel and no toast, so the bug went unnoticed. Server-side, every Connections-tab click for an affected member logged a TypeError. Reproduced on 3 of 5 seed members (pending / banned / suspended) during heavy ad-hoc testing of the freshly-merged dev branch.

## Test plan
- [x] Rebuilt `dhadminportal`, hit `/api/member/connections?member_id=N` for: 30 pending (NULL conn), 27 banned (NULL conn), 24 suspended (NULL conn), 9 inactive (has conn), 7 active (has conn).
- [x] All five returned 200. NULL-conn members returned `{}`; members with data returned `{"discord_username": "…"}`.
- [x] Confirmed `dh_admin_portal` logs no longer show `TypeError: … did not return a valid response`.