### PR TITLE
DHIdentity: replace copy-paste 'authorization' log strings with 'identity'

### DIFF
--- a/code/services/DHIdentity/main.py
+++ b/code/services/DHIdentity/main.py
@@ -71,7 +71,7 @@ async def health_check():
 
 
 ###############################################################################
-# Endpoint to sync authorizations
+# Endpoint to sync identity changes
 ###############################################################################
 
 @app.post("/v1/change_identity")
@@ -102,7 +102,7 @@ async def change_identity(request: dict):
 
         # Deep Harbor allows for multiple emails for a user, but right now we only
         # support the "primary" email. In the future, we may want to support multiple emails and
-        # allow the user to specify which email to use for authorizations changes.
+        # allow the user to specify which email to use for identity changes.
         # This is being done here and not downstream because by the time we get to DH2AD worker, 
         # we want to have all the necessary information to process the request and not have 
         # it be responsible for parsing the member identity and figuring out which email to use. 
@@ -146,14 +146,14 @@ async def change_identity(request: dict):
         payload = dh2ad_request
         response = requests.post(url, json=payload)
         if response.status_code != 200:
-            logger.error(f"Failed to change authorizations via DH2AD: {response.text}")
+            logger.error(f"Failed to change identity via DH2AD: {response.text}")
             raise HTTPException(
-                status_code=500, detail=f"Failed to change authorizations via DH2AD: {response.text}"
+                status_code=500, detail=f"Failed to change identity via DH2AD: {response.text}"
             )
 
         processed_request = {"processed": True, "details": response.json()}
         logger.info(
-            f"Authorization changes processed successfully: {processed_request}"
+            f"Identity changes processed successfully: {processed_request}"
         )
         
         # Here is the only spot where we can do anything with the newly created AD
@@ -163,5 +163,5 @@ async def change_identity(request: dict):
         
         return processed_request
     except Exception as e:
-        logger.error(f"Error processing authorization changes: {e}")
+        logger.error(f"Error processing identity changes: {e}")
         raise HTTPException(status_code=500, detail=f"Internal Server Error: {e}")


### PR DESCRIPTION
## Summary
- Six leftover references to `authorizations` / `Authorization` in `code/services/DHIdentity/main.py` on the `change_identity` endpoint, all looking like copy-paste from `DHAuthorizations` when DHIdentity was first templated off it:
  - Section header comment.
  - One inline comment about primary-email selection.
  - DH2AD failure `logger.error` + matching `HTTPException` detail.
  - Success log line.
  - Outer exception-handler `logger.error`.
- Result of the leak: when DHIdentity fails, `dh_identity` logs `"Error processing authorization changes:"` — the exact same line DHAuthorizations logs for its own failures. Misleading when grepping logs to figure out which worker actually failed.
- Pure cosmetic / log-clarity fix. No behavioral change. No schema or seed change. No production-DB rollout needed beyond the next DHIdentity image roll.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` passes (no syntax break).
- [x] `grep -nE "authoriz" code/services/DHIdentity/main.py` returns zero matches after the change.
- [ ] Next dispatcher cycle that hits the identity path on dev will now log `"Identity changes processed successfully"` / `"Error processing identity changes"`. Verify by tailing `docker logs dh_identity` after the new image rolls (the existing pending-member retry loop — see #280 — exercises this path constantly).

## Related
- Surfaced during the 2026-05-18 heavy ad-hoc test sweep alongside the bigger queue-poisoning issue (#280). Independent fix; this PR is purely log strings.