### PR TITLE
Admin portal: member avatars (Gravatar) in list + detail header

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -1,5 +1,6 @@
 import re
 import uuid
+import hashlib
 import requests
 import json
 from functools import wraps
@@ -38,6 +39,33 @@ def handle_csrf_error(e):
         return {"error": "CSRF token missing or invalid"}, 400
     flash('Your session has expired or this form submission was invalid. Please try again.', 'error')
     return redirect(request.referrer or url_for('index'))
+
+###############################################################################
+# Member avatar resolution
+###############################################################################
+# Pluggable avatar seam. Returns {'source', 'url'} for a member, or None.
+# The URL is intentionally SIZELESS — the frontend appends `&s=` per context
+# (row vs header, with 2x density). `d=404` lives in the base URL so a missing
+# avatar 404s and the frontend falls back to an initials square.
+#
+# Provider precedence is Discord (future) -> Gravatar -> none. Discord avatars
+# will be added here and take precedence once real Discord OAuth linking lands;
+# the Discord data currently in the DB is unverified, so there is no Discord
+# branch yet — only the documented insertion point below.
+
+def resolve_avatar(member):
+    """Resolve a member's avatar to {'source': str, 'url': str}, or None."""
+    # FUTURE: if a verified Discord avatar exists for this member, return it here
+    # (takes precedence over Gravatar).
+    email = member.get("primary_email_address")
+    if email:
+        digest = hashlib.sha256(email.strip().lower().encode("utf-8")).hexdigest()
+        return {
+            "source": "gravatar",
+            "url": f"https://www.gravatar.com/avatar/{digest}?d=404",
+        }
+    return None
+
 
 ###############################################################################
 # Field validation rules for member update endpoints
@@ -692,6 +720,13 @@ def api_members():
         )
 
         result = dhservices.list_members(access_token, query, page, per_page, sort, order)
+
+        # Attach a resolved avatar ({source, url} or None) to each member row.
+        # The same row object feeds both the results list and the detail header.
+        members = result.get("members") if isinstance(result, dict) else None
+        if isinstance(members, list):
+            for member in members:
+                member["avatar"] = resolve_avatar(member)
 
         # Log search activity only when an explicit search query is present
         if query:

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -32,6 +32,79 @@
 }
 th.dh-status-col { cursor: pointer; }
 
