### PR TITLE
DHMemberPortal: keys_locked must come from view, not template block scope

### DIFF
--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -484,10 +484,14 @@ def member_keys():
         elif isinstance(access['rfid_tags'], str):
             access['rfid_tags'] = ','.join(tag.strip().zfill(10) for tag in access['rfid_tags'].split(',') if tag.strip())
 
+    status = member_info.get('status', {}) if isinstance(member_info, dict) else {}
+    keys_locked = (status.get('membership_status') or '').lower() != 'active'
+
     return render_template('dashboard_keys.html',
                          access=access,
                          identity=member_info.get('identity', {}) if isinstance(member_info, dict) else {},
-                         status=member_info.get('status', {}) if isinstance(member_info, dict) else {},
+                         status=status,
+                         keys_locked=keys_locked,
                          user=session.get('user'))
 
 @app.route('/dashboard/auths')

--- a/code/DHMemberPortal/templates/dashboard_keys.html
+++ b/code/DHMemberPortal/templates/dashboard_keys.html
@@ -2,8 +2,6 @@
 {% block title %}Keys & Access - Pumping Station: One{% endblock %}
 {% block page_title %}<i class="fa-solid fa-key ic-keys"></i> Keys & Access{% endblock %}
 {% block dashboard_content %}
-            {% set keys_locked = (status.membership_status or '')|lower != 'active' %}
-
             <div id="keysPageContent">
             <div class="card mb-3{% if keys_locked %} dh-card-locked{% endif %}">
                 <div class="card-body">


### PR DESCRIPTION
## Summary
- `dashboard_keys.html` defined `{% set keys_locked = ... %}` inside `{% block dashboard_content %}` and then referenced it in `{% block scripts %}` to render `const keysLocked = ...`. Jinja `{% set %}` inside a block stays scoped to that block, so the JS literal **always rendered `false`** — even for inactive, suspended, and pending members.
- Server-side `disabled` attributes and the RFID server-side gate were unaffected (template literals inside `dashboard_content` still saw the local `keys_locked`), so a normal user couldn't slip a write through. But the JS-side defense-in-depth (skip Add handler, skip Delete delegation, `preventDefault` on submit) was silently bypassed.
- Move the computation into `member_keys()` in `app.py` and pass `keys_locked` through the template context so both blocks see the same value.

## Test plan
- [x] Active member (Rosalind / id 7): `keysLocked=false`, controls enabled, add tag + Save round-trip persists.
- [x] Pending member (Niels Bohr / id 28): `keysLocked=true`, `.dh-card-locked`, all controls disabled, "Membership Pending" banner.
- [x] Suspended member (Marie Curie / id 9): `keysLocked=true`, all controls disabled.
- [x] Banned member (Edward Teller / id 26): `/dashboard/keys` redirects to `/dashboard/locked` via `_gate_banned_members`, page never reached.
- [x] JS guards on suspended user with controls forcibly re-enabled in DevTools: Add no-op (listener never attached), Delete returns early, submit `preventDefault()` fires.
- [x] Server-side RFID gate already blocks a forged POST for non-active members (regression-check, no change in behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)