### PR TITLE
Make member-detail Roles tab read-only; remove dead role-write path

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -1185,50 +1185,10 @@ def api_update_member_status():
         logger.error(f"Error updating member status: {e}")
         return {"error": str(e)}, 500
 
-@app.route("/api/member/roles", methods=["POST"])
-@requires_change_permission("member.roles")
-def api_update_member_roles():
-    if not session.get("user"):
-        return {"error": "Not authenticated"}, 401
-    
-    member_id = request.args.get("member_id", "")
-    if not member_id:
-        return {"error": "member_id parameter required"}, 400
-    
-    try:
-        access_token = dhservices.get_access_token(
-            dhservices.DH_CLIENT_ID, 
-            dhservices.DH_CLIENT_SECRET
-        )
-        # Get logged-in user's member ID
-        user_email = session["user"].get("email") or session["user"].get("preferred_username")
-        member_data = dhservices.get_member_id(access_token, user_email)
-        logged_in_member_id = member_data.get("member_id")
-        
-        data = request.get_json()
-        data["modified_by"] = logged_in_member_id
-        result = dhservices.update_member_roles(access_token, member_id, data)
-        
-        # Log update activity
-        try:
-            dhservices.log_user_activity(
-                access_token,
-                str(logged_in_member_id),
-                {
-                    "activity_details": {
-                        "action": "update_roles",
-                        "target_member_id": member_id,
-                        "fields_updated": list(data.keys())
-                    }
-                }
-            )
-        except Exception as log_error:
-            logger.error(f"Failed to log update activity: {log_error}")
-        
-        return result
-    except Exception as e:
-        logger.error(f"Error updating member roles: {e}")
-        return {"error": str(e)}, 500
+# NOTE: there is intentionally no POST /api/member/roles route. The member-detail
+# Roles tab is read-only; role assignment is handled by Systems -> Assign Roles
+# (POST /api/admin/assign_role -> DHService /v1/admin/assign_role/). DHService's
+# /v1/member/roles/ is GET-only, so the old write path always 405'd.
 
 @app.route("/api/member/extras", methods=["POST"])
 @requires_change_permission("member.extras")