+/* --- Member avatars ----------------------------------------------------- */
+/* Narrow, centered avatar column in the results table (between status and ID) */
+.dh-avatar-col {
+    width: 1%;
+    white-space: nowrap;
+    text-align: center;
+}
+
+/* Shared rounded-square photo, used in the list and the detail header.
+   Pixel size is set inline (per context, 2x density requested from Gravatar). */
+.dh-avatar {
+    border-radius: 4px;
+    object-fit: cover;
+    vertical-align: middle;
+    display: inline-block;
+}
+
+/* Theme-primary initials placeholder shown when there's no registered photo
+   (d=404) or on a load error. Box size + font-size are set inline. */
+.dh-avatar-initials {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    background: var(--primary-color);
+    color: #fff;
+    font-weight: 700;
+    line-height: 1;
+    overflow: hidden;
+    vertical-align: middle;
+}
+/* The amber/green theme primaries need dark text for contrast on the square. */
+[data-theme="midnight"] .dh-avatar-initials,
+[data-theme="hacker"] .dh-avatar-initials { color: #111; }
+
+/* Wrapper around a real photo — positioning context for the corner badge. */
+.dh-avatar-wrap {
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+    line-height: 0;
+}
+
+/* Corner provider badge ("G" for Gravatar). JS keeps it hidden until the photo
+   actually loads; CSS then reveals it only on hover. */
+.dh-avatar-badge {
+    position: absolute;
+    right: -2px;
+    bottom: -2px;
+    min-width: 12px;
+    height: 12px;
+    padding: 0 2px;
+    border-radius: 4px;
+    background: var(--card-bg);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    font-size: 8px;
+    font-weight: 700;
+    line-height: 12px;
+    text-align: center;
+    opacity: 0;
+    transition: opacity 0.12s ease-in-out;
+    pointer-events: none;
+}
+.dh-avatar-wrap:hover .dh-avatar-badge { opacity: 1; }
+
+/* Detail-header avatar slot — keep it vertically centered with the text block. */
+.dh-member-header-avatar {
+    display: inline-flex;
+    flex: 0 0 auto;
+    line-height: 0;
+}
+
 /* "Matched on" column in the results table (search mode only). Lists each
    curated field that matched, strongest first; the matched substring is bolded.
    Long values get a trailing ellipsis with the full "Field: value" in a tooltip.

--- a/code/DHAdminPortal/templates/base.html
+++ b/code/DHAdminPortal/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdnjs.cloudflare.com; font-src 'self' cdnjs.cloudflare.com; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' *.b2clogin.com;">
+          content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdnjs.cloudflare.com; font-src 'self' cdnjs.cloudflare.com; img-src 'self' data: blob: https://www.gravatar.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' *.b2clogin.com;">
     <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='images/favicon-ps1-admin.svg') }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='images/favicon-32x32.png') }}">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', filename='images/favicon-16x16.png') }}">

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -96,6 +96,7 @@
                                 <i class="fa-solid fa-circle-half-stroke" id="statusLegendIcon" aria-label="Status"></i>
                                 <span id="sort-membership_status"></span>
                             </th>
+                            <th class="dh-avatar-col" aria-label="Avatar"></th>
                             <th onclick="sortTable('id')" style="cursor: pointer;">
                                 ID <span id="sort-id"></span>
                             </th>
@@ -138,10 +139,13 @@
             <!-- Member identity bar with close button -->
             <div id="memberHeaderInfo" class="dh-sidebar-header" style="display: none;">
                 <div class="d-flex justify-content-between align-items-stretch">
-                    <div>
-                        <div id="memberHeaderName" class="fw-bold"></div>
-                        <div id="memberHeaderEmail" class="text-muted small"></div>
-                        <div id="memberHeaderId" class="text-muted small"></div>
+                    <div class="d-flex align-items-center gap-2">
+                        <span id="memberHeaderAvatar" class="dh-member-header-avatar"></span>
+                        <div>
+                            <div id="memberHeaderName" class="fw-bold"></div>
+                            <div id="memberHeaderEmail" class="text-muted small"></div>
+                            <div id="memberHeaderId" class="text-muted small"></div>
+                        </div>
                     </div>
                     <div class="d-flex flex-column align-items-end justify-content-between">
                         <div class="d-flex align-items-center gap-2">
@@ -753,6 +757,10 @@ const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute
 
 // Store current member ID
 let currentMemberId = null;
+// Server-resolved avatar ({source, url} or null) for the selected member, kept so
+// the in-place header refresh can re-render it without re-resolving (and without
+// dropping a future Discord-sourced avatar back to a Gravatar/initials guess).
+let selectedMemberAvatar = null;
 let membershipLevelsCache = null;
 let membershipLevelsPromise = null;
 const loggedInUserName = {{ (
@@ -1638,6 +1646,99 @@ function buildStatusCell(rawStatus) {
     return td;
 }
 
+// --- Member avatars -------------------------------------------------------
+// Avatar provider seam mirror of the backend resolve_avatar(): the server
+// attaches member.avatar = {source, url} (sizeless URL, d=404) or null. The
+// frontend appends `&s=` (2x density) and falls back to a theme-primary
+// initials square when there is no registered photo. XSS-safe throughout:
+// createElement + textContent only; the badge mark comes from an allowlist.
+
+// Source -> human label allowlist. Badge text is derived from this, never from
+// the raw server value.
+const AVATAR_SOURCE_LABELS = { gravatar: 'Gravatar' };
+
+// Up-to-2-char initials; falls back to the member ID, then "?".
+function avatarInitials(member) {
+    const first = ((member && member.first_name) || '').trim();
+    const last = ((member && member.last_name) || '').trim();
+    let initials = '';
+    if (first) initials += first[0];
+    if (last) initials += last[0];
+    initials = initials.toUpperCase();
+    if (initials) return initials;
+    const id = (member && member.member_id != null) ? String(member.member_id) : '';
+    return id || '?';
+}
+
+// Style an element (fresh span, or a wrapper being converted after img error)
+// as the rounded-square initials placeholder.
+function styleAsInitials(el, member, cssPx) {
+    el.className = 'dh-avatar dh-avatar-initials';
+    el.style.width = cssPx + 'px';
+    el.style.height = cssPx + 'px';
+    el.style.fontSize = Math.round(cssPx * 0.42) + 'px';
+    el.replaceChildren(document.createTextNode(avatarInitials(member)));
+}
+
+function buildAvatarInitials(member, cssPx) {
+    const span = document.createElement('span');
+    styleAsInitials(span, member, cssPx);
+    return span;
+}
+
+// Build a member avatar node sized to `cssPx`, reused by the list and header.
+function buildAvatar(member, cssPx) {
+    const avatar = member && member.avatar;
+    if (!avatar || !avatar.url) {
+        return buildAvatarInitials(member, cssPx);
+    }
+
+    const wrap = document.createElement('span');
+    wrap.className = 'dh-avatar-wrap';
+    wrap.style.width = cssPx + 'px';
+    wrap.style.height = cssPx + 'px';
+
+    const sourceLabel = AVATAR_SOURCE_LABELS[avatar.source] || '';
+    const fullName = `${((member.first_name) || '').trim()} ${((member.last_name) || '').trim()}`.trim();
+
+    const img = document.createElement('img');
+    img.className = 'dh-avatar';
+    img.width = cssPx;
+    img.height = cssPx;
+    img.loading = 'lazy';
+    img.alt = fullName || 'Member avatar';
+    if (sourceLabel) img.title = `Avatar source: ${sourceLabel}`;
+    // Sizeless URL from the server; request 2x for a crisp rounded square.
+    img.src = `${avatar.url}&s=${cssPx * 2}`;
+    // d=404 (no registered avatar) or any network error -> initials fallback.
+    // Convert the wrapper in place so it works whether or not it's in the DOM
+    // yet (a cached 404 can fire onerror synchronously) and drops the badge.
+    img.onerror = function() { styleAsInitials(wrap, member, cssPx); };
+    wrap.appendChild(img);
+
+    // Corner source badge — only meaningful once a real photo actually loads,
+    // and revealed on hover via CSS.
+    if (sourceLabel) {
+        const badge = document.createElement('span');
+        badge.className = 'dh-avatar-badge';
+        badge.textContent = sourceLabel.charAt(0);  // "G" for Gravatar
+        badge.title = `Avatar source: ${sourceLabel}`;
+        badge.setAttribute('aria-hidden', 'true');
+        badge.style.display = 'none';
+        img.addEventListener('load', function() { badge.style.display = ''; });
+        wrap.appendChild(badge);
+    }
+    return wrap;
+}
+
+// Build the list <td> for the avatar column (sits between status and ID).
+function buildAvatarCell(member) {
+    const td = document.createElement('td');
+    td.className = 'dh-avatar-col';
+    td.appendChild(buildAvatar(member, 28));
+    return td;
+}
+
 // Append `value` into `container`, bolding any occurrence of a query token.
 // Builds DOM nodes only (text nodes + <strong>) — never innerHTML — so member
 // data can never inject markup. Fuzzy/typo matches have no literal substring to
@@ -1718,7 +1819,7 @@ function displayResults(members) {
     tbody.innerHTML = '';
 
     if (members.length === 0) {
-        const colspan = searching ? 5 : 4;
+        const colspan = searching ? 6 : 5;
         tbody.innerHTML = `<tr><td colspan="${colspan}" class="text-center">No members found</td></tr>`;
     } else {
         members.forEach(member => {
@@ -1727,8 +1828,10 @@ function displayResults(members) {
             if (selectedMemberId && member.member_id == selectedMemberId) {
                 row.classList.add('selected-row');
             }
-            // Status icon first (allowlist-driven class — safe), then text columns.
+            // Status icon first (allowlist-driven class — safe), then avatar, then
+            // text columns. Layout: status | avatar | id | first | last | matched.
             row.appendChild(buildStatusCell(member.membership_status));
+            row.appendChild(buildAvatarCell(member));
             // Use textContent to prevent XSS from member data
             const cells = [
                 member.member_id,
@@ -2561,6 +2664,7 @@ function updateMemberHeaderInfo(member) {
     const emailEl = document.getElementById('memberHeaderEmail');
     const memberIdEl = document.getElementById('memberHeaderId');
     const badgeEl = document.getElementById('memberHeaderAgeBadge');
+    const avatarEl = document.getElementById('memberHeaderAvatar');
 
     if (!header || !nameEl || !emailEl || !memberIdEl) {
         return;
@@ -2571,6 +2675,7 @@ function updateMemberHeaderInfo(member) {
         nameEl.textContent = '';
         emailEl.textContent = '';
         memberIdEl.textContent = '';
+        if (avatarEl) avatarEl.replaceChildren();
         if (badgeEl) badgeEl.style.display = 'none';
         return;
     }
@@ -2584,6 +2689,9 @@ function updateMemberHeaderInfo(member) {
     memberIdEl.textContent = `Member ID: ${memberId}`;
     nameEl.textContent = fullName || 'Member';
     emailEl.textContent = email || 'No email on file';
+    // Same member row object carries member.avatar ({source,url} or null), so
+    // no extra fetch is needed here. 48px header avatar.
+    if (avatarEl) avatarEl.replaceChildren(buildAvatar(member, 48));
     header.style.display = '';
 
     // Members API doesn't include birthday; fetch identity to set the 21+ badge.
@@ -2672,22 +2780,23 @@ function refreshMemberProfile() {
                 first_name: firstName,
                 last_name: lastName,
                 primary_email_address: email,
+                avatar: selectedMemberAvatar,
                 membership_status: membershipStatus,
             });
         }
 
         // Sync this member's row in the results table (status icon + names).
         // Only overwrite cells whose source fetch actually succeeded, so a
-        // failed fetch never blanks a known value. Cells: 0=status, 1=id,
-        // 2=first, 3=last.
+        // failed fetch never blanks a known value. Cells: 0=status, 1=avatar,
+        // 2=id, 3=first, 4=last.
         document.querySelectorAll('#resultsTableBody tr').forEach(r => {
-            if (!r.cells[1] || r.cells[1].textContent != reqMemberId) return;
+            if (!r.cells[2] || r.cells[2].textContent != reqMemberId) return;
             if (hasStatus && r.cells[0]) {
                 r.replaceChild(buildStatusCell(membershipStatus), r.cells[0]);
             }
             if (hasIdentity) {
-                if (r.cells[2]) r.cells[2].textContent = firstName;
-                if (r.cells[3]) r.cells[3].textContent = lastName;
+                if (r.cells[3]) r.cells[3].textContent = firstName;
+                if (r.cells[4]) r.cells[4].textContent = lastName;
             }
         });
 
@@ -2727,12 +2836,14 @@ function loadMemberData(memberOrId) {
     const memberId = member ? member.member_id : memberOrId;
     currentMemberId = memberId;
     selectedMemberId = memberId;
+    // Remember the resolved avatar so refreshMemberProfile() can re-render it.
+    selectedMemberAvatar = member ? (member.avatar || null) : null;
 
     // Highlight the selected row
     document.querySelectorAll('#resultsTableBody tr.selected-row').forEach(r => r.classList.remove('selected-row'));
     document.querySelectorAll('#resultsTableBody tr').forEach(r => {
-        // cells[0] is now the status-icon column; the ID lives in cells[1].
-        if (r.cells[1] && r.cells[1].textContent == memberId) {
+        // Layout: cells[0]=status, cells[1]=avatar; the ID lives in cells[2].
+        if (r.cells[2] && r.cells[2].textContent == memberId) {
             r.classList.add('selected-row');
         }
     });

--- a/pg/sql/seed_data.sql.example
+++ b/pg/sql/seed_data.sql.example
@@ -11763,7 +11763,7 @@ INSERT INTO member (identity, connections, status, forms, access, authorizations
 
 /* ID 979 - Jade Watson */
 INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
-    '{"first_name": "Jade", "last_name": "Watson", "nickname": "jonespaul", "active_directory_username": "jwatson", "emails": [{"type": "primary", "email_address": "kimberly.nguyen589@hotmail.com"}], "birthday": "1992-01-12", "aliases": []}'::jsonb,
+    '{"first_name": "Jade", "last_name": "Watson", "nickname": "jonespaul", "active_directory_username": "jwatson", "emails": [{"type": "primary", "email_address": "test1@example.com"}], "birthday": "1992-01-12", "aliases": []}'::jsonb,
     '{"discord_handle": "", "phone": "", "wildapricot_id": 64192117}'::jsonb,
     '{"membership_status": "suspended", "membership_level": "Stripe Member w/ Storage - $95", "member_since": "2020-12-03T02:46:42+00:00", "renewal_date": null, "balance": 0, "donations": 0, "donor": false}'::jsonb,
     '{"terms_of_use_accepted": true, "essentials_form": "completed", "id_check_1": "MO DL M8913198", "id_check_2": "", "orientation_completed_date": "2023-09-25T00:00:00", "waiver_signed_date": "2022-10-11T00:00:00", "covid_vaccine_policy_acknowledged": null}'::jsonb,
@@ -11811,7 +11811,7 @@ INSERT INTO member (identity, connections, status, forms, access, authorizations
 
 /* ID 983 - Donna Smith */
 INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
-    '{"first_name": "Donna", "last_name": "Smith", "nickname": "kvalenzuela", "active_directory_username": "dsmith2", "emails": [{"type": "primary", "email_address": "thomaswalker@yahoo.com"}], "birthday": "1986-11-18", "aliases": []}'::jsonb,
+    '{"first_name": "Donna", "last_name": "Smith", "nickname": "kvalenzuela", "active_directory_username": "dsmith2", "emails": [{"type": "primary", "email_address": "test2@example.com"}], "birthday": "1986-11-18", "aliases": []}'::jsonb,
     '{"discord_handle": "ecantu", "phone": "", "wildapricot_id": 56302720, "stripe_customer_id": "cus_S5FGj39K38zfMU", "stripe_id": "cus_S5FGj39K38zfMU"}'::jsonb,
     '{"membership_status": "suspended", "membership_level": "Member - Grandfathered Price", "member_since": "2018-11-12T01:23:01+00:00", "renewal_date": "2024-03-10T10:26:55", "balance": 0, "donations": 0, "donor": false}'::jsonb,
     '{"terms_of_use_accepted": true, "essentials_form": "completed", "id_check_1": "saw TX DL, looked legit", "id_check_2": "TH approved", "orientation_completed_date": "2023-08-20T00:00:00", "waiver_signed_date": null, "covid_vaccine_policy_acknowledged": null}'::jsonb,
@@ -11859,7 +11859,7 @@ INSERT INTO member (identity, connections, status, forms, access, authorizations
 
 /* ID 987 - Daniel Johnson */
 INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
-    '{"first_name": "Daniel", "last_name": "Johnson", "nickname": null, "active_directory_username": "djohnson1", "emails": [{"type": "primary", "email_address": "ryan.jones@aol.com"}], "birthday": "1967-08-27", "aliases": []}'::jsonb,
+    '{"first_name": "Daniel", "last_name": "Johnson", "nickname": null, "active_directory_username": "djohnson1", "emails": [{"type": "primary", "email_address": "test3@example.com"}], "birthday": "1967-08-27", "aliases": []}'::jsonb,
     '{"discord_handle": "fitzgeraldjordan", "phone": "2258774104", "wildapricot_id": 85958825}'::jsonb,
     '{"membership_status": "suspended", "membership_level": "Stripe Member - $65", "member_since": "2019-01-31T12:59:02+00:00", "renewal_date": null, "balance": 0, "donations": 0, "donor": false}'::jsonb,
     '{"terms_of_use_accepted": true, "essentials_form": "completed", "id_check_1": "US", "id_check_2": "PP-Q28750860", "orientation_completed_date": "2024-04-03T00:00:00", "waiver_signed_date": "2021-10-05T00:00:00", "essentials_form_completed_date": "2021-09-28T00:00:00", "covid_vaccine_policy_acknowledged": null}'::jsonb,
@@ -11907,7 +11907,7 @@ INSERT INTO member (identity, connections, status, forms, access, authorizations
 
 /* ID 991 - Robert Cannon */
 INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
-    '{"first_name": "Robert", "last_name": "Cannon", "nickname": null, "active_directory_username": "rcannon", "emails": [{"type": "primary", "email_address": "william.williams@alumni.iit.edu"}], "birthday": null, "aliases": [], "pronouns": "she/they"}'::jsonb,
+    '{"first_name": "Robert", "last_name": "Cannon", "nickname": null, "active_directory_username": "rcannon", "emails": [{"type": "primary", "email_address": "octocat@github.com"}], "birthday": null, "aliases": [], "pronouns": "she/they"}'::jsonb,
     '{"discord_handle": "", "phone": "2213448913", "wildapricot_id": 92346847, "stripe_customer_id": "cus_4YAKW9vLK7f4qq"}'::jsonb,
     '{"membership_status": "suspended", "membership_level": "Stripe Member w/ Storage - $95", "member_since": "2025-07-13T03:00:53+00:00", "renewal_date": "2023-11-20T06:53:59", "balance": 0, "donations": 0, "donor": false}'::jsonb,
     '{"terms_of_use_accepted": true, "essentials_form": "completed", "id_check_date": "2022-05-14", "id_check_by": 2, "waiver_signed_date": "2024-04-24T00:00:00", "covid_vaccine_policy_acknowledged": null}'::jsonb,
@@ -11931,7 +11931,7 @@ INSERT INTO member (identity, connections, status, forms, access, authorizations
 
 /* ID 993 - Chelsea Villegas */
 INSERT INTO member (identity, connections, status, forms, access, authorizations, extras, notes) VALUES (
-    '{"first_name": "Chelsea", "last_name": "Villegas", "nickname": null, "active_directory_username": "cvillegas", "emails": [{"type": "primary", "email_address": "jennifer.lee@gmail.com"}], "birthday": "1994-02-15"}'::jsonb,
+    '{"first_name": "Chelsea", "last_name": "Villegas", "nickname": null, "active_directory_username": "cvillegas", "emails": [{"type": "primary", "email_address": "support@gravatar.com"}], "birthday": "1994-02-15"}'::jsonb,
     '{"discord_handle": "", "phone": "3277147263", "wildapricot_id": 90980826}'::jsonb,
     '{"membership_status": "suspended", "membership_level": "Stripe Volunteer w/ Paid Storage - $30", "member_since": "2021-04-27T01:50:21+00:00", "renewal_date": "2021-09-18T12:22:22", "balance": 0, "donations": 0, "donor": false}'::jsonb,
     '{"terms_of_use_accepted": true, "essentials_form": "completed", "id_check_1": "WI", "id_check_2": "DL-7542", "waiver_signed_date": null, "covid_vaccine_policy_acknowledged": "2023-01-10"}'::jsonb,


### PR DESCRIPTION
## What

Adds a member **avatar** to the admin portal — in the member search results list and the member-detail header that opens on select. Built as a pluggable **provider seam** (`resolve_avatar`), with **Gravatar as the first provider** and a documented insertion point for **Discord avatars later** (which will take precedence once real Discord OAuth linking lands).

No DHService or DB schema changes — the member's primary email is already on every `/api/members` row, so the hash is computed in the admin portal and rides along per row to both surfaces.

## Changes

- **Backend** (`app.py`): `resolve_avatar(member) -> {source, url}` returns a **sizeless** Gravatar URL (SHA-256 of the lowercased/trimmed email, `d=404`); `api_members()` attaches `avatar` to each row (type-guarded against error/non-list shapes). Precedence documented as `Discord (future) -> Gravatar -> none`.
- **Search list** (`index.html`): new rounded-square avatar column **between Status and ID** — row-height, **2x density**, `loading="lazy"`. XSS-safe `createElement`/`textContent` throughout; the `.cells[]` lookups (row highlight + in-place refresh) shifted +1 for the new column.
- **Detail header** (`index.html`): 48px avatar left of name/email/ID. Selection-time avatar is cached so the in-place refresh re-renders it without re-resolving (also future-proofs Discord).
- **Fallback**: `d=404` -> theme-primary **initials square** (member ID when no name). Hover-reveal **"G" source badge** + `Avatar source: Gravatar` tooltip, **on real photos only**.
- **CSP** (`base.html`): `img-src` now allows `https://www.gravatar.com` (image-only; no script/connect/style relaxation).
- **Styles** (`styles.css`): `.dh-avatar*` rules incl. a dark-text override for the amber/green (midnight/hacker) theme primaries.
- **Seed** (`seed_data.sql.example`): swap 5 high-id members' (979/983/987/991/993) primary email to verified example Gravatar addresses (`test1/2/3@example.com`, `octocat@github.com`, `support@gravatar.com`) so real photos appear on the first descending page in dev. Dev-login members (1-11) untouched.

## Notes / tradeoffs

- **Privacy:** direct browser fetch sends each viewed member's email **hash** (+ admin IP) to Gravatar/Automattic. Accepted for this cut; a server-side proxy is the future alternative.
- **No synthetic fallback:** real example Gravatars are scarce (only `test1/2/3@example.com` + a couple of brand addresses resolve), so most members show initials by design.
- **Known low-severity limitation:** an in-place email edit + refresh keeps the previous email's avatar until the list reloads (avatars are resolved server-side at list time only).

## Verification

Verified via chrome-devtools across **all 5 themes** (bubblegum / light / dark / midnight / hacker):
- Avatar column renders; initials squares for most members, real Gravatar photos for the seeded fixtures on the first page.
- Gravatar fixtures return 200 at `?d=404&s=56`; others 404 -> initials fallback. No CSP violations.
- Detail-header avatar at `s=96`; hover-reveal badge + tooltip on photos only; refresh persists the photo.
- Initials-square contrast good in every theme (white on bubblegum/light/dark, dark on midnight/hacker).
- Cell-index fixups confirmed (selection highlight + in-place refresh target the right cells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)