### PR TITLE
Admin portal: fix theme dropdown clipped under member list

### DIFF
--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -168,6 +168,14 @@ body {
 .dh-navbar {
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
+    /* Own stacking context so the navbar's dropdowns (theme/Space/Systems) render
+       above the member-list sticky header. Bootstrap's .sticky-top <thead> is
+       z-index 1020 and .dropdown-menu is only 1000, so without this the open menu
+       gets occluded by the table header once the page shifts up (e.g. logging
+       banner dismissed). 1030 sits above 1020 but below the overlay layers:
+       details-sidebar 1040 < onboarder picker 1050 < toast 1090. */
+    position: relative;
+    z-index: 1030;
 }
 
 .dh-navbar .navbar-brand {


### PR DESCRIPTION
## Problem
Opening the theme switcher dropdown (palette icon, top-right navbar) on the admin home page renders fine normally, but once the "changes get logged" warning banner is dismissed, the lower part of the dropdown menu is hidden behind the member-list table's sticky column-header row.

## Root cause
Dismissing the banner removes ~68px of height, shifting the table up so its header overlaps the open dropdown — exposing a pre-existing z-index conflict. Both elements live in the root stacking context, so their z-index values compete directly:

- Theme dropdown menu = Bootstrap `.dropdown-menu` → `z-index: 1000`
- Member-list sticky header = Bootstrap `.sticky-top` `<thead>` → `z-index: 1020`

`1020 > 1000`, so the sticky header paints over the menu wherever they overlap.

## Fix
Give `.dh-navbar` its own stacking context at `z-index: 1030` — above the 1020 sticky header, below the overlay layers (details-sidebar 1040, onboarder picker 1050, toast 1090). One rule lifts every navbar dropdown (Member/Space/Systems/theme), rather than special-casing the theme menu. No markup or JS changes.

## Testing
Verified in the running admin portal via remote Chrome devtools:
- **Repro fixed:** banner dismissed + theme menu open → full menu (through "Hacker") renders above the column-header row; `elementFromPoint` at the former overlap now resolves inside the menu.
- **Regressions clear:** Space/Systems dropdowns render over the table; the details sidebar (1040) still covers the navbar; no new console errors.
- **Theme sweep:** confirmed in all five themes (bubblegum/light/dark/midnight/hacker).

Before/after screenshots in a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)