### PR TITLE
v_member_info: guard member_since/waiver/orientation date casts

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -62,11 +62,12 @@ FIELD_VALIDATORS = {
     "birthday": (r'^\d{4}-\d{2}-\d{2}$', 10, "Birthday must be in YYYY-MM-DD format"),
     "id_check_date": (r'^\d{4}-\d{2}-\d{2}$', 10, "ID check date must be in YYYY-MM-DD format"),
     "id_check_by": (r'^[1-9]\d*$', 10, "Onboarder must be a valid member"),
-    # These three reach v_member_info's date casts. Unlike birthday/id_check_date
-    # they are prod-populated as datetime strings ("YYYY-MM-DD HH:MM:SS[+TZ]") on the
-    # WA-migration cohort, so the pattern is PREFIX-anchored (no $) and max_len is
-    # generous — it rejects the crash-causing formats ("03/15/2026", "N/A") without
-    # rejecting legitimate ISO date OR datetime values. Mirrors the view guard.
+    # These three feed v_member_info's date casts (now hardened with safe_to_date,
+    # which is the authoritative crash guard). This is a friendly early 400 for the
+    # common bad formats ("03/15/2026", "N/A"): PREFIX-anchored (no $) with a generous
+    # max_len so it accepts the prod datetime strings ("YYYY-MM-DD HH:MM:SS[+TZ]") and
+    # plain ISO dates alike. It does NOT calendar-validate (Feb 30 etc.) — safe_to_date
+    # in the view backstops that.
     "member_since": (r'^\d{4}-\d{2}-\d{2}', 32, "member_since must start with an ISO date (YYYY-MM-DD)"),
     "waiver_signed_date": (r'^\d{4}-\d{2}-\d{2}', 32, "waiver_signed_date must start with an ISO date (YYYY-MM-DD)"),
     "orientation_completed_date": (r'^\d{4}-\d{2}-\d{2}', 32, "orientation_completed_date must start with an ISO date (YYYY-MM-DD)"),

--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -62,6 +62,14 @@ FIELD_VALIDATORS = {
     "birthday": (r'^\d{4}-\d{2}-\d{2}$', 10, "Birthday must be in YYYY-MM-DD format"),
     "id_check_date": (r'^\d{4}-\d{2}-\d{2}$', 10, "ID check date must be in YYYY-MM-DD format"),
     "id_check_by": (r'^[1-9]\d*$', 10, "Onboarder must be a valid member"),
+    # These three reach v_member_info's date casts. Unlike birthday/id_check_date
+    # they are prod-populated as datetime strings ("YYYY-MM-DD HH:MM:SS[+TZ]") on the
+    # WA-migration cohort, so the pattern is PREFIX-anchored (no $) and max_len is
+    # generous — it rejects the crash-causing formats ("03/15/2026", "N/A") without
+    # rejecting legitimate ISO date OR datetime values. Mirrors the view guard.
+    "member_since": (r'^\d{4}-\d{2}-\d{2}', 32, "member_since must start with an ISO date (YYYY-MM-DD)"),
+    "waiver_signed_date": (r'^\d{4}-\d{2}-\d{2}', 32, "waiver_signed_date must start with an ISO date (YYYY-MM-DD)"),
+    "orientation_completed_date": (r'^\d{4}-\d{2}-\d{2}', 32, "orientation_completed_date must start with an ISO date (YYYY-MM-DD)"),
 }
 
 ###############################################################################
@@ -1144,9 +1152,12 @@ def api_update_member_status():
         member_data = dhservices.get_member_id(access_token, user_email)
         logged_in_member_id = member_data.get("member_id")
         
-        data = request.get_json()
-        data["modified_by"] = logged_in_member_id
-        result = dhservices.update_member_status(access_token, member_id, data)
+        data = request.get_json() or {}
+        sanitized, error = validate_update_data(data, "status")
+        if error:
+            return {"error": error}, 400
+        sanitized["modified_by"] = logged_in_member_id
+        result = dhservices.update_member_status(access_token, member_id, sanitized)
         
         # Log update activity
         try:

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -128,6 +128,30 @@ SELECT id,
 FROM   member;
 COMMENT ON VIEW v_member_name_email_status IS 'This view provides a list of member IDs along with their first name, last name, primary email address, and membership status from the member table.';
 
+-- Defensive date coercion for v_member_info. Member-data date strings arrive
+-- from many eras/sources (WA import, Stripe, signup, admin edits) in mixed
+-- shapes: 10-char ISO date, 19/25-char ISO datetime, empty string, or free text.
+-- A bare to_date() RAISES on any non-ISO or out-of-range value (e.g.
+-- "03/15/2026", "2026-02-30", "N/A") and 500s EVERY read of the view — which
+-- backs /v1/member/full_info/, the member dashboard, and the banned-gate. A
+-- regex alone can't validate the calendar (leap years, 30- vs 31-day months),
+-- so we require an ISO date prefix (rules out empty/"N/A"/"MM/DD/YYYY", and the
+-- to_date('') -> 0001-01-01 BC quirk) and let the EXCEPTION block NULL anything
+-- to_date still rejects (Feb 30, day 31 of a 30-day month, etc.).
+CREATE OR REPLACE FUNCTION safe_to_date(p_text text) RETURNS date
+    LANGUAGE plpgsql IMMUTABLE
+AS $$
+BEGIN
+    IF p_text !~ '^\d{4}-\d{2}-\d{2}' THEN
+        RETURN NULL;
+    END IF;
+    RETURN to_date(p_text, 'YYYY-MM-DD');
+EXCEPTION WHEN others THEN
+    RETURN NULL;
+END;
+$$;
+COMMENT ON FUNCTION safe_to_date(text) IS 'Parses the leading YYYY-MM-DD of a string to a date, returning NULL for empty/malformed/calendar-invalid input instead of raising. Used by v_member_info so one bad member-data string cannot 500 the whole view.';
+
 -- This view wraps most of the member data for easier querying
 -- and displaying on the member portal
 CREATE OR REPLACE VIEW v_member_info as
@@ -139,12 +163,7 @@ json_build_object(
         'last_name', m.identity ->> 'last_name'::TEXT,
         'primary_email', jsonb_path_query_first( m.identity, '$.emails[*] ? (@.type == "primary").email_address' )#>>'{}',
         'nickname', m.identity ->> 'nickname'::TEXT,
-        -- Same shape-check pattern as id_check_date below: a malformed
-        -- birthday string (anything not YYYY-MM-DD) would otherwise raise
-        -- "invalid value for YYYY" and poison the entire v_member_info row.
-        'birthday', CASE WHEN m.identity ->> 'birthday' ~ '^\d{4}-\d{2}-\d{2}$'
-                         THEN to_date(m.identity ->> 'birthday', 'YYYY-MM-DD')
-                         ELSE NULL END,
+        'birthday', safe_to_date(m.identity ->> 'birthday'),
         'active_directory_username', m.identity ->> 'active_directory_username'::TEXT,
         'pronouns', m.identity ->> 'pronouns'::TEXT,
         'nametag_subtitle', m.identity ->> 'nametag_subtitle'::TEXT,
@@ -157,36 +176,17 @@ json_build_object(
     'forms', json_build_object(
         'id_check_1', m.forms ->> 'id_check_1'::TEXT,
         'id_check_2', m.forms ->> 'id_check_2'::TEXT,
-        -- Bad/empty values in id_check_date / id_check_by would otherwise
-        -- poison the entire v_member_info read (issue #75 territory). The
-        -- regex shape-checks here gracefully NULL them instead.
-        'id_check_date', CASE WHEN m.forms ->> 'id_check_date' ~ '^\d{4}-\d{2}-\d{2}$'
-                              THEN to_date(m.forms ->> 'id_check_date', 'YYYY-MM-DD')
-                              ELSE NULL END,
+        'id_check_date', safe_to_date(m.forms ->> 'id_check_date'),
         'id_check_by',   CASE WHEN m.forms ->> 'id_check_by' ~ '^[0-9]+$'
                               THEN (m.forms ->> 'id_check_by')::INT
                               ELSE NULL END,
-        -- Same poison-the-whole-row hazard as id_check_date/birthday: a
-        -- malformed non-empty string (e.g. "03/15/2026", "N/A") makes to_date
-        -- raise and 500s every read of the view. These three are prod-populated
-        -- as datetime strings ("YYYY-MM-DD HH:MM:SS[+TZ]") on the WA-migration
-        -- cohort, so the guard is PREFIX-anchored (no trailing $) — it keeps the
-        -- date prefix parseable (to_date ignores the trailing time) while NULLing
-        -- anything that isn't year-prefixed ISO. Do NOT tighten to ^...$ or the
-        -- ~2766 datetime-format rows would all go NULL.
-        'waiver_signed_date', CASE WHEN m.forms ->> 'waiver_signed_date' ~ '^\d{4}-\d{2}-\d{2}'
-                                   THEN to_date(m.forms ->> 'waiver_signed_date', 'YYYY-MM-DD')
-                                   ELSE NULL END,
+        'waiver_signed_date', safe_to_date(m.forms ->> 'waiver_signed_date'),
         'terms_of_use_accepted', m.forms ->> 'terms_of_use_accepted'::TEXT,
         'essentials_form', m.forms ->> 'essentials_form'::TEXT,
-        'orientation_completed_date', CASE WHEN m.forms ->> 'orientation_completed_date' ~ '^\d{4}-\d{2}-\d{2}'
-                                           THEN to_date(m.forms ->> 'orientation_completed_date', 'YYYY-MM-DD')
-                                           ELSE NULL END
+        'orientation_completed_date', safe_to_date(m.forms ->> 'orientation_completed_date')
     ),
     'status', json_build_object(
-        'member_since', CASE WHEN m.status ->> 'member_since' ~ '^\d{4}-\d{2}-\d{2}'
-                             THEN to_date(m.status ->> 'member_since', 'YYYY-MM-DD')
-                             ELSE NULL END,
+        'member_since', safe_to_date(m.status ->> 'member_since'),
         'membership_status', m.status ->> 'membership_status'::TEXT,
         'membership_level', m.status ->> 'membership_level'::TEXT
     ),

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -166,13 +166,27 @@ json_build_object(
         'id_check_by',   CASE WHEN m.forms ->> 'id_check_by' ~ '^[0-9]+$'
                               THEN (m.forms ->> 'id_check_by')::INT
                               ELSE NULL END,
-        'waiver_signed_date', to_date(m.forms ->> 'waiver_signed_date'::TEXT, 'YYYY-MM-DD' ),
+        -- Same poison-the-whole-row hazard as id_check_date/birthday: a
+        -- malformed non-empty string (e.g. "03/15/2026", "N/A") makes to_date
+        -- raise and 500s every read of the view. These three are prod-populated
+        -- as datetime strings ("YYYY-MM-DD HH:MM:SS[+TZ]") on the WA-migration
+        -- cohort, so the guard is PREFIX-anchored (no trailing $) — it keeps the
+        -- date prefix parseable (to_date ignores the trailing time) while NULLing
+        -- anything that isn't year-prefixed ISO. Do NOT tighten to ^...$ or the
+        -- ~2766 datetime-format rows would all go NULL.
+        'waiver_signed_date', CASE WHEN m.forms ->> 'waiver_signed_date' ~ '^\d{4}-\d{2}-\d{2}'
+                                   THEN to_date(m.forms ->> 'waiver_signed_date', 'YYYY-MM-DD')
+                                   ELSE NULL END,
         'terms_of_use_accepted', m.forms ->> 'terms_of_use_accepted'::TEXT,
         'essentials_form', m.forms ->> 'essentials_form'::TEXT,
-        'orientation_completed_date', to_date(m.forms ->> 'orientation_completed_date'::TEXT, 'YYYY-MM-DD' )
+        'orientation_completed_date', CASE WHEN m.forms ->> 'orientation_completed_date' ~ '^\d{4}-\d{2}-\d{2}'
+                                           THEN to_date(m.forms ->> 'orientation_completed_date', 'YYYY-MM-DD')
+                                           ELSE NULL END
     ),
     'status', json_build_object(
-        'member_since', to_date(m.status ->> 'member_since'::TEXT, 'YYYY-MM-DD'), 
+        'member_since', CASE WHEN m.status ->> 'member_since' ~ '^\d{4}-\d{2}-\d{2}'
+                             THEN to_date(m.status ->> 'member_since', 'YYYY-MM-DD')
+                             ELSE NULL END,
         'membership_status', m.status ->> 'membership_status'::TEXT,
         'membership_level', m.status ->> 'membership_level'::TEXT
     ),


### PR DESCRIPTION
## Summary
Extends the PR #275 birthday fix to all five `to_date()` casts in `v_member_info`. A malformed/out-of-range date string in `status.member_since`, `forms.waiver_signed_date`, `forms.orientation_completed_date` (or `birthday`/`id_check_date`) makes `to_date()` raise and **500s every read of the view** — cascading to `/v1/member/full_info/`, the member-portal dashboard, and the banned-gate.

Not currently firing in prod (all populated values are year-prefixed ISO), but one bad admin edit or future WF2DH waiver write away from a member-level outage.

## Changes
- **`pg/sql/pgsql_schema.sql`** — add a `safe_to_date(text)` PL/pgSQL helper and route all five view date casts through it. It requires an ISO date *prefix* (rules out empty/`N/A`/`MM/DD/YYYY` and the `to_date('') -> 0001-01-01 BC` quirk, while still parsing the prod 19/25-char datetime strings), then an `EXCEPTION` block NULLs anything `to_date` still rejects. A regex alone can't validate the calendar (leap years, 30- vs 31-day months), so the exception handler is what actually closes the gap.
- **`code/DHAdminPortal/app.py`** — add the three fields to `FIELD_VALIDATORS` (friendly early 400 for common bad formats; `safe_to_date` in the view is the authoritative guard), and wire `validate_update_data` into `/api/member/status`, the only member POST that was skipping input validation.

## Test plan
- [x] `safe_to_date` matrix: valid 10/19/25-char ISO parse; empty/`N/A`/`MM/DD/YYYY`/`2026-13-45`/`2026-02-30`/`2026-04-31`/non-leap `2025-02-29` → NULL; leap `2024-02-29` → parses
- [x] DB: no regression — real members' member_since/birthday still render; full 63-row view scan errors-free
- [x] DB: rolled-back txn planting Feb-30 / Apr-31 / US-format birthday → view returns NULL, no error (pre-fix: hard error)
- [x] UI: member dashboard storage page renders 200
- [x] UI: planted malformed `member_since` on a member, reloaded → 200 (was 500), field cleanly hidden; restored original
- [x] UI: admin `/api/member/status` → malformed date 400 (friendly message), valid status change and valid date 200, member data untouched

## Production deploy
The function + view live in `pgsql_schema.sql` (fresh-init only). Production needs a manual `CREATE OR REPLACE FUNCTION safe_to_date(...)` **before** `CREATE OR REPLACE VIEW v_member_info`. Bundle with the existing #260 `v_member_info` view-deploy ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)