### PR TITLE
Backport two main-only fixes into dev: B2C disabled-by-default + RFID 10-digit pad

### DIFF
--- a/code/workers/DHADController/b2c.py
+++ b/code/workers/DHADController/b2c.py
@@ -129,7 +129,7 @@ def create_user_in_b2c(access_token,
 
     # Okay, here we go...
     user_data = {
-        'accountEnabled': True,
+        'accountEnabled': False,
         'displayName': f'{first_name} {last_name}',
         'mailNickname': username,
         'identities': [

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -422,7 +422,7 @@ BEGIN
                      FROM   member m
                      WHERE  m.id = p_member_id
              )
-        SELECT   at.tag,
+        SELECT   lpad(at.tag::text, 10, '0') as tag,
                  converttowiegand(at.tag::BIGINT) WIEGAND_TAG_NUM,
                  CASE
                           WHEN EXISTS (    SELECT 1


### PR DESCRIPTION
## Summary
Back-merges two fixes that shipped to `main` but never landed in `dev`. Found by auditing `git cherry origin/dev origin/main`.

- **`8cf4787`** — `get_all_tags_for_member` now left-pads RFID tags to 10 digits (`lpad(at.tag::text, 10, '0')`) in `pg/sql/pgsql_schema.sql`.
- **`96f8058`** — new B2C accounts are created with `accountEnabled: False` (disabled until an admin explicitly enables) in `DHADController/b2c.py`.

The third main-only commit (`e29df13`, "Stripe change cannot unban member") was **deliberately skipped** — dev already has the identical banned-stays-banned branch in `ST2DH/app.py`; the only delta was an unrelated `Dockerfile` bump to `python:3.14-slim`.

## Notes
- `pgsql_schema.sql` changes only apply on fresh DB init — the running dev/prod DBs will need this function manually applied via `CREATE OR REPLACE FUNCTION` (file a deployment issue if rolling to prod).
- `b2c.py` diff includes a trailing-newline fix on `get_user_enabled_status` (dev's function kept; main's missing-newline dropped).

## Test plan
- [ ] Confirm new B2C account creation lands disabled and admin enable flow still works
- [ ] Confirm RFID tag query returns 10-digit zero-padded tags after schema reapply