### PR TITLE
Admin portal UI fixes

### DIFF
--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -3604,6 +3604,22 @@ body.sidebar-resizing .details-sidebar {
     overflow-y: auto;
 }
 
+/* WA Legacy ID Check read-only value boxes (Forms tab). Replaces Bootstrap's
+   `.bg-body-secondary` utility, which forces a light-gray background that no
+   theme overrides — illegible under the light foreground text of dark/midnight/
+   hacker. These rules mirror each theme's `.form-control[readonly]` surface so
+   the boxes stay readable and read as muted/non-editable in every theme.
+   The compound `.form-control.dh-legacy-value` selector is intentional: it
+   raises specificity above the bare per-theme `.form-control` rules (and the
+   trailing `.form-control { background-color:#fff }` reset) so these win. */
+.form-control.dh-legacy-value {
+    background-color: #e9ecef;          /* preserve current light/bubblegum look */
+    border-color: #dee2e6;
+}
+[data-theme="dark"]     .form-control.dh-legacy-value { background-color: #09090b; color: var(--text-color);      border-color: #3f3f46; }
+[data-theme="midnight"] .form-control.dh-legacy-value { background-color: #080c18; color: var(--text-color);      border-color: #243356; }
+[data-theme="hacker"]   .form-control.dh-legacy-value { background-color: #0a0a0a; color: var(--secondary-color); border-color: #1a3a1a; }
+
 /* Unchecked checkbox/radio: bump border contrast across all themes.
    Higher specificity than the per-theme `.form-check-input` rules above,
    so :checked and :focus states are unaffected. */

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -25,10 +25,9 @@
    so unrelated keyframe animations (e.g. Bootstrap `.spinner-border` loaders)
    keep spinning. Keep this list in sync when adding a themed animation.
    The selectors cover every theme's `@keyframes` target:
-     body::before/::after  — bubblegum bubble, hacker scanline + CRT flicker
-     .body-content h1       — bg-bounce / dark-fire-flicker / hacker-text-flicker
+     body::before/::after  — bubblegum bubble, hacker scanline + CRT flicker, midnight starfield
+     .body-content h1       — bg-bounce / dark-fire-flicker / hacker-text-flicker / midnight twinkle
      .body-content h1/p ::before/::after — bubblegum sparkles, hacker cursor
-     .midnight-char / .midnight-sparkle  — midnight twinkle + sparkle particles
    =================================================================== */
 
 html.dh-anim-paused body::before,
@@ -37,9 +36,7 @@ html.dh-anim-paused .body-content h1,
 html.dh-anim-paused .body-content h1::before,
 html.dh-anim-paused .body-content h1::after,
 html.dh-anim-paused .body-content p::before,
-html.dh-anim-paused .body-content p::after,
-html.dh-anim-paused .midnight-char,
-html.dh-anim-paused .midnight-sparkle {
+html.dh-anim-paused .body-content p::after {
     animation-play-state: paused !important;
 }
 
@@ -58,9 +55,7 @@ html.dh-anim-paused body::after {
     .body-content h1::before,
     .body-content h1::after,
     .body-content p::before,
-    .body-content p::after,
-    .midnight-char,
-    .midnight-sparkle {
+    .body-content p::after {
         animation: none !important;
         will-change: auto !important;
     }
@@ -2218,14 +2213,22 @@ body.sidebar-resizing .details-sidebar {
     color: var(--text-color);
 }
 
-/* Midnight — suppress bubblegum pseudo-elements */
+/* Midnight — keep the bubblegum body pseudo-elements suppressed. The starfield
+   lives on the title instead (h1::after below), so it stays behind the header
+   rather than scattering across the whole page. */
 
 [data-theme="midnight"] body::before,
 [data-theme="midnight"] body::after {
     display: none;
 }
 
-/* Midnight title — starry twinkle with sparkles */
+@keyframes midnight-starfield {
+    0%, 100% { opacity: 0.35; }
+    50%      { opacity: 0.95; }
+}
+
+/* Midnight title — gradient shimmer that sweeps across the letters + a small
+   sparkle field localized to the header. Both pure CSS, no JS. */
 
 [data-theme="midnight"] .body-content h1 {
     font-family: 'Nothing You Could Do', cursive;
@@ -2234,62 +2237,58 @@ body.sidebar-resizing .details-sidebar {
     text-align: center;
     margin-bottom: 1.5rem;
     padding: 0.5rem 0;
-    color: #fbbf24;
-    text-shadow: 0 0 8px rgba(251, 191, 36, 0.3);
-    background: none;
     border-radius: 0;
     border: none;
     box-shadow: none;
-    animation: none;
     position: relative;
     z-index: 1;
+    /* Shimmer: a bright band travels through a gold base, clipped to the glyphs,
+       so each letter lights up in turn as the highlight passes over it (a moving
+       sheen rather than the whole title pulsing together). */
+    background: linear-gradient(100deg,
+        #a8740a 0%, #c8910f 30%,
+        #ffffff 50%,
+        #c8910f 70%, #a8740a 100%);
+    background-size: 220% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    filter: drop-shadow(0 0 4px rgba(251, 191, 36, 0.25));
+    animation: midnight-shimmer 4.5s linear infinite;
 }
 
-/* Individual letter twinkle */
-[data-theme="midnight"] .body-content h1 .midnight-char {
-    display: inline-block;
-    animation: midnight-twinkle var(--twinkle-duration, 3s) ease-in-out infinite;
-    animation-delay: var(--twinkle-delay, 0s);
+@keyframes midnight-shimmer {
+    0%   { background-position: 150% 0; }
+    100% { background-position: -50% 0; }
 }
 
-@keyframes midnight-twinkle {
-    0%, 100% {
-        color: #b8860b;
-        text-shadow: 0 0 2px rgba(251, 191, 36, 0.1);
-        opacity: 0.7;
-    }
-    50% {
-        color: #ffffff;
-        text-shadow: 0 0 12px rgba(255, 255, 255, 0.6), 0 0 25px rgba(251, 191, 36, 0.4);
-        opacity: 1;
-    }
-}
-
-/* Sparkle particles */
-[data-theme="midnight"] .body-content h1 .midnight-sparkle {
+/* Sparkle field — scattered twinkling dots confined to the header box (behind
+   the title text via z-index:-1, showing through the gaps between letters). */
+[data-theme="midnight"] .body-content h1::after {
+    content: "";
     position: absolute;
-    width: 4px;
-    height: 4px;
-    border-radius: 50%;
-    background: #ffffff;
-    box-shadow: 0 0 6px 2px rgba(255, 255, 255, 0.8), 0 0 12px 4px rgba(251, 191, 36, 0.4);
+    left: 0;
+    right: 0;
+    top: -0.6em;
+    bottom: -0.6em;
+    z-index: -1;
     pointer-events: none;
-    animation: midnight-sparkle-pop var(--sparkle-duration, 2s) ease-in-out infinite;
-    animation-delay: var(--sparkle-delay, 0s);
-    opacity: 0;
-}
-
-@keyframes midnight-sparkle-pop {
-    0%, 100% { opacity: 0; transform: scale(0); }
-    10% { opacity: 1; transform: scale(1.5); }
-    20% { opacity: 1; transform: scale(0.8); }
-    35% { opacity: 0.8; transform: scale(1.2); }
-    50% { opacity: 0.4; transform: scale(0.6); }
-    65% { opacity: 0; transform: scale(0); }
+    background-repeat: no-repeat;
+    /* Each dot: a solid bright core (to 35%) fading to a soft glow (to 75%). */
+    background-image:
+        radial-gradient(4px 4px at 8% 30%, #ffffff 35%, transparent 75%),
+        radial-gradient(4px 4px at 22% 78%, rgba(251, 191, 36, 0.95) 35%, transparent 75%),
+        radial-gradient(3px 3px at 37% 18%, #ffffff 35%, transparent 75%),
+        radial-gradient(4.5px 4.5px at 50% 88%, #ffffff 35%, transparent 75%),
+        radial-gradient(3px 3px at 63% 22%, rgba(251, 191, 36, 0.9) 35%, transparent 75%),
+        radial-gradient(4px 4px at 78% 72%, #ffffff 35%, transparent 75%),
+        radial-gradient(3px 3px at 92% 33%, #ffffff 35%, transparent 75%),
+        radial-gradient(4px 4px at 96% 82%, rgba(251, 191, 36, 0.85) 35%, transparent 75%);
+    animation: midnight-starfield 4s ease-in-out infinite;
 }
 
 [data-theme="midnight"] .body-content h1::before,
-[data-theme="midnight"] .body-content h1::after,
 [data-theme="midnight"] .body-content p::before,
 [data-theme="midnight"] .body-content p::after {
     content: none;

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -323,6 +323,17 @@ body {
     margin-bottom: 0;
 }
 
+/* Logging-notice banner dismiss (x): Bootstrap's default 1.25rem padding makes
+   the hit-area taller than this thin py-2 alert and pins it to the top corner.
+   Shrink it and vertically center it so it sits neatly in the band. */
+#loggingNoticeRow .btn-close {
+    top: 50%;
+    right: 0.5rem;
+    transform: translateY(-50%);
+    padding: 0.5rem;
+    background-size: 0.75em;
+}
+
 [data-theme="bubblegum"] .dh-member-bar + .dh-suspended-warning {
     border-left: 4px solid #ff1493;
     border-right: 1px solid #ff69b4;

--- a/code/DHAdminPortal/templates/base.html
+++ b/code/DHAdminPortal/templates/base.html
@@ -278,43 +278,6 @@
         });
     })();
     </script>
-    <!-- Midnight theme: starry twinkle letters + sparkle particles -->
-    <script>
-    (function() {
-        if (document.documentElement.getAttribute('data-theme') !== 'midnight') return;
-        var h1 = document.querySelector('.body-content h1');
-        if (!h1) return;
-
-        // Wrap each character in a span with random twinkle timing
-        var text = h1.textContent;
-        var html = '';
-        for (var i = 0; i < text.length; i++) {
-            var ch = text[i];
-            if (ch === ' ') {
-                html += ' ';
-            } else {
-                var dur = (2 + Math.random() * 3).toFixed(1);
-                var del = (Math.random() * 4).toFixed(1);
-                html += '<span class="midnight-char" style="--twinkle-duration:' + dur + 's;--twinkle-delay:' + del + 's;">' + ch + '</span>';
-            }
-        }
-        h1.innerHTML = html;
-
-        // Spawn sparkle particles around the title
-        var rect = h1.getBoundingClientRect();
-        var sparkleCount = 12;
-        for (var j = 0; j < sparkleCount; j++) {
-            var spark = document.createElement('span');
-            spark.className = 'midnight-sparkle';
-            var x = Math.random() * 100;
-            var y = -5 + Math.random() * 110;
-            var sDur = (1.5 + Math.random() * 2.5).toFixed(1);
-            var sDel = (Math.random() * 4).toFixed(1);
-            spark.style.cssText = 'left:' + x + '%;top:' + y + '%;--sparkle-duration:' + sDur + 's;--sparkle-delay:' + sDel + 's;';
-            h1.appendChild(spark);
-        }
-    })();
-    </script>
     <!-- Animation CPU saver: pause theme animations after 60s idle + while tab hidden -->
     <script>
     (function () {

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -16,7 +16,7 @@
 <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
 
 <!-- Logging notice -->
-<div class="row justify-content-center" id="loggingNoticeRow" style="display: none;">
+<div class="row justify-content-center" id="loggingNoticeRow">
     <div class="col-md-8">
         <div class="alert alert-warning alert-dismissible fade show text-center py-2 mb-4" role="alert">
             <i class="bi bi-exclamation-triangle-fill"></i>
@@ -1366,10 +1366,12 @@ function dismissLoggingNotice() {
 }
 
 function restoreLoggingNotice() {
+    // Banner renders visible by default in the server-side HTML, so the logging
+    // notice is fail-safe even if this script never runs (JS error, CSP, etc.).
+    // Only hide it if the user previously dismissed it on this browser.
+    if (localStorage.getItem('dh-logging-notice-dismissed') !== '1') return;
     const row = document.getElementById('loggingNoticeRow');
-    if (row && localStorage.getItem('dh-logging-notice-dismissed') !== '1') {
-        row.style.display = '';  // not dismissed -> show
-    }
+    if (row) row.style.display = 'none';
 }
 
 // Core data loading
@@ -1527,7 +1529,7 @@ function updatePaginationControls() {
 function changePerPage(value) {
     perPage = parseInt(value, 10) || 20;
     localStorage.setItem('dh-per-page', perPage);
-    loadMembers(1).then(scrollToSearchBar);
+    paginateTo(1);
 }
 
 // Pagination helpers: after a page change, bring the search bar to the top of

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -81,8 +81,8 @@
                         <option value="50">50</option>
                         <option value="100">100</option>
                     </select>
-                    <button class="btn btn-sm btn-primary" id="prevPageBtn" onclick="loadMembers(currentPage - 1)" disabled>Previous</button>
-                    <button class="btn btn-sm btn-primary" id="nextPageBtn" onclick="loadMembers(currentPage + 1)" disabled>Next</button>
+                    <button class="btn btn-sm btn-primary" id="prevPageBtn" onclick="paginateTo(currentPage - 1)" disabled>Previous</button>
+                    <button class="btn btn-sm btn-primary" id="nextPageBtn" onclick="paginateTo(currentPage + 1)" disabled>Next</button>
                 </div>
             </div>
         </div>
@@ -1511,7 +1511,25 @@ function updatePaginationControls() {
 function changePerPage(value) {
     perPage = parseInt(value, 10) || 20;
     localStorage.setItem('dh-per-page', perPage);
-    loadMembers(1);
+    loadMembers(1).then(scrollToSearchBar);
+}
+
+// Pagination helpers: after a page change, bring the search bar to the top of
+// the viewport so the user starts at row one (the prev/next controls sit at the
+// bottom). We anchor on the search bar rather than the very top of the page so
+// the navbar/logging notice don't need to scroll back into view.
+function scrollToSearchBar() {
+    // behavior:'instant' overrides the global `html { scroll-behavior: smooth }`
+    // so pagination snaps into place instead of animating up the whole list.
+    // Land 8px above the search bar so it isn't flush against the viewport edge.
+    const anchor = document.getElementById('memberSection');
+    if (!anchor) return;
+    const top = anchor.getBoundingClientRect().top + window.scrollY - 8;
+    window.scrollTo({ top: Math.max(0, top), behavior: 'instant' });
+}
+
+function paginateTo(page) {
+    loadMembers(page).then(scrollToSearchBar);
 }
 
 // Details sidebar

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -16,11 +16,12 @@
 <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
 
 <!-- Logging notice -->
-<div class="row justify-content-center">
+<div class="row justify-content-center" id="loggingNoticeRow" style="display: none;">
     <div class="col-md-8">
-        <div class="alert alert-warning text-center py-2 mb-4" role="alert">
+        <div class="alert alert-warning alert-dismissible fade show text-center py-2 mb-4" role="alert">
             <i class="bi bi-exclamation-triangle-fill"></i>
             <strong>HEY!</strong> All changes you make will get logged!
+            <button type="button" class="btn-close" aria-label="Close" onclick="dismissLoggingNotice()"></button>
         </div>
     </div>
 </div>
@@ -1355,6 +1356,21 @@ let currentSort = 'id';
 let currentOrder = 'desc';
 let perPage = parseInt(localStorage.getItem('dh-per-page'), 10) || 20;
 let selectedMemberId = null;
+
+// Logging-notice banner: dismissible, remembered per-browser in localStorage
+
+function dismissLoggingNotice() {
+    localStorage.setItem('dh-logging-notice-dismissed', '1');
+    const row = document.getElementById('loggingNoticeRow');
+    if (row) row.style.display = 'none';
+}
+
+function restoreLoggingNotice() {
+    const row = document.getElementById('loggingNoticeRow');
+    if (row && localStorage.getItem('dh-logging-notice-dismissed') !== '1') {
+        row.style.display = '';  // not dismissed -> show
+    }
+}
 
 // Core data loading
 
@@ -3155,6 +3171,9 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         }
     });
+
+    // Restore dismissed state of the logging-notice banner
+    restoreLoggingNotice();
 
     // Apply navbar visibility based on permissions
     filterNavbarByPermissions();

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -1978,11 +1978,11 @@ function formatFormsData(data) {
         <div class="row g-2">
             <div class="col-md-4">
                 <label class="form-label small text-muted">ID Check 1</label>
-                <div class="form-control form-control-sm bg-body-secondary">${escapeHtml(legacy1) || '<span class="text-muted">—</span>'}</div>
+                <div class="form-control form-control-sm dh-legacy-value">${escapeHtml(legacy1) || '<span class="text-muted">—</span>'}</div>
             </div>
             <div class="col-md-8">
                 <label class="form-label small text-muted">ID Check 2</label>
-                <div class="form-control form-control-sm bg-body-secondary">${escapeHtml(legacy2) || '<span class="text-muted">—</span>'}</div>
+                <div class="form-control form-control-sm dh-legacy-value">${escapeHtml(legacy2) || '<span class="text-muted">—</span>'}</div>
             </div>
         </div>`;
 


### PR DESCRIPTION
A batch of small admin-portal UI fixes.

## Changes
- **Scroll member list to search bar on pagination** — paginating the member list now scrolls back up to the search bar so you're not left mid-table.
- **Fix unreadable WA Legacy ID Check boxes in non-light themes** — the read-only WA Legacy ID Check fields on the Forms tab were near-invisible in dark/midnight/hacker/bubblegum; corrected their contrast.
- **Add dismissible (×) to admin "changes get logged" banner** — the audit-logging notice banner can now be dismissed.
- **Make midnight theme decoration pure CSS (fixes no-animate on theme switch)** — the midnight theme's letter twinkle + sparkles were built by a one-time JS pass at page load, so switching *to* midnight at runtime never animated (only a reload did). Replaced the JS entirely with CSS: a header-scoped field of twinkling sparkle dots (`h1::after`) and a gradient shimmer swept across the title letters (`background-clip: text`). The `.midnight-char`/`.midnight-sparkle` JS scaffolding and dead keyframes are removed; both new animation targets were already covered by the #307 idle-pause and `prefers-reduced-motion` lists, so those keep working.
- **Make the "changes get logged" banner fail-safe + tidy pagination** — the dismissible banner had become default-hidden, revealed only by JS late in a `DOMContentLoaded` handler, so any earlier script error could silently suppress the compliance notice. It now renders visible by default in the server HTML and JS only *hides* it when the user has dismissed it — fail-safe even if the page script never runs. Also collapsed `changePerPage`'s duplicated `loadMembers(1).then(scrollToSearchBar)` into a single `paginateTo(1)` call so the load-then-scroll behavior lives in one place.

## Testing
Verified in the running admin portal via remote Chrome devtools, sweeping all five themes. The midnight change was confirmed to animate on a runtime theme switch (not just on reload), with sparkles confined to the header and the shimmer band travelling across the letters. The logging-notice banner was exercised end-to-end: visible by default with no inline style applied (proving it no longer depends on JS), hidden + remembered on dismiss, and stays hidden across reloads; the dismiss × renders legibly in all five themes. Pagination (Next/Previous and per-page change) was confirmed to reload the correct page and snap the search bar to the top of the viewport, with no console errors. Screenshots in the PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
