### PR TITLE
ST2DH: return 400 instead of 500 for malformed/forged webhook requests

### DIFF
--- a/code/external/ST2DH/app.py
+++ b/code/external/ST2DH/app.py
@@ -9,7 +9,7 @@ import dhservices
 from dhs_logging import logger
 from config import config
 
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, abort
 
 app = Flask(__name__)
 
@@ -371,19 +371,22 @@ def health():
 def webhook():
     event = None
     payload = request.data
-    sig_header = request.headers["STRIPE_SIGNATURE"]
+    sig_header = request.headers.get("Stripe-Signature")
+    if sig_header is None:
+        logger.warning("Webhook called without a Stripe-Signature header; rejecting.")
+        abort(400, "Missing Stripe-Signature header")
 
     # Did we get a valid event from Stripe?
     try:
         event = stripe.Webhook.construct_event(payload, sig_header, config["stripe"]["signing_secret"])
     except ValueError as e:
         # Invalid payload
-        logger.error(f"Invalid payload: {e}")        
-        raise e
+        logger.error(f"Invalid payload: {e}")
+        abort(400, "Invalid payload")
     except stripe.error.SignatureVerificationError as e:
         # Invalid signature
-        logger.error(f"Invalid signature: {e}")        
-        raise e
+        logger.error(f"Invalid signature: {e}")
+        abort(400, "Invalid signature")
 
     # Send the event data to our DHService API to save it in our database
     try:


### PR DESCRIPTION
## Summary
- The ST2DH `/webhook` handler read the Stripe signature header via a bare dict lookup, so any POST missing the header crashed with `KeyError` → **500 + traceback**.
- The bad-payload and bad-signature branches re-raised into 500s as well, which is incorrect webhook semantics — a 500 makes Stripe pointlessly retry a request that can never succeed.
- Switch to `request.headers.get("Stripe-Signature")` with an explicit reject, and `abort(400)` on a missing header, an unparseable payload, or a failed signature verification.

Net behavior:
- Malformed / forged / header-less requests → clean **400** (no traceback).
- Genuinely-received-but-unprocessable events (downstream save/handle failures) → **left as 500 on purpose** so Stripe's retry machinery still fires for transient failures.
- Success → **200** (unchanged).

The signature-verification security control (`stripe.Webhook.construct_event`) is untouched and still gates all event processing.

## Test plan
Tested on dev with curl against the running container (dev has no Stripe configured, so the happy-path 200 / downstream chain can't be exercised end-to-end):
- [x] `POST /webhook` with no signature header → **400** (was 500 + traceback)
- [x] `POST /webhook` with a garbage `Stripe-Signature` → **400** (signature-verification failure path)
- [x] `GET /health` → still **200**
- [x] Container logs show clean warnings, no `KeyError` / traceback for the above probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)