### PR TITLE
Admin search: pg_trgm fuzzy, curated fields, name-first ranking

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -705,7 +705,7 @@ def api_members():
                     {
                         "activity_details": {
                             "action": "search",
-                            "query": query,
+                            "query_length": len(query),  # keep raw query (PII) out of the activity log
                             "results_count": result.get("total", 0)
                         }
                     }
@@ -757,7 +757,7 @@ def api_search():
                 {
                     "activity_details": {
                         "action": "search",
-                        "query": query,
+                        "query_length": len(query),  # keep raw query (PII) out of the activity log
                         "results_count": results_count
                     }
                 }

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -32,6 +32,22 @@
 }
 th.dh-status-col { cursor: pointer; }
 
+/* "Matched on" column in the results table (search mode only). Lists each
+   curated field that matched, strongest first; the matched substring is bolded.
+   Long values get a trailing ellipsis with the full "Field: value" in a tooltip.
+   Muting via opacity (not a fixed grey) keeps the label readable in all themes. */
+.dh-match-col { vertical-align: top; }
+.dh-match-line {
+    max-width: 340px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: 0.85rem;
+    line-height: 1.35;
+}
+.dh-match-field { opacity: 0.65; }
+.dh-match-value strong { font-weight: 700; }
+
 /* ===================================================================
    SHARED BASE (theme-neutral — layout, structure, resets)
    =================================================================== */

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -504,6 +504,7 @@ body.sidebar-open .body-content {
     background: none;
     border: none;
     padding: 0;
+    margin-right: 0.35rem;
     font-size: 1.3rem;
     line-height: 1;
     cursor: pointer;

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -4,6 +4,35 @@
    =================================================================== */
 
 /* ===================================================================
+   MEMBERSHIP STATUS PALETTE (base / default = Bubblegum)
+   Per-theme overrides live in each [data-theme="…"] block below.
+   Same hue family across themes; lightness/saturation tuned per bg.
+   =================================================================== */
+:root {
+    --status-active:    #16a34a; /* green */
+    --status-pending:   #2563eb; /* blue */
+    --status-suspended: #d97706; /* amber */
+    --status-banned:    #dc2626; /* red */
+    --status-other:     #6b7280; /* grey — inactive / blank / unknown */
+}
+
+/* Colored status icons — used in the results table and the detail warning */
+.dh-status-icon         { line-height: 1; }
+.dh-status-active       { color: var(--status-active); }
+.dh-status-pending      { color: var(--status-pending); }
+.dh-status-suspended    { color: var(--status-suspended); }
+.dh-status-banned       { color: var(--status-banned); }
+.dh-status-other        { color: var(--status-other); }
+
+/* Narrow, centered status column in the results table */
+.dh-status-col {
+    width: 1%;
+    white-space: nowrap;
+    text-align: center;
+}
+th.dh-status-col { cursor: pointer; }
+
+/* ===================================================================
    SHARED BASE (theme-neutral — layout, structure, resets)
    =================================================================== */
 
@@ -338,12 +367,10 @@ body {
 }
 
 [data-theme="bubblegum"] .dh-member-bar + .dh-suspended-warning {
-    border-left: 4px solid #ff1493;
     border-right: 1px solid #ff69b4;
 }
 
 [data-theme="light"] .dh-member-bar + .dh-suspended-warning {
-    border-left: 4px solid var(--error-color);
     border-right: 1px solid var(--border-color);
 }
 
@@ -550,6 +577,36 @@ body.sidebar-open .body-content {
     padding: 0.05rem 0.3rem;
     border-radius: 0.25rem;
     font-size: 0.82em;
+}
+
+/* Status-column legend popover — themed through Bootstrap's own CSS vars, same
+ * pattern as the search-tips popover (bubblegum falls back to literal colors). */
+.dh-status-legend-popover {
+    --bs-popover-max-width: 240px;
+    --bs-popover-bg: var(--card-bg, #ffffff);
+    --bs-popover-border-color: var(--border-color, #f3afca);
+    --bs-popover-body-color: var(--text-color, #212529);
+    --bs-popover-header-bg: var(--card-bg, #fff0f6);
+    --bs-popover-header-color: var(--primary-color, #d63384);
+}
+.dh-status-legend-popover .popover-header {
+    font-weight: 600;
+    border-bottom-color: var(--border-color, #f3afca);
+}
+.dh-status-legend {
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+.dh-status-legend .dh-sl-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.12rem 0;
+}
+.dh-status-legend .dh-sl-row i {
+    width: 1.1rem;
+    text-align: center;
+    flex-shrink: 0;
 }
 
 /* Sidebar close button */
@@ -852,12 +909,17 @@ body.sidebar-resizing .details-sidebar {
     padding-left: 1.25rem;
 }
 
-/* Suspended member warning */
+/* Non-active member warning — left-border accent driven by status (set as a
+   .dh-status-<key> modifier class in JS); background stays neutral per theme. */
 
 .dh-suspended-warning {
-    border-left: 4px solid #dc2626;
+    border-left: 4px solid var(--status-other);
     border-radius: 6px;
 }
+.dh-suspended-warning.dh-status-pending   { border-left-color: var(--status-pending); }
+.dh-suspended-warning.dh-status-suspended { border-left-color: var(--status-suspended); }
+.dh-suspended-warning.dh-status-banned    { border-left-color: var(--status-banned); }
+.dh-suspended-warning.dh-status-other     { border-left-color: var(--status-other); }
 
 
 /* ===================================================================
@@ -1307,7 +1369,6 @@ body.sidebar-resizing .details-sidebar {
 
 [data-theme="bubblegum"] .dh-suspended-warning {
     background: rgba(255, 255, 255, 0.9);
-    border-left-color: #ff1493;
 }
 
 /* Bubblegum responsive */
@@ -1349,6 +1410,13 @@ body.sidebar-resizing .details-sidebar {
     --card-bg: #ffffff;
     --text-color: #1e293b;
     --border-color: #e2e8f0;
+
+    /* Membership status palette — light bg, same hues as base */
+    --status-active:    #16a34a;
+    --status-pending:   #2563eb;
+    --status-suspended: #d97706;
+    --status-banned:    #dc2626;
+    --status-other:     #6b7280;
 
     /* Bootstrap variable overrides */
     --bs-primary: #2563eb;
@@ -1634,8 +1702,7 @@ body.sidebar-resizing .details-sidebar {
 /* Light suspended warning */
 
 [data-theme="light"] .dh-suspended-warning {
-    background: #fef2f2;
-    border-left-color: var(--error-color);
+    background: var(--card-bg);
 }
 
 /* ===================================================================
@@ -1652,6 +1719,13 @@ body.sidebar-resizing .details-sidebar {
     --card-bg: #18181b;
     --text-color: #e4e4e7;
     --border-color: #27272a;
+
+    /* Membership status palette — lightened for dark bg */
+    --status-active:    #22c55e;
+    --status-pending:   #3b82f6;
+    --status-suspended: #f59e0b;
+    --status-banned:    #f87171;
+    --status-other:     #a1a1aa;
 
     /* Bootstrap variable overrides */
     --bs-primary: #ef4444;
@@ -2140,12 +2214,10 @@ body.sidebar-resizing .details-sidebar {
 /* Dark suspended warning */
 
 [data-theme="dark"] .dh-suspended-warning {
-    background: #1c1117;
-    border-left-color: var(--error-color);
+    background: var(--card-bg);
 }
 
 [data-theme="dark"] .dh-member-bar + .dh-suspended-warning {
-    border-left: 4px solid var(--error-color);
     border-right: 1px solid #3f3f46;
 }
 
@@ -2256,6 +2328,13 @@ body.sidebar-resizing .details-sidebar {
     --card-bg: #0f1629;
     --text-color: #c8d6e5;
     --border-color: #1a2744;
+
+    /* Membership status palette — lightened for deep-navy bg */
+    --status-active:    #22c55e;
+    --status-pending:   #60a5fa;
+    --status-suspended: #fbbf24;
+    --status-banned:    #f87171;
+    --status-other:     #94a3b8;
 
     --bs-primary: #fbbf24;
     --bs-secondary: #8b9dc3;
@@ -2745,12 +2824,10 @@ body.sidebar-resizing .details-sidebar {
 /* Midnight suspended warning */
 
 [data-theme="midnight"] .dh-suspended-warning {
-    background: #180a0a;
-    border-left-color: var(--error-color);
+    background: var(--card-bg);
 }
 
 [data-theme="midnight"] .dh-member-bar + .dh-suspended-warning {
-    border-left: 4px solid var(--error-color);
     border-right: 1px solid #243356;
 }
 
@@ -2935,6 +3012,13 @@ body.sidebar-resizing .details-sidebar {
     --card-bg: #111111;
     --text-color: #00ff41;
     --border-color: #1a3a1a;
+
+    /* Membership status palette — bright variants for green-on-black bg */
+    --status-active:    #00ff41;
+    --status-pending:   #2f81f7;
+    --status-suspended: #ffae00;
+    --status-banned:    #ff3333;
+    --status-other:     #9aa0a6;
 
     --bs-primary: #00ff41;
     --bs-secondary: #00cc33;
@@ -3465,12 +3549,10 @@ body.sidebar-resizing .details-sidebar {
 /* Hacker suspended warning */
 
 [data-theme="hacker"] .dh-suspended-warning {
-    background: #0a0a0a;
-    border-left-color: #ff3333;
+    background: var(--card-bg);
 }
 
 [data-theme="hacker"] .dh-member-bar + .dh-suspended-warning {
-    border-left: 4px solid #ff3333;
     border-right: 1px solid #1a3a1a;
 }
 

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -499,6 +499,58 @@ body.sidebar-open .body-content {
 [data-theme="midnight"] .dh-refresh-btn { color: var(--primary-color); }
 [data-theme="hacker"] .dh-refresh-btn { color: var(--primary-color); }
 
+/* Search-tips info icon (left of the search bar) */
+.dh-search-help-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 1.3rem;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.7;
+    transition: opacity 0.15s ease;
+    flex-shrink: 0;
+    color: inherit;
+}
+.dh-search-help-btn:hover,
+.dh-search-help-btn:focus { opacity: 1; outline: none; }
+[data-theme="bubblegum"] .dh-search-help-btn { color: #d63384; }
+[data-theme="light"] .dh-search-help-btn { color: var(--primary-color); }
+[data-theme="dark"] .dh-search-help-btn { color: var(--primary-color); }
+[data-theme="midnight"] .dh-search-help-btn { color: var(--primary-color); }
+[data-theme="hacker"] .dh-search-help-btn { color: var(--primary-color); }
+
+/* Search-tips popover — themed through Bootstrap's own CSS vars so the arrow,
+ * header, and body all follow the active theme. Fallbacks cover bubblegum
+ * (which styles with literal colors instead of the --*-color custom props). */
+.dh-search-help-popover {
+    --bs-popover-max-width: 320px;
+    --bs-popover-bg: var(--card-bg, #ffffff);
+    --bs-popover-border-color: var(--border-color, #f3afca);
+    --bs-popover-body-color: var(--text-color, #212529);
+    --bs-popover-header-bg: var(--card-bg, #fff0f6);
+    --bs-popover-header-color: var(--primary-color, #d63384);
+}
+.dh-search-help-popover .popover-header {
+    font-weight: 600;
+    border-bottom-color: var(--border-color, #f3afca);
+}
+.dh-search-help .dh-sh-lead { font-weight: 600; margin: 0.5rem 0 0.2rem; }
+.dh-search-help .dh-sh-lead:first-child { margin-top: 0; }
+.dh-search-help .dh-sh-list {
+    margin: 0;
+    padding-left: 1.1rem;
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+.dh-search-help code {
+    background: rgba(125, 125, 125, 0.18);
+    color: inherit;
+    padding: 0.05rem 0.3rem;
+    border-radius: 0.25rem;
+    font-size: 0.82em;
+}
+
 /* Sidebar close button */
 .sidebar-close-btn {
     font-size: 1.5rem;

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -34,12 +34,41 @@
     <div class="col-md-6">
         <div class="mb-3">
             <div class="d-flex gap-2 align-items-center">
+                <button type="button" class="dh-search-help-btn" id="searchHelpBtn" aria-label="Search tips">
+                    <i class="fa-solid fa-circle-info"></i>
+                </button>
                 <div class="input-group">
-                    <input type="search" class="form-control" id="memberSearch" placeholder="Search for a member..." title="Type at least 2 characters. Wrap a term in double quotes for an exact match, e.g. &quot;robert13&quot;" autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" onkeydown="if(event.key==='Enter')searchMembers()">
+                    <input type="search" class="form-control" id="memberSearch" placeholder="Search for a member..." autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" onkeydown="if(event.key==='Enter')searchMembers()">
                     <button class="btn btn-primary cute-signin" type="button" id="searchButton" onclick="searchMembers()" aria-label="Search" title="Search"><i class="fa-solid fa-magnifying-glass"></i></button>
                 </div>
                 <span class="dh-refresh-btn" onclick="loadMembers(currentPage)" title="Refresh results"><i class="fa-solid fa-arrow-rotate-right"></i></span>
             </div>
+            <!-- Hidden content for the search-tips info popover (#searchHelpBtn) -->
+            <template id="searchHelpContent">
+                <div class="dh-search-help">
+                    <p class="dh-sh-lead">Searches across:</p>
+                    <ul class="dh-sh-list">
+                        <li>Name &amp; nickname</li>
+                        <li>Member&nbsp;ID &amp; username</li>
+                        <li>Email address</li>
+                        <li>Discord handle</li>
+                        <li>Phone &amp; RFID tag</li>
+                    </ul>
+                    <p class="dh-sh-lead">How it matches:</p>
+                    <ul class="dh-sh-list">
+                        <li><strong>Partial</strong> — <code>jon</code> finds Jonathan</li>
+                        <li><strong>Typo-tolerant</strong> — <code>smtih</code> finds Smith</li>
+                        <li><strong>Ignores accents</strong> — <code>jose</code> finds José</li>
+                        <li><strong>Any phone format</strong> — <code>(312) 555-0101</code> = <code>3125550101</code></li>
+                        <li><strong>Multi-word, any order</strong></li>
+                    </ul>
+                    <p class="dh-sh-lead">Tricks:</p>
+                    <ul class="dh-sh-list">
+                        <li>Wrap a term in <code>"quotes"</code> for an <strong>exact</strong> match — e.g. <code>"robert13"</code> finds that handle instead of every&nbsp;Robert.</li>
+                        <li>Type at least 2 characters.</li>
+                    </ul>
+                </div>
+            </template>
         </div>
     </div>
 </div>
@@ -1690,6 +1719,24 @@ function restoreFromURL() {
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', restoreFromURL);
+
+// Search-tips info popover: hover to peek, click to pin it open (dismiss by
+// clicking away). Themed per-theme via the .dh-search-help-popover customClass.
+document.addEventListener('DOMContentLoaded', function() {
+    const btn = document.getElementById('searchHelpBtn');
+    const tpl = document.getElementById('searchHelpContent');
+    if (btn && tpl && window.bootstrap && bootstrap.Popover) {
+        new bootstrap.Popover(btn, {
+            html: true,
+            trigger: 'hover focus',
+            placement: 'bottom',
+            container: 'body',
+            customClass: 'dh-search-help-popover',
+            title: 'Search tips',
+            content: () => tpl.innerHTML,
+        });
+    }
+});
 window.addEventListener('popstate', restoreFromURL);
 
 // Special format function for authorizations tab

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -35,8 +35,8 @@
         <div class="mb-3">
             <div class="d-flex gap-2 align-items-center">
                 <div class="input-group">
-                    <input type="text" class="form-control" id="memberSearch" placeholder="Search for a member..." onkeydown="if(event.key==='Enter')searchMembers()">
-                    <button class="btn btn-primary cute-signin" type="button" id="searchButton" onclick="searchMembers()">Search</button>
+                    <input type="search" class="form-control" id="memberSearch" placeholder="Search for a member..." autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" onkeydown="if(event.key==='Enter')searchMembers()">
+                    <button class="btn btn-primary cute-signin" type="button" id="searchButton" onclick="searchMembers()" aria-label="Search" title="Search"><i class="fa-solid fa-magnifying-glass"></i></button>
                 </div>
                 <span class="dh-refresh-btn" onclick="loadMembers(currentPage)" title="Refresh results"><i class="fa-solid fa-arrow-rotate-right"></i></span>
             </div>
@@ -1390,7 +1390,7 @@ function loadMembers(page) {
     // Show loading state on search button
     const searchBtn = document.getElementById('searchButton');
     searchBtn.disabled = true;
-    searchBtn.textContent = 'Loading...';
+    searchBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>';
 
     return fetch(`/api/members?${params.toString()}`)
         .then(response => {
@@ -1412,7 +1412,7 @@ function loadMembers(page) {
         })
         .finally(() => {
             searchBtn.disabled = false;
-            searchBtn.textContent = 'Search';
+            searchBtn.innerHTML = '<i class="fa-solid fa-magnifying-glass"></i>';
         });
 }
 

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -69,6 +69,16 @@
                     </ul>
                 </div>
             </template>
+            <!-- Hidden content for the status-column legend popover (#statusLegendIcon) -->
+            <template id="statusLegendContent">
+                <div class="dh-status-legend">
+                    <div class="dh-sl-row"><i class="fa-solid fa-circle-check dh-status-icon dh-status-active"></i> Active</div>
+                    <div class="dh-sl-row"><i class="fa-solid fa-circle-plus dh-status-icon dh-status-pending"></i> Pending</div>
+                    <div class="dh-sl-row"><i class="fa-solid fa-circle-pause dh-status-icon dh-status-suspended"></i> Suspended</div>
+                    <div class="dh-sl-row"><i class="fa-solid fa-circle-minus dh-status-icon dh-status-banned"></i> Banned</div>
+                    <div class="dh-sl-row"><i class="fa-solid fa-circle-question dh-status-icon dh-status-other"></i> Other</div>
+                </div>
+            </template>
         </div>
     </div>
 </div>
@@ -83,6 +93,10 @@
                 <table class="table table-striped table-hover mb-0">
                     <thead class="sticky-top bg-white">
                         <tr>
+                            <th class="dh-status-col" onclick="sortTable('membership_status')">
+                                <i class="fa-solid fa-circle-half-stroke" id="statusLegendIcon" aria-label="Status"></i>
+                                <span id="sort-membership_status"></span>
+                            </th>
                             <th onclick="sortTable('id')" style="cursor: pointer;">
                                 ID <span id="sort-id"></span>
                             </th>
@@ -91,9 +105,6 @@
                             </th>
                             <th onclick="sortTable('last_name')" style="cursor: pointer;">
                                 Last Name <span id="sort-last_name"></span>
-                            </th>
-                            <th onclick="sortTable('membership_status')" style="cursor: pointer;">
-                                Status <span id="sort-membership_status"></span>
                             </th>
                         </tr>
                     </thead>
@@ -144,7 +155,7 @@
 
             <!-- Suspended member warning (shown dynamically by loadMemberData) -->
             <div id="memberSuspendedWarning" class="alert dh-suspended-warning alert-dismissible fade show mb-0" role="alert" style="display: none;">
-                <i class="fa-solid fa-triangle-exclamation me-2"></i>
+                <i id="memberSuspendedIcon" class="fa-solid fa-triangle-exclamation me-2"></i>
                 <strong>This member is not active.</strong> Status: <span id="memberSuspendedStatus"></span>
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
@@ -1510,6 +1521,43 @@ function updateSortIndicators() {
 
 // Display results table
 
+// Membership-status -> Font Awesome glyph + color class + tooltip label.
+// The className is assembled ONLY from this allowlist; the raw status string is
+// never interpolated into a class name (keeps the XSS-safe rendering posture).
+const STATUS_ICONS = {
+    active:    { icon: 'fa-circle-check',  cls: 'dh-status-active',    label: 'Active' },
+    pending:   { icon: 'fa-circle-plus',   cls: 'dh-status-pending',   label: 'Pending' },
+    suspended: { icon: 'fa-circle-pause',  cls: 'dh-status-suspended', label: 'Suspended' },
+    banned:    { icon: 'fa-circle-minus',  cls: 'dh-status-banned',    label: 'Banned' },
+};
+const STATUS_ICON_DEFAULT = { icon: 'fa-circle-question', cls: 'dh-status-other' };
+
+// Resolve a raw membership_status value to its icon/color/label. Unknown, blank
+// or otherwise-unmapped values (incl. "inactive") fall to the grey question mark;
+// the tooltip then shows the title-cased raw value, or "Unknown" when empty.
+function statusMeta(rawStatus) {
+    const key = (rawStatus || '').toLowerCase().trim();
+    const known = STATUS_ICONS[key];
+    if (known) return { icon: known.icon, cls: known.cls, label: known.label };
+    const label = rawStatus
+        ? rawStatus.charAt(0).toUpperCase() + rawStatus.slice(1)
+        : 'Unknown';
+    return { icon: STATUS_ICON_DEFAULT.icon, cls: STATUS_ICON_DEFAULT.cls, label };
+}
+
+// Build the leftmost status <td> as a colored icon with a hover/aria tooltip.
+function buildStatusCell(rawStatus) {
+    const meta = statusMeta(rawStatus);
+    const td = document.createElement('td');
+    td.className = 'dh-status-col';
+    const icon = document.createElement('i');
+    icon.className = `fa-solid ${meta.icon} fa-lg dh-status-icon ${meta.cls}`;
+    icon.title = meta.label;
+    icon.setAttribute('aria-label', meta.label);
+    td.appendChild(icon);
+    return td;
+}
+
 function displayResults(members) {
     const tbody = document.getElementById('resultsTableBody');
     const resultsSection = document.getElementById('resultsSection');
@@ -1525,12 +1573,13 @@ function displayResults(members) {
             if (selectedMemberId && member.member_id == selectedMemberId) {
                 row.classList.add('selected-row');
             }
+            // Status icon first (allowlist-driven class — safe), then text columns.
+            row.appendChild(buildStatusCell(member.membership_status));
             // Use textContent to prevent XSS from member data
             const cells = [
                 member.member_id,
                 member.first_name || '',
                 member.last_name || '',
-                member.membership_status || '',
             ];
             cells.forEach(text => {
                 const td = document.createElement('td');
@@ -1734,6 +1783,22 @@ document.addEventListener('DOMContentLoaded', function() {
             customClass: 'dh-search-help-popover',
             title: 'Search tips',
             content: () => tpl.innerHTML,
+        });
+    }
+
+    // Status-column header legend: hover the header icon to see the icon/color
+    // key. Header click still sorts (hover-only, never pins).
+    const statusIcon = document.getElementById('statusLegendIcon');
+    const statusTpl = document.getElementById('statusLegendContent');
+    if (statusIcon && statusTpl && window.bootstrap && bootstrap.Popover) {
+        new bootstrap.Popover(statusIcon, {
+            html: true,
+            trigger: 'hover focus',
+            placement: 'bottom',
+            container: 'body',
+            customClass: 'dh-status-legend-popover',
+            title: 'Status',
+            content: () => statusTpl.innerHTML,
         });
     }
 });
@@ -2385,7 +2450,8 @@ function loadMemberData(memberOrId) {
     // Highlight the selected row
     document.querySelectorAll('#resultsTableBody tr.selected-row').forEach(r => r.classList.remove('selected-row'));
     document.querySelectorAll('#resultsTableBody tr').forEach(r => {
-        if (r.cells[0] && r.cells[0].textContent == memberId) {
+        // cells[0] is now the status-icon column; the ID lives in cells[1].
+        if (r.cells[1] && r.cells[1].textContent == memberId) {
             r.classList.add('selected-row');
         }
     });
@@ -2396,13 +2462,23 @@ function loadMemberData(memberOrId) {
     const activatedNotice = document.getElementById('memberActivatedNotice');
     if (activatedNotice) activatedNotice.style.display = 'none';
 
-    // Show suspended/inactive member warning
+    // Show non-active member warning — icon + left-border accent match the
+    // status palette used in the results table.
     const warningEl = document.getElementById('memberSuspendedWarning');
     const statusEl = document.getElementById('memberSuspendedStatus');
+    const warningIconEl = document.getElementById('memberSuspendedIcon');
     if (warningEl && statusEl) {
         const status = member ? (member.membership_status || '').toLowerCase() : '';
         if (status && status !== 'active') {
             statusEl.textContent = member.membership_status;
+            const meta = statusMeta(member.membership_status);
+            // Reset any prior status modifier class, then apply the current one.
+            warningEl.classList.remove('dh-status-pending', 'dh-status-suspended',
+                'dh-status-banned', 'dh-status-other');
+            warningEl.classList.add(meta.cls);
+            if (warningIconEl) {
+                warningIconEl.className = `fa-solid ${meta.icon} me-2 dh-status-icon ${meta.cls}`;
+            }
             warningEl.style.display = '';
             warningEl.classList.add('show');
         } else {

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -1565,15 +1565,26 @@ function buildStatusCell(rawStatus) {
 // data can never inject markup. Fuzzy/typo matches have no literal substring to
 // bold and render plain.
 function appendHighlighted(container, value, query) {
-    const tokens = (query || '')
+    const escapeRe = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');  // regex-escape
+    // Map each query token to a regex fragment. A phone/RFID-style token (digits +
+    // phone punctuation) is matched on its digits with optional non-digit separators
+    // between them, mirroring the backend's digit-normalized phone/RFID matching —
+    // so a query like 3125550101 still highlights inside a stored "(312) 555-0101".
+    const patterns = (query || '')
         .replace(/^"(.*)"$/, '$1')               // strip exact-mode quotes
         .trim()
         .split(/\s+/)
         .filter(t => t.length > 0)
-        .map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));  // regex-escape
-    if (tokens.length === 0) { container.textContent = value; return; }
+        .map(t => {
+            if (/^[0-9()+.\-\s]+$/.test(t)) {
+                const digits = t.replace(/\D/g, '');
+                if (digits.length > 0) return digits.split('').join('[^0-9]*');
+            }
+            return escapeRe(t);
+        });
+    if (patterns.length === 0) { container.textContent = value; return; }
     let re;
-    try { re = new RegExp('(' + tokens.join('|') + ')', 'gi'); }
+    try { re = new RegExp('(' + patterns.join('|') + ')', 'gi'); }
     catch (e) { container.textContent = value; return; }
     let lastIndex = 0, m;
     while ((m = re.exec(value)) !== null) {

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -64,7 +64,7 @@
                     </ul>
                     <p class="dh-sh-lead">Tricks:</p>
                     <ul class="dh-sh-list">
-                        <li>Wrap a term in <code>"quotes"</code> for an <strong>exact</strong> match — e.g. <code>"jordan13"</code> finds that handle instead of every&nbsp;Jordan.</li>
+                        <li>Wrap a term in <code>"quotes"</code> for an <strong>exact</strong> match — e.g. <code>"kai13"</code> finds that handle instead of every&nbsp;Kai.</li>
                         <li>Type at least 2 characters.</li>
                     </ul>
                 </div>
@@ -106,6 +106,8 @@
                             <th onclick="sortTable('last_name')" style="cursor: pointer;">
                                 Last Name <span id="sort-last_name"></span>
                             </th>
+                            <!-- Search-only column; shown/hidden in displayResults() -->
+                            <th id="matchHeader" style="display: none;">Matched on</th>
                         </tr>
                     </thead>
                     <tbody id="resultsTableBody">
@@ -1558,14 +1560,77 @@ function buildStatusCell(rawStatus) {
     return td;
 }
 
+// Append `value` into `container`, bolding any occurrence of a query token.
+// Builds DOM nodes only (text nodes + <strong>) — never innerHTML — so member
+// data can never inject markup. Fuzzy/typo matches have no literal substring to
+// bold and render plain.
+function appendHighlighted(container, value, query) {
+    const tokens = (query || '')
+        .replace(/^"(.*)"$/, '$1')               // strip exact-mode quotes
+        .trim()
+        .split(/\s+/)
+        .filter(t => t.length > 0)
+        .map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));  // regex-escape
+    if (tokens.length === 0) { container.textContent = value; return; }
+    let re;
+    try { re = new RegExp('(' + tokens.join('|') + ')', 'gi'); }
+    catch (e) { container.textContent = value; return; }
+    let lastIndex = 0, m;
+    while ((m = re.exec(value)) !== null) {
+        if (m[0].length === 0) { re.lastIndex++; continue; }  // guard zero-width
+        if (m.index > lastIndex) {
+            container.appendChild(document.createTextNode(value.slice(lastIndex, m.index)));
+        }
+        const strong = document.createElement('strong');
+        strong.textContent = m[0];
+        container.appendChild(strong);
+        lastIndex = m.index + m[0].length;
+    }
+    if (lastIndex < value.length) {
+        container.appendChild(document.createTextNode(value.slice(lastIndex)));
+    }
+}
+
+// Build the search-only "Matched on" <td>: one "Field: value" line per matched
+// field (backend already orders strongest-first), with the matched substring
+// bolded and long values ellipsized (full text in the title tooltip).
+function buildMatchCell(matches, query) {
+    const td = document.createElement('td');
+    td.className = 'dh-match-col';
+    if (!Array.isArray(matches) || matches.length === 0) return td;
+    matches.forEach(item => {
+        const field = (item && item.field) || '';
+        const value = (item && item.value != null) ? String(item.value) : '';
+        const line = document.createElement('div');
+        line.className = 'dh-match-line';
+        line.title = `${field}: ${value}`;
+        const label = document.createElement('span');
+        label.className = 'dh-match-field';
+        label.textContent = field + ': ';
+        const valSpan = document.createElement('span');
+        valSpan.className = 'dh-match-value';
+        appendHighlighted(valSpan, value, query);
+        line.appendChild(label);
+        line.appendChild(valSpan);
+        td.appendChild(line);
+    });
+    return td;
+}
+
 function displayResults(members) {
     const tbody = document.getElementById('resultsTableBody');
     const resultsSection = document.getElementById('resultsSection');
+    const matchHeader = document.getElementById('matchHeader');
+
+    // The "Matched on" column only makes sense for an active search.
+    const searching = !!currentQuery;
+    matchHeader.style.display = searching ? 'table-cell' : 'none';
 
     tbody.innerHTML = '';
 
     if (members.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="4" class="text-center">No members found</td></tr>';
+        const colspan = searching ? 5 : 4;
+        tbody.innerHTML = `<tr><td colspan="${colspan}" class="text-center">No members found</td></tr>`;
     } else {
         members.forEach(member => {
             const row = document.createElement('tr');
@@ -1586,6 +1651,9 @@ function displayResults(members) {
                 td.textContent = text;
                 row.appendChild(td);
             });
+            if (searching) {
+                row.appendChild(buildMatchCell(member.matches, currentQuery));
+            }
             row.onclick = function() {
                 loadMemberData(member);
             };

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -64,7 +64,7 @@
                     </ul>
                     <p class="dh-sh-lead">Tricks:</p>
                     <ul class="dh-sh-list">
-                        <li>Wrap a term in <code>"quotes"</code> for an <strong>exact</strong> match — e.g. <code>"robert13"</code> finds that handle instead of every&nbsp;Robert.</li>
+                        <li>Wrap a term in <code>"quotes"</code> for an <strong>exact</strong> match — e.g. <code>"jordan13"</code> finds that handle instead of every&nbsp;Jordan.</li>
                         <li>Type at least 2 characters.</li>
                     </ul>
                 </div>

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -57,7 +57,7 @@
                     <p class="dh-sh-lead">How it matches:</p>
                     <ul class="dh-sh-list">
                         <li><strong>Partial</strong> — <code>jon</code> finds Jonathan</li>
-                        <li><strong>Typo-tolerant</strong> — <code>smtih</code> finds Smith</li>
+                        <li><strong>Typo-tolerant</strong> — <code>smiht</code> finds Smith</li>
                         <li><strong>Ignores accents</strong> — <code>jose</code> finds José</li>
                         <li><strong>Any phone format</strong> — <code>(312) 555-0101</code> = <code>3125550101</code></li>
                         <li><strong>Multi-word, any order</strong></li>
@@ -1465,7 +1465,11 @@ function loadMembers(page) {
 // "@" / "---" / single chars are rejected). Used to surface a friendly alert
 // instead of letting the server silently return an empty result set.
 function isSearchableQuery(q) {
-    const s = (q || '').trim();
+    let s = (q || '').trim();
+    // Mirror member_search_normalize / _is_searchable_query: surrounding double
+    // quotes (exact mode) are stripped before matching, so measure the inner
+    // term — a quoted single char ('"a"') must not pass the 2-char floor.
+    if (s.length >= 2 && s[0] === '"' && s[s.length - 1] === '"') s = s.slice(1, -1);
     return s.length >= 2 && /[\p{L}\p{N}_]/u.test(s);
 }
 const SEARCH_TOO_SHORT_MSG = 'Please enter at least 2 characters (letters or numbers) to search. Tip: wrap a term in double quotes for an exact match, e.g. "robert13".';

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -35,7 +35,7 @@
         <div class="mb-3">
             <div class="d-flex gap-2 align-items-center">
                 <div class="input-group">
-                    <input type="search" class="form-control" id="memberSearch" placeholder="Search for a member..." autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" onkeydown="if(event.key==='Enter')searchMembers()">
+                    <input type="search" class="form-control" id="memberSearch" placeholder="Search for a member..." title="Type at least 2 characters. Wrap a term in double quotes for an exact match, e.g. &quot;robert13&quot;" autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" onkeydown="if(event.key==='Enter')searchMembers()">
                     <button class="btn btn-primary cute-signin" type="button" id="searchButton" onclick="searchMembers()" aria-label="Search" title="Search"><i class="fa-solid fa-magnifying-glass"></i></button>
                 </div>
                 <span class="dh-refresh-btn" onclick="loadMembers(currentPage)" title="Refresh results"><i class="fa-solid fa-arrow-rotate-right"></i></span>
@@ -1418,6 +1418,16 @@ function loadMembers(page) {
 
 // Search
 
+// Mirrors DHService _is_searchable_query: needs >= 2 chars and at least one
+// word character (unicode-aware, so accent-only queries like "Éé" pass while
+// "@" / "---" / single chars are rejected). Used to surface a friendly alert
+// instead of letting the server silently return an empty result set.
+function isSearchableQuery(q) {
+    const s = (q || '').trim();
+    return s.length >= 2 && /[\p{L}\p{N}_]/u.test(s);
+}
+const SEARCH_TOO_SHORT_MSG = 'Please enter at least 2 characters (letters or numbers) to search. Tip: wrap a term in double quotes for an exact match, e.g. "robert13".';
+
 function searchMembers() {
     const input = document.getElementById('memberSearch').value.trim();
     if (!input && currentQuery) {
@@ -1431,6 +1441,10 @@ function searchMembers() {
     if (!input) {
         // Empty input, no existing query — just reload
         loadMembers(1);
+        return;
+    }
+    if (!isSearchableQuery(input)) {
+        alert(SEARCH_TOO_SHORT_MSG);
         return;
     }
     currentQuery = input;
@@ -3731,6 +3745,10 @@ function confirmRoleAssign(roleId) {
 function searchAssignRoleMembers() {
     const query = document.getElementById('assignRoleMemberSearch').value.trim();
     if (!query) return;
+    if (!isSearchableQuery(query)) {
+        alert(SEARCH_TOO_SHORT_MSG);
+        return;
+    }
 
     fetch(`/api/search?query=${encodeURIComponent(query)}`)
         .then(r => r.json())

--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -492,9 +492,15 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
     total = 0
     with get_db_connection() as conn:
         with conn.cursor() as cur:
+            # Paginate first, then attribute matches only on the returned page:
+            # the SRF is uncapped, so per-field attribution runs on at most
+            # per_page rows rather than the whole result set.
             cur.execute(
-                f"""WITH results AS (
+                f"""WITH base AS (
                         SELECT id,
+                               identity,
+                               connections,
+                               access,
                                identity ->> 'first_name' AS first_name,
                                identity ->> 'last_name' AS last_name,
                                identity -> 'emails' -> 0 ->> 'email_address' AS primary_email_address,
@@ -502,18 +508,31 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
                                status ->> 'stripe_product_id' AS stripe_product_id,
                                rank
                         FROM   search_members_by_identity_and_access(%s)
+                    ),
+                    counted AS (
+                        SELECT *, COUNT(*) OVER() AS total_count FROM base
+                    ),
+                    page AS (
+                        SELECT * FROM counted
+                        ORDER BY {sort_col} {direction}, id ASC
+                        LIMIT  %s OFFSET %s
                     )
-                    SELECT *, COUNT(*) OVER() AS total_count
-                    FROM   results
+                    SELECT id, first_name, last_name, primary_email_address,
+                           membership_status, stripe_product_id, total_count,
+                           ( SELECT jsonb_agg(
+                                        jsonb_build_object('field', match_field, 'value', match_value)
+                                        ORDER BY score DESC)
+                             FROM member_search_matches(%s, id, identity, connections, access)
+                           ) AS matches
+                    FROM   page
                     ORDER BY {sort_col} {direction}, id ASC
-                    LIMIT  %s OFFSET %s
                 """,
-                (query, per_page, offset),
+                (query, per_page, offset, query),
             )
             results = cur.fetchall()
 
     for result in results:
-        total = result[7]
+        total = result[6]
         members.append({
             "member_id": result[0],
             "first_name": result[1],
@@ -521,6 +540,10 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
             "primary_email_address": result[3],
             "membership_status": result[4],
             "stripe_product_id": result[5],
+            # Per-field attribution for the admin "Matched on" column: list of
+            # {field, value} ordered strongest-first, or None when nothing
+            # attributable (e.g. an access-blob-only digit match).
+            "matches": result[7],
         })
 
     logger.debug(f"Paginated search found {len(members)} members (total={total})")

--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -427,6 +427,12 @@ def _is_searchable_query(query: str) -> bool:
     against a short/empty query matching the whole roster.
     """
     q = (query or "").strip()
+    # Mirror member_search_normalize: a query wrapped in double quotes is exact
+    # mode, and the quotes are stripped before matching. Measure the *inner*
+    # term, not the quotes, so a quoted single char ('"a"') doesn't slip past
+    # the 2-char floor and run a 1-char exact-substring search over the roster.
+    if len(q) >= 2 and q[0] == '"' and q[-1] == '"':
+        q = q[1:-1]
     return len(q) >= 2 and re.search(r"\w", q) is not None
 
 def _paginated_response(members: list[dict], total: int, page: int, per_page: int) -> dict:
@@ -464,16 +470,23 @@ def list_members(page: int = 1, per_page: int = 25,
             )
             results = cur.fetchall()
 
-    for result in results:
-        total = result[6]
-        members.append({
-            "member_id": result[0],
-            "first_name": result[1],
-            "last_name": result[2],
-            "primary_email_address": result[3],
-            "membership_status": result[4],
-            "stripe_product_id": result[5],
-        })
+            for result in results:
+                total = result[6]
+                members.append({
+                    "member_id": result[0],
+                    "first_name": result[1],
+                    "last_name": result[2],
+                    "primary_email_address": result[3],
+                    "membership_status": result[4],
+                    "stripe_product_id": result[5],
+                })
+
+            # A past-the-end page returns no rows, so the COUNT(*) OVER() total
+            # never comes back — fetch it directly so the response still reports
+            # the real member count instead of 0.
+            if not results:
+                cur.execute("SELECT COUNT(*) FROM member")
+                total = cur.fetchone()[0]
 
     logger.debug(f"Listed {len(members)} members (total={total})")
     return _paginated_response(members, total, page, per_page)
@@ -495,6 +508,10 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
             # Paginate first, then attribute matches only on the returned page:
             # the SRF is uncapped, so per-field attribution runs on at most
             # per_page rows rather than the whole result set.
+            # `tot` carries the full match count independent of the page, joined
+            # via LEFT JOIN ... ON true so an out-of-range (past-the-end) page
+            # still returns one row bearing the real total (page columns NULL)
+            # instead of zero rows — otherwise `total` reads back as 0.
             cur.execute(
                 f"""WITH base AS (
                         SELECT id,
@@ -509,23 +526,24 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
                                rank
                         FROM   search_members_by_identity_and_access(%s)
                     ),
-                    counted AS (
-                        SELECT *, COUNT(*) OVER() AS total_count FROM base
+                    tot AS (
+                        SELECT COUNT(*) AS total_count FROM base
                     ),
                     page AS (
-                        SELECT * FROM counted
+                        SELECT * FROM base
                         ORDER BY {sort_col} {direction}, id ASC
                         LIMIT  %s OFFSET %s
                     )
-                    SELECT id, first_name, last_name, primary_email_address,
-                           membership_status, stripe_product_id, total_count,
+                    SELECT page.id, page.first_name, page.last_name,
+                           page.primary_email_address, page.membership_status,
+                           page.stripe_product_id, tot.total_count,
                            ( SELECT jsonb_agg(
                                         jsonb_build_object('field', match_field, 'value', match_value)
                                         ORDER BY score DESC)
-                             FROM member_search_matches(%s, id, identity, connections, access)
+                             FROM member_search_matches(%s, page.id, page.identity, page.connections, page.access)
                            ) AS matches
-                    FROM   page
-                    ORDER BY {sort_col} {direction}, id ASC
+                    FROM   tot LEFT JOIN page ON true
+                    ORDER BY {sort_col} {direction}, page.id ASC
                 """,
                 (query, per_page, offset, query),
             )
@@ -533,6 +551,10 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
 
     for result in results:
         total = result[6]
+        # Skip the empty-page sentinel (NULL id) emitted by the tot LEFT JOIN
+        # when the requested page is past the end — its only job is to carry total.
+        if result[0] is None:
+            continue
         members.append({
             "member_id": result[0],
             "first_name": result[1],

--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -1,4 +1,5 @@
 import math
+import re
 import psycopg2
 from contextlib import contextmanager
 import json
@@ -355,19 +356,28 @@ def search_members(query: str) -> list[dict]:
     return members
 
 def search_members_by_identity_and_access(query: str) -> list[dict]:
-    logger.debug(f"Searching members with query: {query}")
+    logger.debug(f"Searching members with query (len={len(query or '')})")
+    # Guard pathological queries (short/punctuation-only) so the non-paginated
+    # consumer (role-assign modal via /api/search) never receives the whole roster.
+    if not _is_searchable_query(query):
+        return []
     members = []
     with get_db_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
+                # The SQL function already orders by its name-first rank; re-state
+                # the order here (a bare SELECT from a SRF does not guarantee it)
+                # with a stable tiebreak, and cap the non-paginated result set.
                 """SELECT id,
                           identity ->> 'first_name' first_name,
                           identity ->> 'last_name' last_name,
                           identity -> 'emails' -> 0 ->> 'email_address' primary_email_address,
                           status ->> 'membership_status' membership_status
                    FROM   search_members_by_identity_and_access(%s)
+                   ORDER BY rank DESC NULLS LAST, id
+                   LIMIT  %s
                 """,
-                (query,),
+                (query, 200),
             )
             results = cur.fetchall()
     for result in results:
@@ -408,6 +418,16 @@ def _validate_sort(sort: str, order: str, allowlist: dict, default_sort: str) ->
     col = allowlist.get(sort, allowlist[default_sort])
     direction = "ASC" if order.lower() == "asc" else "DESC"
     return col, direction
+
+def _is_searchable_query(query: str) -> bool:
+    """Reject pathological search queries (under 2 chars, or no word character).
+
+    `\\w` is unicode-aware, so accented-only queries (e.g. 'Éé') pass while
+    punctuation-only ('@', '---') and single-char queries are rejected. Guards
+    against a short/empty query matching the whole roster.
+    """
+    q = (query or "").strip()
+    return len(q) >= 2 and re.search(r"\w", q) is not None
 
 def _paginated_response(members: list[dict], total: int, page: int, per_page: int) -> dict:
     return {
@@ -460,7 +480,11 @@ def list_members(page: int = 1, per_page: int = 25,
 
 def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
                              sort: str = "rank", order: str = "desc") -> dict:
-    logger.debug(f"Paginated search query={query} page={page} per_page={per_page} sort={sort} order={order}")
+    logger.debug(f"Paginated search query_len={len(query or '')} page={page} per_page={per_page} sort={sort} order={order}")
+    # Guard pathological queries (short/punctuation-only) so they return an empty
+    # page instead of dumping the whole roster.
+    if not _is_searchable_query(query):
+        return _paginated_response([], 0, page, per_page)
     sort_col, direction = _validate_sort(sort, order, _SEARCH_SORT_COLUMNS, "rank")
     offset = (page - 1) * per_page
 
@@ -481,7 +505,7 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
                     )
                     SELECT *, COUNT(*) OVER() AS total_count
                     FROM   results
-                    ORDER BY {sort_col} {direction}
+                    ORDER BY {sort_col} {direction}, id ASC
                     LIMIT  %s OFFSET %s
                 """,
                 (query, per_page, offset),
@@ -774,8 +798,10 @@ def get_member_roles(member_id: str) -> list[str]:
     return roles
 
 def search_onboarder_candidates(query: str, limit: int = 20) -> list[dict]:
-    """Search members by name/username for the onboarder picker.
+    """Search members by name/nickname/username for the onboarder picker.
 
+    Accent-insensitive substring match (via f_unaccent) across first_name,
+    last_name, nickname, and active_directory_username.
     Ranks members holding the `member.forms` change permission first (via any
     role they hold), then alphabetical by last_name, first_name. Returns at
     most `limit` rows. Used by the admin portal Onboard tab and Forms tab
@@ -803,16 +829,17 @@ def search_onboarder_candidates(query: str, limit: int = 20) -> list[dict]:
                 FROM       member m
                 LEFT JOIN  member_to_role mtr ON mtr.member_id = m.id
                 LEFT JOIN  roles r            ON r.id = mtr.role_id
-                WHERE      m.identity ->> 'first_name' ILIKE %s
-                       OR  m.identity ->> 'last_name'  ILIKE %s
-                       OR  m.identity ->> 'active_directory_username' ILIKE %s
+                WHERE      f_unaccent(m.identity ->> 'first_name')                ILIKE f_unaccent(%s)
+                       OR  f_unaccent(m.identity ->> 'last_name')                 ILIKE f_unaccent(%s)
+                       OR  f_unaccent(m.identity ->> 'nickname')                  ILIKE f_unaccent(%s)
+                       OR  f_unaccent(m.identity ->> 'active_directory_username') ILIKE f_unaccent(%s)
                 GROUP BY   m.id
                 ORDER BY   has_forms_change_perm DESC,
                            LOWER(m.identity ->> 'last_name')  ASC NULLS LAST,
                            LOWER(m.identity ->> 'first_name') ASC NULLS LAST
                 LIMIT      %s
                 """,
-                (pattern, pattern, pattern, limit),
+                (pattern, pattern, pattern, pattern, limit),
             )
             rows = cur.fetchall()
     return [

--- a/pg/db-init/init.sql
+++ b/pg/db-init/init.sql
@@ -5,5 +5,10 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
  * which is relevant for tracking member access logs and other time-based events. 
  */
 CREATE EXTENSION IF NOT EXISTS timescaledb;
+/* pg_trgm provides trigram-based fuzzy/substring matching used by the admin-portal
+ * member search (search_members_by_identity_and_access). */
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+/* unaccent provides accent-folding (e.g. José -> Jose) for member search. */
+CREATE EXTENSION IF NOT EXISTS unaccent;
 
 /* Schema is created in the pgsql_schema.sql file */

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -539,9 +539,56 @@ $body$ LANGUAGE plpgsql;
 COMMENT ON FUNCTION search_members_by_identity(text) IS 'Performs full text search on the identity JSONB column of member records and returns results ranked by relevance.';
 
 /*
+ * IMMUTABLE wrapper around unaccent(). The stock unaccent() is only STABLE
+ * (it depends on a dictionary that could change), so it cannot be used inside
+ * another IMMUTABLE function. The 2-arg form pins the dictionary explicitly.
+ * Used by member search for accent-folding (e.g. José -> jose).
+ */
+CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT unaccent('unaccent', $1) $$;
+
+/*
+ * Builds the curated, accent-folded, lowercased searchable text blob for a
+ * member from an allowlist of identity/connections/access keys. Curated
+ * extraction (not whole-JSON-as-text) keeps JSON key names and internal IDs
+ * (Stripe, WildApricot) out of the searchable text. Phone is normalized to
+ * digits-only so any entry format collapses to a uniform digit string.
+ */
+CREATE OR REPLACE FUNCTION member_search_text(p_identity jsonb, p_connections jsonb, p_access jsonb)
+RETURNS text AS $$
+    SELECT lower(f_unaccent(concat_ws(' ',
+        p_identity ->> 'first_name',
+        p_identity ->> 'last_name',
+        p_identity ->> 'nickname',
+        p_identity ->> 'member_id',
+        p_identity ->> 'active_directory_username',
+        ( SELECT string_agg(e ->> 'email_address', ' ')
+          FROM jsonb_array_elements(
+                 CASE WHEN jsonb_typeof(p_identity -> 'emails') = 'array'
+                      THEN p_identity -> 'emails' ELSE '[]'::jsonb END) AS e ),
+        p_connections ->> 'discord_handle',
+        nullif(regexp_replace(coalesce(p_connections ->> 'phone', ''), '\D', '', 'g'), ''),
+        ( SELECT string_agg(t, ' ')
+          FROM jsonb_array_elements_text(
+                 CASE WHEN jsonb_typeof(p_access -> 'rfid_tags') = 'array'
+                      THEN p_access -> 'rfid_tags' ELSE '[]'::jsonb END) AS t )
+    )));
+$$ LANGUAGE sql IMMUTABLE;
+
+/*
  * This function is used for searching members by identity and access
  * (e.g., RFID tags) and returning full member records. This is used in
- * the admin portal so that an admin can search for a member by name or RFID tag
+ * the admin portal so that an admin can search for a member by name or RFID tag.
+ *
+ * Matching (pg_trgm + curated blob, accent-folded):
+ *   (a) every whitespace token must appear as a substring of the blob
+ *       (order-independent multi-word); phone-like tokens are digit-normalized
+ *       so dashed/parenthesized phone queries match the digits-only stored phone;
+ *   (b) word_similarity >= 0.4 adds typo tolerance (jon -> John);
+ *   (c) a digits-only query also matches RFID tags w/ or w/o leading zeros.
+ * Ranking is name-first: first/last/nickname matches are weighted 2x over the
+ * full-blob similarity.
  */
 CREATE OR REPLACE FUNCTION search_members_by_identity_and_access(search_query text)
 RETURNS TABLE (
@@ -555,9 +602,11 @@ RETURNS TABLE (
     notes jsonb,
     rank real
 ) AS $body$
+DECLARE
+    q text := lower(f_unaccent(trim(search_query)));
 BEGIN
     RETURN QUERY
-    SELECT 
+    SELECT
         m.id,
         m.identity,
         m.connections,
@@ -566,27 +615,34 @@ BEGIN
         m.authorizations,
         m.extras,
         m.notes,
-        ts_rank(
-            (
-                to_tsvector('english', COALESCE(jsonb_to_tsvector('english', m.identity, '["all"]')::text, '')) ||
-                to_tsvector('english', COALESCE(jsonb_to_tsvector('english', m.access, '["all"]')::text, ''))
-            ),
-            plainto_tsquery('english', search_query)
-        ) AS rank
+        (   -- name-first: weight name-field matches 2x over the full-blob match
+            2.0 * word_similarity(q, lower(f_unaccent(concat_ws(' ',
+                      m.identity ->> 'first_name', m.identity ->> 'last_name', m.identity ->> 'nickname'))))
+            + word_similarity(q, member_search_text(m.identity, m.connections, m.access))
+        )::real AS rank
     FROM member m
-    WHERE 
-        -- Full-text search on identity and access
+    WHERE
         (
-            to_tsvector('english', COALESCE(jsonb_to_tsvector('english', m.identity, '["all"]')::text, '')) ||
-            to_tsvector('english', COALESCE(jsonb_to_tsvector('english', m.access, '["all"]')::text, ''))
-        ) @@ plainto_tsquery('english', search_query)
-        OR
-        -- Pattern matching for numeric searches (handles RFID tags with/without leading zeros)
-        (search_query ~ '^[0-9]+$' AND m.access::text ILIKE '%' || search_query || '%')
-    ORDER BY rank DESC;
+            -- (a) every query token must be a substring of the blob (phone-like tokens digit-normalized)
+            NOT EXISTS (
+                SELECT 1 FROM regexp_split_to_table(q, '\s+') tok
+                WHERE tok <> ''
+                  AND member_search_text(m.identity, m.connections, m.access)
+                      NOT ILIKE '%' ||
+                          CASE WHEN tok ~ '^[0-9()+.\- ]+$'
+                               THEN regexp_replace(tok, '\D', '', 'g')
+                               ELSE tok END
+                      || '%'
+            )
+            -- (b) typo tolerance
+            OR word_similarity(q, member_search_text(m.identity, m.connections, m.access)) >= 0.4
+        )
+        -- (c) numeric RFID fallback (handles tags with/without leading zeros)
+        OR (search_query ~ '^[0-9]+$' AND m.access::text ILIKE '%' || search_query || '%')
+    ORDER BY rank DESC NULLS LAST;
 END;
 $body$ LANGUAGE plpgsql;
-COMMENT ON FUNCTION search_members_by_identity_and_access(text) IS 'Performs full text search on the identity and access JSONB columns of member records and returns results ranked by relevance.';
+COMMENT ON FUNCTION search_members_by_identity_and_access(text) IS 'Curated, accent-folded pg_trgm search over allowlisted identity/connections/access keys (names, nickname, member_id, AD username, emails, Discord, phone, RFID). Substring + word_similarity typo tolerance, ranked name-first.';
 
 /*
  * Function that returns full member records based on identity search

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -559,120 +559,163 @@ LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$ SELECT replace(replace(replace($1, '\', '\\'), '%', '\%'), '_', '\_') $$;
 
 /*
- * Builds the curated, accent-folded, lowercased searchable text blob for a
- * member from an allowlist of identity/connections/access keys. Curated
- * extraction (not whole-JSON-as-text) keeps JSON key names and internal IDs
- * (Stripe, WildApricot) out of the searchable text. Phone is normalized to
- * digits-only so any entry format collapses to a uniform digit string.
+ * Parse a raw member-search query into its normalized parts — the single source
+ * of truth for "how a query is interpreted", shared by both the search function
+ * and member_search_matches so the two can never drift on quote-parsing.
+ * A query wrapped in double quotes ("robert13") flips to exact mode: the quotes
+ * are stripped and only literal-substring matches apply.
+ *   q_in  = trimmed input, surrounding quotes stripped in exact mode
+ *   exact = whether the query was quoted
+ *   q     = accent-folded, lowercased q_in (the value actually matched against)
+ */
+CREATE OR REPLACE FUNCTION member_search_normalize(search_query text)
+RETURNS TABLE(q_in text, exact boolean, q text) AS $$
+    SELECT qi, ex, lower(f_unaccent(qi))
+    FROM (
+        SELECT
+            CASE WHEN btrim(search_query) ~ '^".*"$' AND length(btrim(search_query)) >= 2
+                 THEN substring(btrim(search_query) FROM 2 FOR length(btrim(search_query)) - 2)
+                 ELSE btrim(search_query) END AS qi,
+            (btrim(search_query) ~ '^".*"$' AND length(btrim(search_query)) >= 2) AS ex
+    ) s;
+$$ LANGUAGE sql IMMUTABLE;
+
+/*
+ * THE curated, searchable member field allowlist — the single place that
+ * decides which fields member search covers. Both member_search_text (the blob)
+ * and member_search_matches (per-field "Matched on" attribution) derive from
+ * this, so adding/removing a searchable field is a one-place edit and the two
+ * can never disagree about which fields are searchable.
  *
- * NOTE: the legacy Wild Apricot id (identity ->> 'member_id') is intentionally
- * NOT searched here — it is the predecessor platform's number, not the DB id an
- * admin sees in the results list. The displayed DB id (member.id) is matched
+ * Internal IDs (Stripe, the legacy Wild Apricot identity.member_id) and JSON key
+ * names are deliberately excluded — the displayed DB id (member.id) is matched
  * exactly and separately in search_members_by_identity_and_access().
+ * `numeric_field` marks phone/RFID, whose values are matched digit-normalized.
+ * `priority` orders fields for tie-break / name-first nudging (lower = stronger)
+ * AND fixes the blob field order in member_search_text — kept sequential so the
+ * blob matches the pre-refactor concat order exactly (no fuzzy-rank drift).
+ */
+CREATE OR REPLACE FUNCTION member_search_candidates(
+    p_identity jsonb, p_connections jsonb, p_access jsonb)
+RETURNS TABLE(label text, value text, priority int, numeric_field boolean) AS $$
+    VALUES
+        ('First name',  p_identity ->> 'first_name',                1, false),
+        ('Last name',   p_identity ->> 'last_name',                 2, false),
+        ('Nickname',    p_identity ->> 'nickname',                  3, false),
+        ('AD username', p_identity ->> 'active_directory_username', 4, false),
+        ('Discord',     p_connections ->> 'discord_handle',         6, false),
+        ('Phone',       p_connections ->> 'phone',                  7, true)
+    UNION ALL
+    SELECT 'Email', e ->> 'email_address', 5, false
+      FROM jsonb_array_elements(
+             CASE WHEN jsonb_typeof(p_identity -> 'emails') = 'array'
+                  THEN p_identity -> 'emails' ELSE '[]'::jsonb END) AS e
+    UNION ALL
+    SELECT 'RFID tag', t, 8, true
+      FROM jsonb_array_elements_text(
+             CASE WHEN jsonb_typeof(p_access -> 'rfid_tags') = 'array'
+                  THEN p_access -> 'rfid_tags' ELSE '[]'::jsonb END) AS t;
+$$ LANGUAGE sql IMMUTABLE;
+
+/*
+ * Does `token` match `value` under the member-search rules: accent-folded,
+ * lowercased, LIKE-escaped substring; numeric values additionally match
+ * digit-normalized (a dashed/parenthesized phone token hits a digits-only stored
+ * phone, and vice-versa). The single per-field/per-token match primitive — used
+ * by member_search_matches so its predicates can't drift field to field.
+ */
+CREATE OR REPLACE FUNCTION member_token_in_value(value text, token text, is_numeric boolean)
+RETURNS boolean AS $$
+    SELECT
+        lower(f_unaccent(value)) LIKE '%' || like_escape(lower(f_unaccent(token))) || '%'
+        OR ( is_numeric
+             AND nullif(regexp_replace(token, '\D', '', 'g'), '') IS NOT NULL
+             AND regexp_replace(value, '\D', '', 'g')
+                 LIKE '%' || regexp_replace(token, '\D', '', 'g') || '%' );
+$$ LANGUAGE sql IMMUTABLE;
+
+/*
+ * Builds the curated, accent-folded, lowercased searchable text blob for a
+ * member by concatenating the member_search_candidates() allowlist (numeric
+ * fields digit-normalized, fields space-separated to preserve token boundaries).
+ * Sourcing from the shared allowlist keeps the blob and the per-field attribution
+ * in lockstep. JSON key names and internal IDs never enter the blob.
  */
 CREATE OR REPLACE FUNCTION member_search_text(p_identity jsonb, p_connections jsonb, p_access jsonb)
 RETURNS text AS $$
-    SELECT lower(f_unaccent(concat_ws(' ',
-        p_identity ->> 'first_name',
-        p_identity ->> 'last_name',
-        p_identity ->> 'nickname',
-        p_identity ->> 'active_directory_username',
-        ( SELECT string_agg(e ->> 'email_address', ' ')
-          FROM jsonb_array_elements(
-                 CASE WHEN jsonb_typeof(p_identity -> 'emails') = 'array'
-                      THEN p_identity -> 'emails' ELSE '[]'::jsonb END) AS e ),
-        p_connections ->> 'discord_handle',
-        nullif(regexp_replace(coalesce(p_connections ->> 'phone', ''), '\D', '', 'g'), ''),
-        ( SELECT string_agg(t, ' ')
-          FROM jsonb_array_elements_text(
-                 CASE WHEN jsonb_typeof(p_access -> 'rfid_tags') = 'array'
-                      THEN p_access -> 'rfid_tags' ELSE '[]'::jsonb END) AS t )
-    )));
+    SELECT lower(f_unaccent(string_agg(
+               CASE WHEN numeric_field
+                    THEN nullif(regexp_replace(value, '\D', '', 'g'), '')
+                    ELSE value END,
+               ' ' ORDER BY priority)))
+    FROM member_search_candidates(p_identity, p_connections, p_access)
+    WHERE value IS NOT NULL AND value <> '';
 $$ LANGUAGE sql IMMUTABLE;
 
 /*
  * Per-field match attribution for the admin results list's "Matched on" column.
  * Given a query and a member's id + curated JSONB, returns one row per curated
- * field whose value matched the query, using the SAME predicates as
- * search_members_by_identity_and_access (accent-folded per-token substring with
- * digit-normalization for phone/RFID, plus word_similarity >= 0.4 typo
- * tolerance, plus exact DB-id). The raw (un-normalized) value is returned for
+ * field whose value matched the query. Shares the field allowlist
+ * (member_search_candidates), the query parse (member_search_normalize) and the
+ * per-token predicate (member_token_in_value) with the search function, so
+ * attribution can't drift from what actually matched. Typo tolerance
+ * (word_similarity >= 0.4) applies to NON-numeric fields only — two unrelated
+ * phone/RFID digit strings can be trigram-similar enough to attribute a field
+ * the query is not visibly in. The raw (un-normalized) value is returned for
  * display. `score` tiers exact/substring matches above fuzzy ones, with a small
  * name-first nudge, so callers ORDER BY score DESC for "strongest match first".
  *
- * Mirrors member_search_text's curated allowlist; the legacy Wild Apricot
- * identity.member_id is intentionally NOT attributed (only the DB id, p_id).
+ * The legacy Wild Apricot identity.member_id is intentionally NOT attributed
+ * (only the DB id, p_id).
  */
 CREATE OR REPLACE FUNCTION member_search_matches(
     search_query text, p_id integer,
     p_identity jsonb, p_connections jsonb, p_access jsonb)
 RETURNS TABLE(match_field text, match_value text, score real) AS $matches$
-    WITH norm AS (
-        SELECT
-            CASE WHEN btrim(search_query) ~ '^".*"$' AND length(btrim(search_query)) >= 2
-                 THEN substring(btrim(search_query) FROM 2 FOR length(btrim(search_query)) - 2)
-                 ELSE btrim(search_query) END AS q_in,
-            (btrim(search_query) ~ '^".*"$' AND length(btrim(search_query)) >= 2) AS exact
-    ),
-    n AS (
-        SELECT q_in, exact, lower(f_unaccent(q_in)) AS q FROM norm
-    ),
-    candidates(label, value, priority, numeric_field) AS (
-        VALUES
-            ('First name',  p_identity ->> 'first_name',                1, false),
-            ('Last name',   p_identity ->> 'last_name',                 2, false),
-            ('Nickname',    p_identity ->> 'nickname',                  3, false),
-            ('AD username', p_identity ->> 'active_directory_username', 6, false),
-            ('Discord',     p_connections ->> 'discord_handle',         7, false),
-            ('Phone',       p_connections ->> 'phone',                  8, true)
-        UNION ALL
-        SELECT 'Email', e ->> 'email_address', 5, false
-          FROM jsonb_array_elements(
-                 CASE WHEN jsonb_typeof(p_identity -> 'emails') = 'array'
-                      THEN p_identity -> 'emails' ELSE '[]'::jsonb END) AS e
-        UNION ALL
-        SELECT 'RFID tag', t, 9, true
-          FROM jsonb_array_elements_text(
-                 CASE WHEN jsonb_typeof(p_access -> 'rfid_tags') = 'array'
-                      THEN p_access -> 'rfid_tags' ELSE '[]'::jsonb END) AS t
+    WITH n AS (
+        SELECT q_in, exact, q FROM member_search_normalize(search_query)
     )
-    -- (1) exact DB-id match (priority 4) — always the strongest signal.
+    -- (1) exact DB-id match — always the strongest signal.
+    --     The ::int cast is gated inside a CASE (not sibling ANDed quals) so the
+    --     digit/length guards always run BEFORE the cast — Postgres is free to
+    --     reorder top-level WHERE quals, and an ungated cast would raise
+    --     "invalid input syntax for integer" / overflow on a non-numeric or
+    --     10+-digit query (this fn runs per result row, so that would 500 search).
     SELECT 'Member ID'::text, p_id::text, 100::real
     FROM n
-    WHERE p_id IS NOT NULL AND n.q_in ~ '^[0-9]+$' AND length(n.q_in) <= 9 AND p_id = n.q_in::int
+    WHERE p_id IS NOT NULL
+      AND p_id = CASE WHEN n.q_in ~ '^[0-9]+$' AND length(n.q_in) <= 9
+                      THEN n.q_in::int END
 
     UNION ALL
 
-    -- (2) curated-field matches, mirroring the search predicates per field.
+    -- (2) curated-field matches, sharing member_token_in_value with the search
+    --     predicate so attribution can't drift from what actually matched.
     SELECT c.label, c.value,
            ( CASE WHEN sm.substr_match
                   THEN 1.0 + word_similarity(n.q, lower(f_unaccent(c.value)))
                   ELSE word_similarity(n.q, lower(f_unaccent(c.value))) END
              + (10 - c.priority) * 0.001 )::real AS score
-    FROM candidates c
+    FROM member_search_candidates(p_identity, p_connections, p_access) c
     CROSS JOIN n
     CROSS JOIN LATERAL (
         SELECT CASE WHEN n.exact THEN
-                   lower(f_unaccent(c.value)) LIKE '%' || like_escape(n.q) || '%'
-                   OR ( c.numeric_field
-                        AND nullif(regexp_replace(n.q, '\D', '', 'g'), '') IS NOT NULL
-                        AND regexp_replace(c.value, '\D', '', 'g')
-                            LIKE '%' || regexp_replace(n.q, '\D', '', 'g') || '%' )
+                   member_token_in_value(c.value, n.q, c.numeric_field)
                ELSE
                    EXISTS (
                        SELECT 1 FROM regexp_split_to_table(n.q, '\s+') tok
                        WHERE tok <> ''
-                         AND ( lower(f_unaccent(c.value)) LIKE '%' || like_escape(tok) || '%'
-                               OR ( c.numeric_field
-                                    AND nullif(regexp_replace(tok, '\D', '', 'g'), '') IS NOT NULL
-                                    AND regexp_replace(c.value, '\D', '', 'g')
-                                        LIKE '%' || regexp_replace(tok, '\D', '', 'g') || '%' ) )
+                         AND member_token_in_value(c.value, tok, c.numeric_field)
                    )
                END
     ) sm(substr_match)
     WHERE c.value IS NOT NULL AND c.value <> ''
       AND ( sm.substr_match
-            OR word_similarity(n.q, lower(f_unaccent(c.value))) >= 0.4 )
+            -- Typo tolerance only for NON-numeric fields: two unrelated phone/RFID
+            -- digit strings can be >= 0.4 trigram-similar, which would attribute a
+            -- field whose value the query is not visibly in (unbolded noise row).
+            OR ( NOT c.numeric_field
+                 AND word_similarity(n.q, lower(f_unaccent(c.value))) >= 0.4 ) )
     ORDER BY 3 DESC;
 $matches$ LANGUAGE sql STABLE;
 COMMENT ON FUNCTION member_search_matches(text, integer, jsonb, jsonb, jsonb) IS 'Per-field match attribution for the admin "Matched on" column. Returns (field label, raw value, score) for each curated field that matched, mirroring search_members_by_identity_and_access predicates. Order by score DESC for strongest-first.';
@@ -711,18 +754,14 @@ RETURNS TABLE (
     rank real
 ) AS $body$
 DECLARE
-    -- Trimmed raw input. A query wrapped in double quotes ("robert13") flips to
-    -- exact mode: the quotes are stripped and only literal-substring matches are
-    -- returned (no typo tolerance / no RFID fallback).
-    q_in  text := trim(search_query);
-    exact boolean := false;
+    -- Query parsing (quote-strip / exact mode / accent-fold) is delegated to the
+    -- shared member_search_normalize() so it can't drift from member_search_matches.
+    q_in  text;
+    exact boolean;
     q     text;
 BEGIN
-    IF q_in ~ '^".*"$' AND length(q_in) >= 2 THEN
-        exact := true;
-        q_in  := substring(q_in FROM 2 FOR length(q_in) - 2);
-    END IF;
-    q := lower(f_unaccent(q_in));
+    SELECT n.q_in, n.exact, n.q INTO q_in, exact, q
+    FROM member_search_normalize(search_query) n;
 
     RETURN QUERY
     SELECT
@@ -737,20 +776,31 @@ BEGIN
         (   -- name-first: weight name-field matches 2x over the full-blob match
             2.0 * word_similarity(q, lower(f_unaccent(concat_ws(' ',
                       m.identity ->> 'first_name', m.identity ->> 'last_name', m.identity ->> 'nickname'))))
-            + word_similarity(q, member_search_text(m.identity, m.connections, m.access))
+            + word_similarity(q, msb.blob)
             -- An all-digit query equal to the displayed DB id (member.id) floats that
             -- member to the very top while other fuzzy digit matches still appear below.
             + CASE WHEN q_in ~ '^[0-9]+$' AND length(q_in) <= 9 AND m.id = q_in::int
                    THEN 100 ELSE 0 END
         )::real AS rank
     FROM member m
+    -- Compute the curated blob ONCE per row. The OFFSET 0 fences the lateral
+    -- subquery from being pulled up / inlined, so member_search_text (which does
+    -- concat_ws + two correlated subqueries + f_unaccent) runs once instead of
+    -- once per reference below (rank + exact + per-token + typo).
+    CROSS JOIN LATERAL (
+        SELECT member_search_text(m.identity, m.connections, m.access) AS blob
+        OFFSET 0
+    ) msb
     WHERE
         (
             CASE WHEN exact THEN
                 -- Exact mode: the accent-folded, lowercased phrase must appear
-                -- verbatim as a substring of the blob. Wildcards escaped.
-                member_search_text(m.identity, m.connections, m.access)
-                    ILIKE '%' || like_escape(q) || '%'
+                -- verbatim as a substring of the blob (wildcards escaped) — OR, for
+                -- a digit-bearing query, its digit-normalized form, so a quoted
+                -- formatted phone/RFID matches the digits-only stored value.
+                msb.blob ILIKE '%' || like_escape(q) || '%'
+                OR ( nullif(regexp_replace(q, '\D', '', 'g'), '') IS NOT NULL
+                     AND msb.blob ILIKE '%' || regexp_replace(q, '\D', '', 'g') || '%' )
             ELSE
                 (
                     -- (a) every query token must be a substring of the blob (phone-like tokens digit-normalized).
@@ -758,7 +808,7 @@ BEGIN
                     NOT EXISTS (
                         SELECT 1 FROM regexp_split_to_table(q, '\s+') tok
                         WHERE tok <> ''
-                          AND member_search_text(m.identity, m.connections, m.access)
+                          AND msb.blob
                               NOT ILIKE '%' ||
                                   like_escape(CASE WHEN tok ~ '^[0-9()+.\- ]+$'
                                                    THEN regexp_replace(tok, '\D', '', 'g')
@@ -766,7 +816,7 @@ BEGIN
                               || '%'
                     )
                     -- (b) typo tolerance
-                    OR word_similarity(q, member_search_text(m.identity, m.connections, m.access)) >= 0.4
+                    OR word_similarity(q, msb.blob) >= 0.4
                 )
                 -- (c) numeric RFID fallback (handles tags with/without leading zeros); use the
                 --     trimmed input so whitespace-padded digit queries still take this path.

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -549,6 +549,16 @@ LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$ SELECT unaccent('unaccent', $1) $$;
 
 /*
+ * Escapes LIKE/ILIKE wildcard metacharacters (\, %, _) so user-supplied search
+ * text is matched literally and a typed `%` or `_` doesn't silently become a
+ * wildcard. Mirrors the Python-side escaping in search_onboarder_candidates
+ * (DHService db.py). Relies on the default LIKE escape character (\).
+ */
+CREATE OR REPLACE FUNCTION like_escape(text) RETURNS text
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT replace(replace(replace($1, '\', '\\'), '%', '\%'), '_', '\_') $$;
+
+/*
  * Builds the curated, accent-folded, lowercased searchable text blob for a
  * member from an allowlist of identity/connections/access keys. Curated
  * extraction (not whole-JSON-as-text) keeps JSON key names and internal IDs
@@ -589,6 +599,11 @@ $$ LANGUAGE sql IMMUTABLE;
  *   (c) a digits-only query also matches RFID tags w/ or w/o leading zeros.
  * Ranking is name-first: first/last/nickname matches are weighted 2x over the
  * full-blob similarity.
+ *
+ * Exact mode: a query wrapped in double quotes (e.g. "robert13") strips the
+ * quotes and matches the phrase as a literal substring of the blob only — no
+ * typo tolerance and no RFID fallback. Use it to pin an exact handle/email/name
+ * that the fuzzy ranking would otherwise bury under near-matches.
  */
 CREATE OR REPLACE FUNCTION search_members_by_identity_and_access(search_query text)
 RETURNS TABLE (
@@ -603,8 +618,19 @@ RETURNS TABLE (
     rank real
 ) AS $body$
 DECLARE
-    q text := lower(f_unaccent(trim(search_query)));
+    -- Trimmed raw input. A query wrapped in double quotes ("robert13") flips to
+    -- exact mode: the quotes are stripped and only literal-substring matches are
+    -- returned (no typo tolerance / no RFID fallback).
+    q_in  text := trim(search_query);
+    exact boolean := false;
+    q     text;
 BEGIN
+    IF q_in ~ '^".*"$' AND length(q_in) >= 2 THEN
+        exact := true;
+        q_in  := substring(q_in FROM 2 FOR length(q_in) - 2);
+    END IF;
+    q := lower(f_unaccent(q_in));
+
     RETURN QUERY
     SELECT
         m.id,
@@ -622,23 +648,32 @@ BEGIN
         )::real AS rank
     FROM member m
     WHERE
-        (
-            -- (a) every query token must be a substring of the blob (phone-like tokens digit-normalized)
-            NOT EXISTS (
-                SELECT 1 FROM regexp_split_to_table(q, '\s+') tok
-                WHERE tok <> ''
-                  AND member_search_text(m.identity, m.connections, m.access)
-                      NOT ILIKE '%' ||
-                          CASE WHEN tok ~ '^[0-9()+.\- ]+$'
-                               THEN regexp_replace(tok, '\D', '', 'g')
-                               ELSE tok END
-                      || '%'
+        CASE WHEN exact THEN
+            -- Exact mode: the accent-folded, lowercased phrase must appear
+            -- verbatim as a substring of the blob. Wildcards escaped.
+            member_search_text(m.identity, m.connections, m.access)
+                ILIKE '%' || like_escape(q) || '%'
+        ELSE
+            (
+                -- (a) every query token must be a substring of the blob (phone-like tokens digit-normalized).
+                --     User-supplied tokens are wildcard-escaped so a typed % or _ matches literally.
+                NOT EXISTS (
+                    SELECT 1 FROM regexp_split_to_table(q, '\s+') tok
+                    WHERE tok <> ''
+                      AND member_search_text(m.identity, m.connections, m.access)
+                          NOT ILIKE '%' ||
+                              like_escape(CASE WHEN tok ~ '^[0-9()+.\- ]+$'
+                                               THEN regexp_replace(tok, '\D', '', 'g')
+                                               ELSE tok END)
+                          || '%'
+                )
+                -- (b) typo tolerance
+                OR word_similarity(q, member_search_text(m.identity, m.connections, m.access)) >= 0.4
             )
-            -- (b) typo tolerance
-            OR word_similarity(q, member_search_text(m.identity, m.connections, m.access)) >= 0.4
-        )
-        -- (c) numeric RFID fallback (handles tags with/without leading zeros)
-        OR (search_query ~ '^[0-9]+$' AND m.access::text ILIKE '%' || search_query || '%')
+            -- (c) numeric RFID fallback (handles tags with/without leading zeros); use the
+            --     trimmed input so whitespace-padded digit queries still take this path.
+            OR (q_in ~ '^[0-9]+$' AND m.access::text ILIKE '%' || q_in || '%')
+        END
     ORDER BY rank DESC NULLS LAST;
 END;
 $body$ LANGUAGE plpgsql;

--- a/pg/sql/pgsql_schema.sql
+++ b/pg/sql/pgsql_schema.sql
@@ -564,6 +564,11 @@ AS $$ SELECT replace(replace(replace($1, '\', '\\'), '%', '\%'), '_', '\_') $$;
  * extraction (not whole-JSON-as-text) keeps JSON key names and internal IDs
  * (Stripe, WildApricot) out of the searchable text. Phone is normalized to
  * digits-only so any entry format collapses to a uniform digit string.
+ *
+ * NOTE: the legacy Wild Apricot id (identity ->> 'member_id') is intentionally
+ * NOT searched here — it is the predecessor platform's number, not the DB id an
+ * admin sees in the results list. The displayed DB id (member.id) is matched
+ * exactly and separately in search_members_by_identity_and_access().
  */
 CREATE OR REPLACE FUNCTION member_search_text(p_identity jsonb, p_connections jsonb, p_access jsonb)
 RETURNS text AS $$
@@ -571,7 +576,6 @@ RETURNS text AS $$
         p_identity ->> 'first_name',
         p_identity ->> 'last_name',
         p_identity ->> 'nickname',
-        p_identity ->> 'member_id',
         p_identity ->> 'active_directory_username',
         ( SELECT string_agg(e ->> 'email_address', ' ')
           FROM jsonb_array_elements(
@@ -587,6 +591,93 @@ RETURNS text AS $$
 $$ LANGUAGE sql IMMUTABLE;
 
 /*
+ * Per-field match attribution for the admin results list's "Matched on" column.
+ * Given a query and a member's id + curated JSONB, returns one row per curated
+ * field whose value matched the query, using the SAME predicates as
+ * search_members_by_identity_and_access (accent-folded per-token substring with
+ * digit-normalization for phone/RFID, plus word_similarity >= 0.4 typo
+ * tolerance, plus exact DB-id). The raw (un-normalized) value is returned for
+ * display. `score` tiers exact/substring matches above fuzzy ones, with a small
+ * name-first nudge, so callers ORDER BY score DESC for "strongest match first".
+ *
+ * Mirrors member_search_text's curated allowlist; the legacy Wild Apricot
+ * identity.member_id is intentionally NOT attributed (only the DB id, p_id).
+ */
+CREATE OR REPLACE FUNCTION member_search_matches(
+    search_query text, p_id integer,
+    p_identity jsonb, p_connections jsonb, p_access jsonb)
+RETURNS TABLE(match_field text, match_value text, score real) AS $matches$
+    WITH norm AS (
+        SELECT
+            CASE WHEN btrim(search_query) ~ '^".*"$' AND length(btrim(search_query)) >= 2
+                 THEN substring(btrim(search_query) FROM 2 FOR length(btrim(search_query)) - 2)
+                 ELSE btrim(search_query) END AS q_in,
+            (btrim(search_query) ~ '^".*"$' AND length(btrim(search_query)) >= 2) AS exact
+    ),
+    n AS (
+        SELECT q_in, exact, lower(f_unaccent(q_in)) AS q FROM norm
+    ),
+    candidates(label, value, priority, numeric_field) AS (
+        VALUES
+            ('First name',  p_identity ->> 'first_name',                1, false),
+            ('Last name',   p_identity ->> 'last_name',                 2, false),
+            ('Nickname',    p_identity ->> 'nickname',                  3, false),
+            ('AD username', p_identity ->> 'active_directory_username', 6, false),
+            ('Discord',     p_connections ->> 'discord_handle',         7, false),
+            ('Phone',       p_connections ->> 'phone',                  8, true)
+        UNION ALL
+        SELECT 'Email', e ->> 'email_address', 5, false
+          FROM jsonb_array_elements(
+                 CASE WHEN jsonb_typeof(p_identity -> 'emails') = 'array'
+                      THEN p_identity -> 'emails' ELSE '[]'::jsonb END) AS e
+        UNION ALL
+        SELECT 'RFID tag', t, 9, true
+          FROM jsonb_array_elements_text(
+                 CASE WHEN jsonb_typeof(p_access -> 'rfid_tags') = 'array'
+                      THEN p_access -> 'rfid_tags' ELSE '[]'::jsonb END) AS t
+    )
+    -- (1) exact DB-id match (priority 4) — always the strongest signal.
+    SELECT 'Member ID'::text, p_id::text, 100::real
+    FROM n
+    WHERE p_id IS NOT NULL AND n.q_in ~ '^[0-9]+$' AND length(n.q_in) <= 9 AND p_id = n.q_in::int
+
+    UNION ALL
+
+    -- (2) curated-field matches, mirroring the search predicates per field.
+    SELECT c.label, c.value,
+           ( CASE WHEN sm.substr_match
+                  THEN 1.0 + word_similarity(n.q, lower(f_unaccent(c.value)))
+                  ELSE word_similarity(n.q, lower(f_unaccent(c.value))) END
+             + (10 - c.priority) * 0.001 )::real AS score
+    FROM candidates c
+    CROSS JOIN n
+    CROSS JOIN LATERAL (
+        SELECT CASE WHEN n.exact THEN
+                   lower(f_unaccent(c.value)) LIKE '%' || like_escape(n.q) || '%'
+                   OR ( c.numeric_field
+                        AND nullif(regexp_replace(n.q, '\D', '', 'g'), '') IS NOT NULL
+                        AND regexp_replace(c.value, '\D', '', 'g')
+                            LIKE '%' || regexp_replace(n.q, '\D', '', 'g') || '%' )
+               ELSE
+                   EXISTS (
+                       SELECT 1 FROM regexp_split_to_table(n.q, '\s+') tok
+                       WHERE tok <> ''
+                         AND ( lower(f_unaccent(c.value)) LIKE '%' || like_escape(tok) || '%'
+                               OR ( c.numeric_field
+                                    AND nullif(regexp_replace(tok, '\D', '', 'g'), '') IS NOT NULL
+                                    AND regexp_replace(c.value, '\D', '', 'g')
+                                        LIKE '%' || regexp_replace(tok, '\D', '', 'g') || '%' ) )
+                   )
+               END
+    ) sm(substr_match)
+    WHERE c.value IS NOT NULL AND c.value <> ''
+      AND ( sm.substr_match
+            OR word_similarity(n.q, lower(f_unaccent(c.value))) >= 0.4 )
+    ORDER BY 3 DESC;
+$matches$ LANGUAGE sql STABLE;
+COMMENT ON FUNCTION member_search_matches(text, integer, jsonb, jsonb, jsonb) IS 'Per-field match attribution for the admin "Matched on" column. Returns (field label, raw value, score) for each curated field that matched, mirroring search_members_by_identity_and_access predicates. Order by score DESC for strongest-first.';
+
+/*
  * This function is used for searching members by identity and access
  * (e.g., RFID tags) and returning full member records. This is used in
  * the admin portal so that an admin can search for a member by name or RFID tag.
@@ -596,9 +687,11 @@ $$ LANGUAGE sql IMMUTABLE;
  *       (order-independent multi-word); phone-like tokens are digit-normalized
  *       so dashed/parenthesized phone queries match the digits-only stored phone;
  *   (b) word_similarity >= 0.4 adds typo tolerance (jon -> John);
- *   (c) a digits-only query also matches RFID tags w/ or w/o leading zeros.
+ *   (c) a digits-only query also matches RFID tags w/ or w/o leading zeros;
+ *   (d) a short digits-only query equal to the displayed DB id (member.id, NOT
+ *       the legacy Wild Apricot identity.member_id) matches that member exactly.
  * Ranking is name-first: first/last/nickname matches are weighted 2x over the
- * full-blob similarity.
+ * full-blob similarity; an exact DB-id match is boosted to the top.
  *
  * Exact mode: a query wrapped in double quotes (e.g. "robert13") strips the
  * quotes and matches the phrase as a literal substring of the blob only — no
@@ -645,39 +738,48 @@ BEGIN
             2.0 * word_similarity(q, lower(f_unaccent(concat_ws(' ',
                       m.identity ->> 'first_name', m.identity ->> 'last_name', m.identity ->> 'nickname'))))
             + word_similarity(q, member_search_text(m.identity, m.connections, m.access))
+            -- An all-digit query equal to the displayed DB id (member.id) floats that
+            -- member to the very top while other fuzzy digit matches still appear below.
+            + CASE WHEN q_in ~ '^[0-9]+$' AND length(q_in) <= 9 AND m.id = q_in::int
+                   THEN 100 ELSE 0 END
         )::real AS rank
     FROM member m
     WHERE
-        CASE WHEN exact THEN
-            -- Exact mode: the accent-folded, lowercased phrase must appear
-            -- verbatim as a substring of the blob. Wildcards escaped.
-            member_search_text(m.identity, m.connections, m.access)
-                ILIKE '%' || like_escape(q) || '%'
-        ELSE
-            (
-                -- (a) every query token must be a substring of the blob (phone-like tokens digit-normalized).
-                --     User-supplied tokens are wildcard-escaped so a typed % or _ matches literally.
-                NOT EXISTS (
-                    SELECT 1 FROM regexp_split_to_table(q, '\s+') tok
-                    WHERE tok <> ''
-                      AND member_search_text(m.identity, m.connections, m.access)
-                          NOT ILIKE '%' ||
-                              like_escape(CASE WHEN tok ~ '^[0-9()+.\- ]+$'
-                                               THEN regexp_replace(tok, '\D', '', 'g')
-                                               ELSE tok END)
-                          || '%'
+        (
+            CASE WHEN exact THEN
+                -- Exact mode: the accent-folded, lowercased phrase must appear
+                -- verbatim as a substring of the blob. Wildcards escaped.
+                member_search_text(m.identity, m.connections, m.access)
+                    ILIKE '%' || like_escape(q) || '%'
+            ELSE
+                (
+                    -- (a) every query token must be a substring of the blob (phone-like tokens digit-normalized).
+                    --     User-supplied tokens are wildcard-escaped so a typed % or _ matches literally.
+                    NOT EXISTS (
+                        SELECT 1 FROM regexp_split_to_table(q, '\s+') tok
+                        WHERE tok <> ''
+                          AND member_search_text(m.identity, m.connections, m.access)
+                              NOT ILIKE '%' ||
+                                  like_escape(CASE WHEN tok ~ '^[0-9()+.\- ]+$'
+                                                   THEN regexp_replace(tok, '\D', '', 'g')
+                                                   ELSE tok END)
+                              || '%'
+                    )
+                    -- (b) typo tolerance
+                    OR word_similarity(q, member_search_text(m.identity, m.connections, m.access)) >= 0.4
                 )
-                -- (b) typo tolerance
-                OR word_similarity(q, member_search_text(m.identity, m.connections, m.access)) >= 0.4
-            )
-            -- (c) numeric RFID fallback (handles tags with/without leading zeros); use the
-            --     trimmed input so whitespace-padded digit queries still take this path.
-            OR (q_in ~ '^[0-9]+$' AND m.access::text ILIKE '%' || q_in || '%')
-        END
+                -- (c) numeric RFID fallback (handles tags with/without leading zeros); use the
+                --     trimmed input so whitespace-padded digit queries still take this path.
+                OR (q_in ~ '^[0-9]+$' AND m.access::text ILIKE '%' || q_in || '%')
+            END
+        )
+        -- (d) exact DB-id match on the displayed member.id (NOT the legacy WA member_id).
+        --     A short all-digit query equal to the row's id always matches, in either mode.
+        OR (q_in ~ '^[0-9]+$' AND length(q_in) <= 9 AND m.id = q_in::int)
     ORDER BY rank DESC NULLS LAST;
 END;
 $body$ LANGUAGE plpgsql;
-COMMENT ON FUNCTION search_members_by_identity_and_access(text) IS 'Curated, accent-folded pg_trgm search over allowlisted identity/connections/access keys (names, nickname, member_id, AD username, emails, Discord, phone, RFID). Substring + word_similarity typo tolerance, ranked name-first.';
+COMMENT ON FUNCTION search_members_by_identity_and_access(text) IS 'Curated, accent-folded pg_trgm search over allowlisted identity/connections/access keys (names, nickname, AD username, emails, Discord, phone, RFID) plus exact DB-id (member.id) match. The legacy Wild Apricot identity.member_id is NOT searched. Substring + word_similarity typo tolerance, ranked name-first.';
 
 /*
  * Function that returns full member records based on identity search

--- a/pg/sql/seed_data.sql.example
+++ b/pg/sql/seed_data.sql.example
@@ -12035,6 +12035,61 @@ INSERT INTO member (identity, connections, status, forms, access, authorizations
 
 
 /* =====================================================
+ * Member search test fixtures (accents / phone formats / Discord / RFID)
+ * Exercise the pg_trgm curated search: unaccent folding, dash-agnostic phone,
+ * leading-zero RFID, hyphenated names, and plus-alias emails.
+ * ===================================================== */
+
+/* ID 1001 - José Muñoz: accents, leading-zero RFID, parenthesized phone */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "José", "last_name": "Muñoz", "nickname": "pepe", "active_directory_username": "jmunoz", "emails": [{"type": "primary", "email_address": "jose.munoz@example.com"}], "birthday": "1990-05-05"}'::jsonb,
+    '{"discord_handle": "jmunoz_test", "phone": "(312) 555-0101"}'::jsonb,
+    '{"membership_status": "active", "membership_level": "Membership", "member_since": "2021-03-01"}'::jsonb,
+    NULL,
+    '{"rfid_tags": ["0000001234"]}'::jsonb,
+    NULL,
+    NULL,
+    NULL
+);
+
+/* ID 1002 - Renée Dubois: accent é, dash-formatted phone */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Renée", "last_name": "Dubois", "nickname": null, "active_directory_username": "rdubois", "emails": [{"type": "primary", "email_address": "renee.dubois@example.com"}], "birthday": "1987-09-12"}'::jsonb,
+    '{"discord_handle": "renee_test", "phone": "312-555-0190"}'::jsonb,
+    '{"membership_status": "active", "membership_level": "Membership", "member_since": "2022-06-01"}'::jsonb,
+    NULL,
+    '{"rfid_tags": ["1055667788"]}'::jsonb,
+    NULL,
+    NULL,
+    NULL
+);
+
+/* ID 1003 - Pat Smith-Jones: hyphenated last name, +1 phone, plus-alias email, known Discord */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Pat", "last_name": "Smith-Jones", "nickname": null, "active_directory_username": "psmithjones", "emails": [{"type": "primary", "email_address": "pat+tag@example.com"}], "birthday": "1995-01-20"}'::jsonb,
+    '{"discord_handle": "ps1_search_fixture", "phone": "+13125550191"}'::jsonb,
+    '{"membership_status": "active", "membership_level": "Membership", "member_since": "2023-02-15"}'::jsonb,
+    NULL,
+    '{"rfid_tags": ["1066778899"]}'::jsonb,
+    NULL,
+    NULL,
+    NULL
+);
+
+/* ID 1004 - Zoë Carter: accent ë, dot-separated phone */
+INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
+    '{"first_name": "Zoë", "last_name": "Carter", "nickname": "zo", "active_directory_username": "zcarter", "emails": [{"type": "primary", "email_address": "zoe.carter@example.com"}], "birthday": "1992-02-02"}'::jsonb,
+    '{"discord_handle": "zoe_test", "phone": "312.555.0192"}'::jsonb,
+    '{"membership_status": "active", "membership_level": "Membership", "member_since": "2024-04-10"}'::jsonb,
+    NULL,
+    '{"rfid_tags": ["1077889900"]}'::jsonb,
+    NULL,
+    NULL,
+    NULL
+);
+
+
+/* =====================================================
  * Role Assignments
  * Roles: Authorizer (1), Administrator (2), Board (3), ID Check (4), CTO (5), Treasurer (6), Area Host (7)
  * ===================================================== */


### PR DESCRIPTION
## Why

Member search in the admin portal was rough in day-to-day use. This PR reworks
the existing full-text search so member lookups are more forgiving: match partial
and misspelled names, fold accents, find people by Discord handle or phone in any
format, rank by relevance so the right person surfaces first, and explain *why*
each result matched.

## What changed

### Search engine (`pg/sql/pgsql_schema.sql`, `pg/db-init/init.sql`)

- Add `pg_trgm` + `unaccent` extensions and an `IMMUTABLE` `f_unaccent()` wrapper
  (stock `unaccent()` is only `STABLE`).
- A single **curated allowlist** drives everything. `member_search_candidates()`
  enumerates the searchable fields — first/last name, nickname, AD username, all
  emails, Discord handle, phone (digit-normalized), and RFID tags
  (digit-normalized). JSON key names and internal IDs (Stripe / WildApricot) are
  deliberately excluded. `member_search_text()` builds the accent-folded,
  lowercased blob from that allowlist, so the blob can never drift from the
  per-field attribution.
- `search_members_by_identity_and_access` does trigram matching: per-token
  substring match (multi-word, order-independent; phone/RFID-like tokens
  digit-normalized so dashed/parenthesized phones match) **plus `word_similarity`
  typo tolerance**, ranked **name-first** (name fields weighted 2×). The RFID
  leading-zero fallback (keyed off the trimmed input) is preserved.
- **Exact member-ID match.** The displayed DB `member.id` is matched exactly
  (all-digit query, `length <= 9`) and rank-boosted to the top. The id is **not**
  part of the substring blob, so a partial-digit query doesn't pull in unrelated
  members by id substring. (The legacy WildApricot `identity.member_id` is not
  searched.)
- **Wildcards are literal.** Every user token is wrapped in an `IMMUTABLE`
  `like_escape()` (escapes `\ % _`) before going into `ILIKE '%…%'`, so a typed
  `%`/`_` matches literally instead of matching the whole roster.
- **Quoted = exact mode.** A query in double quotes (e.g. `"robert13"`) matches
  the phrase as a literal substring only — no typo tolerance, no RFID fallback —
  to pin an exact handle/email/name the fuzzy ranking would otherwise bury.
  Formatted phone/RFID queries in quotes also match via digit-normalization.

### "Matched on" column

Each result row shows *why* it matched: every curated field whose value matched,
as `Field: value` lines, strongest-first, with the matched substring **bolded**
and long values ellipsized (full text in a tooltip). This surfaces hits on
otherwise-invisible fields — an old email, a phone number, an RFID tag, a Discord
handle. Browse mode (no search) is unchanged.

- `member_search_matches(query, id, identity, connections, access)` returns
  per-field `(field, value, score)` attribution, mirroring the search's own
  predicates. It shares the allowlist, quote-parse, and match primitive with the
  search function (`member_search_candidates`, `member_search_normalize`,
  `member_token_in_value`) so the two can't drift. Typo tolerance is applied to
  non-numeric fields only, so two unrelated phone/RFID digit strings can't
  trigram-attribute a field the query isn't visibly in.
- `search_members_paginated` paginates **first**, then `LATERAL`-joins attribution
  over only the returned page — never the full result set.
- The frontend builds the cell with DOM nodes only (`textContent` / `<strong>`,
  never `innerHTML`), and the highlighter digit-normalizes, so a `3125550101`
  query bolds the run inside a stored `(312) 555-0101`.

### DHService (`code/DHService/db.py`)

- `_is_searchable_query` short-circuits `<2-char` / punctuation-only queries on
  both the paginated (`/list/`) and raw (`/search/`) paths, returning nothing
  instead of the whole roster. Stable `, id` tiebreak on the paginated CTE.
- `/api/search` (role-assign modal) inherits the name-first ranking and is capped
  at **200 rows** (it feeds a non-paginated modal).
- Onboarder picker: accent-fold + nickname matching, keeping its onboarders-first
  ranking. (Now depends on `f_unaccent` existing in the DB.)

### Admin portal (`code/DHAdminPortal/`)

- Log `query_length` instead of the raw search query in activity logs (keeps PII
  out of logs).
- Search input: `type="search"` + `autocapitalize/autocorrect/spellcheck` off
  (mobile-friendly); the Search button is a magnifying-glass icon (spinner while
  loading).
- A `circle-info` **search-tips popover** left of the search bar (hover/focus,
  themed via Bootstrap's `--bs-popover-*` API, verified across all five themes)
  documents what's searchable, how matching works, and the tricks (double-quote
  for exact, 2-char minimum).
- Too-short queries show a friendly "enter at least 2 characters" alert
  (`isSearchableQuery` mirrors the server-side guard, unicode-aware so accent-only
  queries pass) on both the main search and the role-assign modal; the server-side
  guard remains as defense-in-depth.

### Seed (`pg/sql/seed_data.sql.example`)

Added accent / phone-format / Discord / RFID test fixtures.

## Behavior

| Query | Result |
|-------|--------|
| `joh` / partial | substring match |
| `jon`, `smiht` | typo-tolerant (`word_similarity`) |
| `jose` | matches `José` (accent-folded) |
| `312-555-0101`, `(312) 555-0101`, `3125550101` | all match the same member |
| `Smith-Jones`, `user+tag@…` | preserved (only phone/RFID-like tokens are digit-normalized) |
| `john` | members *named* John rank above email-only matches |
| `"robert13"` (quoted) | **exact** substring only — the `robert13` handle owner, not every `Robert` |
| `"(312) 555-0101"` (quoted) | matches via digit-normalization |
| `a%`, `name_` | `%`/`_` matched **literally**, not as wildcards |
| `a`, `@`, `---` | empty + "enter at least 2 characters" alert |
| an exact member ID (e.g. `142`) | floats to the **top**; cell shows `Member ID: 142` |
| `lovelace` | cell lists `Last name`, `Email`, `AD username` matches, strongest-first |
| a Stripe `cus_…` / `wildapricot_id` / the literal `first_name` | no match (curation) |

## Verification (dev)

Applied the SQL to the dev DB, rebuilt `dhservice` + `dhadminportal`, and ran SQL
smoke tests + end-to-end API + Chrome UI tests. Confirmed: partial / typo /
accent / multi-format-phone matching, name-first ranking, quoted exact mode
(including formatted phone via digit-normalization), literal `%`/`_`, the
too-short guard + alert on both surfaces, `/api/search` 200-row cap, the
onboarder picker accent-folding and keeping onboarders-first, exact member-ID
float-to-top, multi-field strongest-first "Matched on" ordering, the digit-run
highlight, and the graceful empty-cell case. Excluded fields (Stripe / WildApricot
id / JSON key names) return nothing. Non-numeric and 10+-digit id queries raise no
error. Swept all five admin themes (bubblegum / light / dark / midnight / hacker)
— bold highlight and muted labels readable in each.

One honest note: a query of the literal `first_name` returns a few bottom-ranked
(~0.45) fuzzy hits — not a curation leak (no blob contains the string), just the
`word_similarity ≥ 0.4` arm coincidentally matching email substrings like
`future.first@…`. Real-name matches dominate. `0.4` is the one empirical knob; it
can go to `0.5` if we want it quieter.

## Deployment

Schema-file changes apply on **fresh init only** — production needs a separate
manual deploy (filed as #314, refs #260). Ordering: the two extensions
(**superuser**), then the helpers (`f_unaccent`, `like_escape`,
`member_search_normalize`, `member_search_candidates`, `member_token_in_value`,
`member_search_text`, `member_search_matches`) **before** the rewritten search
function and the DHService code that calls `f_unaccent`. The main search function
keeps its signature, so it's a safe `CREATE OR REPLACE` with a one-statement
rollback. No new index (the per-token filter seq-scans regardless; sub-100ms at
~3.2k members). The #314 runbook carries the exact statements, create order,
verification queries, and rollback.