--- a/code/DHAdminPortal/dhservices.py
+++ b/code/DHAdminPortal/dhservices.py
@@ -242,14 +242,9 @@ def update_member_identity(access_token: str, member_id: str, identity_data: dic
     response.raise_for_status()
     return response.json()
 
-def update_member_roles(access_token: str, member_id: str, roles_data: dict):
-    url = f"{DH_API_BASE_URL}/v1/member/roles/"
-    headers = {"Authorization": f"Bearer {access_token}"}
-    headers["X-Member-ID"] = str(member_id)
-    params = {"member_id": member_id}
-    response = requests.post(url, headers=headers, params=params, json=roles_data)
-    response.raise_for_status()
-    return response.json()
+# NOTE: no update_member_roles() — the member-detail Roles tab is read-only and
+# DHService's /v1/member/roles/ is GET-only. Role assignment goes through
+# assign_role_to_member() (POST /v1/admin/assign_role/) instead.
 
 def update_member_extras(access_token: str, member_id: str, extras_data: dict):
     url = f"{DH_API_BASE_URL}/v1/member/extras/"

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -791,9 +791,11 @@ document.addEventListener('click', function(e) {
     // Only show hint if the user has change permission for this tab
     if (!canChangeTab('member.' + tabName)) return;
 
-    // Don't show if already in edit mode
+    // Don't show if the tab has no edit button (read-only tabs like Roles —
+    // telling the user to "click Edit" when there's no Edit button is wrong),
+    // or if it's already in edit mode.
     var editBtn = document.getElementById(tabName + 'EditBtn');
-    if (editBtn && editBtn.textContent === 'Cancel') return;
+    if (!editBtn || editBtn.textContent === 'Cancel') return;
 
     // Show the hint toast
     var toastEl = document.getElementById('dh-validation-toast');
@@ -3863,7 +3865,7 @@ function clearAutoRefresh() {
 const PERMISSION_SECTIONS = [
     { area: 'Member', key: 'member.identity',       changeAllowed: true  },
     { area: 'Member', key: 'member.status',          changeAllowed: true  },
-    { area: 'Member', key: 'member.roles',           changeAllowed: true  },
+    { area: 'Member', key: 'member.roles',           changeAllowed: false },
     { area: 'Member', key: 'member.forms',           changeAllowed: true  },
     { area: 'Member', key: 'member.connections',     changeAllowed: true  },
     { area: 'Member', key: 'member.extras',          changeAllowed: true  },

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -348,8 +348,10 @@
                         <div class="card-body">
                             <div class="d-flex justify-content-between align-items-center mb-3">
                                 <h5 class="mb-0">Roles Information</h5>
-                                <span class="dh-btn-group"><button class="btn btn-primary btn-sm" id="rolesEditBtn" onclick="toggleEditMode('roles')">Edit</button></span>
                             </div>
+                            <p class="small mb-3" style="color: inherit; opacity: 0.85;">
+                                <i class="fa-solid fa-circle-info me-1"></i>To change a member's role, use <a href="#" onclick="showSection('assignRoles'); return false;">Systems &rarr; Assign Roles</a>.
+                            </p>
                             <div id="rolesLoading" class="text-center" style="display: none;">
                                 <div class="spinner-border" role="status">
                                     <span class="visually-hidden">Loading...</span>
@@ -837,10 +839,16 @@ document.addEventListener('click', function(e) {
 
 // Toggle edit mode for a specific tab
 function toggleEditMode(tabName) {
+    // The roles tab is read-only (no edit button — role assignment lives on
+    // Systems -> Assign Roles). Backstop guard so it can never enter edit mode
+    // even if an edit button is ever re-added; the old edit path POSTed to a
+    // GET-only DHService route and 405'd.
+    if (tabName === 'roles') return;
+
     const editBtn = document.getElementById(`${tabName}EditBtn`);
     const tabPane = document.getElementById(tabName);
     const isNotesTab = tabName === 'notes';
-    
+
     if (!tabPane) return;
     
     // Check current mode
@@ -1372,7 +1380,10 @@ function filterTabsByPermissions() {
             console.log(`${isVisible ? 'Showing' : 'Hiding'} tab "${tabName}"`);
         }
 
-        // Show edit button or read-only indicator based on permissions
+        // Show edit button or read-only indicator based on permissions.
+        // Note: the roles tab has no edit button (it's read-only — role
+        // assignment lives on Systems -> Assign Roles), so editBtn is null
+        // for it and this block is skipped.
         if (editBtn) {
             if (canChange) {
                 editBtn.style.display = '';


### PR DESCRIPTION
## Problem

Assigning a role via the member-detail **Roles tab** failed with:

```
405 Client Error: Method Not Allowed for url: .../v1/member/roles/?member_id=…
```

The tab's Edit→Save used the generic per-tab save path, POSTing to DHService `/v1/member/roles/` — but that route is **GET-only**. There is no POST handler and no `db.update_member_roles`, so the write path never worked (and the payload shape was wrong too). Role assignment is already fully handled by the **Systems → Assign Roles** page (`/api/admin/assign_role` → `/v1/admin/assign_role/` → `db.assign_role_to_member`).

## Fix

Make the member-detail Roles tab a clean **read-only display** and remove the dead plumbing.

**Frontend (`templates/index.html`):**
- Remove the Roles tab Edit button.
- Add a hint linking to **Systems → Assign Roles** (`showSection('assignRoles')`, already permission-gated — no-ops without `systems.assign_roles`).
- Backstop guard in `toggleEditMode`: `if (tabName === 'roles') return;` so the tab can never enter edit mode even if a button is re-added later.

**Backend:**
- Remove the dead `POST /api/member/roles` route (`app.py`) and the orphaned `update_member_roles` (`dhservices.py`). The GET read endpoint stays.

DHService and the DB are untouched; no schema change.

### Note on the backstop guard
A first pass (disabled "Read Only" pill) left a hole: `fetchTabData`'s finally-block re-enables the button's `disabled`, and `pointer-events:none` only blocks the mouse — so a **keyboard** user (Tab+Enter) on an admin account could still enter edit mode. Removing the button + guarding `toggleEditMode` closes it.

## Verification
- chrome-devtools on dev, rebuilt container.
- No edit button; read view shows the member's permission JSON in a readonly box; `toggleEditMode('roles')` now yields 0 editable inputs.
- Hint link reveals the Assign Roles section.
- **All 5 themes swept** (bubblegum / light / dark / midnight / hacker) — hint + link readable in each (screenshots below).
- No new console errors.
- `POST /api/member/roles` → 405 at Flask (route gone, never reaches DHService); `GET` read endpoint intact.

## Out of scope
- The member portal has its own unused `update_member_roles` (dead, zero callers) — left alone; can clean up in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)