### PR TITLE
Admin portal: avatar hover-preview popover + header click-through

### DIFF
--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -67,7 +67,7 @@ th.dh-status-col { cursor: pointer; }
 [data-theme="midnight"] .dh-avatar-initials,
 [data-theme="hacker"] .dh-avatar-initials { color: #111; }
 
-/* Wrapper around a real photo — positioning context for the corner badge. */
+/* Wrapper around a real photo — hover trigger for the preview popover. */
 .dh-avatar-wrap {
     position: relative;
     display: inline-block;
@@ -75,34 +75,55 @@ th.dh-status-col { cursor: pointer; }
     line-height: 0;
 }
 
-/* Corner provider badge ("G" for Gravatar). JS keeps it hidden until the photo
-   actually loads; CSS then reveals it only on hover. */
-.dh-avatar-badge {
-    position: absolute;
-    right: -2px;
-    bottom: -2px;
-    min-width: 12px;
-    height: 12px;
-    padding: 0 2px;
-    border-radius: 4px;
-    background: var(--card-bg);
-    color: var(--text-color);
-    border: 1px solid var(--border-color);
-    font-size: 8px;
-    font-weight: 700;
-    line-height: 12px;
-    text-align: center;
-    opacity: 0;
-    transition: opacity 0.12s ease-in-out;
-    pointer-events: none;
+/* Header click-through link wrapping the photo (opens full size in a new tab). */
+.dh-avatar-link {
+    display: inline-block;
+    line-height: 0;
+    cursor: pointer;
 }
-.dh-avatar-wrap:hover .dh-avatar-badge { opacity: 1; }
 
 /* Detail-header avatar slot — keep it vertically centered with the text block. */
 .dh-member-header-avatar {
     display: inline-flex;
     flex: 0 0 auto;
     line-height: 0;
+}
+
+/* Avatar hover-preview popover — themed through Bootstrap's own CSS vars, same
+   pattern as the search-tips / status-legend popovers (all five themes define
+   the palette). Body-only (no header); max-width fits the 512 header image. */
+.dh-avatar-preview-popover {
+    --bs-popover-max-width: 560px;
+    --bs-popover-bg: var(--card-bg);
+    --bs-popover-border-color: var(--border-color);
+    --bs-popover-body-color: var(--text-color);
+}
+.dh-avatar-preview {
+    text-align: center;
+    max-width: 512px;
+}
+.dh-avatar-preview-img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    border-radius: 6px;
+    margin: 0 auto 0.5rem;
+}
+.dh-avatar-preview-name {
+    font-weight: 700;
+    line-height: 1.25;
+}
+.dh-avatar-preview-discord {
+    font-size: 0.85rem;
+    opacity: 0.8;
+    line-height: 1.25;
+}
+.dh-avatar-preview-source {
+    margin-top: 0.3rem;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--primary-color);
 }
 
 /* "Matched on" column in the results table (search mode only). Lists each

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -1649,13 +1649,18 @@ function buildStatusCell(rawStatus) {
 // --- Member avatars -------------------------------------------------------
 // Avatar provider seam mirror of the backend resolve_avatar(): the server
 // attaches member.avatar = {source, url} (sizeless URL, d=404) or null. The
-// frontend appends `&s=` (2x density) and falls back to a theme-primary
-// initials square when there is no registered photo. XSS-safe throughout:
-// createElement + textContent only; the badge mark comes from an allowlist.
+// thumbnail appends `&s=` (2x density) and falls back to a theme-primary
+// initials square when there is no registered photo. Hovering a real photo
+// opens a themed Bootstrap popover with a larger image (list 256 / header 512),
+// the member's name, and the source. XSS-safe throughout: createElement +
+// textContent only; the source label comes from an allowlist.
 
-// Source -> human label allowlist. Badge text is derived from this, never from
-// the raw server value.
+// Source -> human label allowlist. The card label is derived from this, never
+// from the raw server value.
 const AVATAR_SOURCE_LABELS = { gravatar: 'Gravatar' };
+// Source -> largest size the provider serves, used for the header click-through
+// (opens the full-size image in a new tab). Gravatar caps at 2048; Discord 4096.
+const AVATAR_SOURCE_MAX = { gravatar: 2048 };
 
 // Up-to-2-char initials; falls back to the member ID, then "?".
 function avatarInitials(member) {
@@ -1671,7 +1676,7 @@ function avatarInitials(member) {
 }
 
 // Style an element (fresh span, or a wrapper being converted after img error)
-// as the rounded-square initials placeholder.
+// as the rounded-square initials placeholder. Drops any anchor/img children.
 function styleAsInitials(el, member, cssPx) {
     el.className = 'dh-avatar dh-avatar-initials';
     el.style.width = cssPx + 'px';
@@ -1686,8 +1691,118 @@ function buildAvatarInitials(member, cssPx) {
     return span;
 }
 
+// Dispose the hover-preview popover attached to an avatar wrap, if any. Bootstrap
+// keys instances by element in a strong Map, so undisposed instances leak when
+// their row/header is replaced.
+function disposeAvatarPopover(wrapEl) {
+    if (wrapEl && window.bootstrap && bootstrap.Popover) {
+        const inst = bootstrap.Popover.getInstance(wrapEl);
+        if (inst) inst.dispose();
+    }
+}
+
+// Dispose every avatar popover within a subtree (used before re-rendering rows).
+function disposeAvatarPopoversIn(rootEl) {
+    if (rootEl) rootEl.querySelectorAll('.dh-avatar-wrap').forEach(disposeAvatarPopover);
+}
+
+// Build the popover card content (detached DOM): enlarged image, name line(s),
+// optional Discord handle (future seam), source. The big image is created
+// WITHOUT a src — attachAvatarPreview sets it lazily on first hover.
+function buildAvatarPreviewContent(member, sourceLabel, previewPx) {
+    const root = document.createElement('div');
+    root.className = 'dh-avatar-preview';
+
+    const img = document.createElement('img');
+    img.className = 'dh-avatar-preview-img';
+    img.width = previewPx;
+    img.height = previewPx;
+    img.alt = '';  // decorative; the name is spelled out below
+    root.appendChild(img);
+
+    const nickname = ((member.nickname) || '').trim();
+    const first = ((member.first_name) || '').trim();
+    const last = ((member.last_name) || '').trim();
+    const fullName = `${first} ${last}`.trim();
+
+    // Single name line: *nickname* lastname when a nickname exists, else First
+    // Last. Never both — the nickname form replaces the plain name, not adds to it.
+    const nameLine = document.createElement('div');
+    nameLine.className = 'dh-avatar-preview-name';
+    if (nickname) {
+        const em = document.createElement('em');
+        em.textContent = nickname;
+        nameLine.appendChild(em);
+        if (last) nameLine.appendChild(document.createTextNode(' ' + last));
+    } else {
+        nameLine.textContent = fullName;
+    }
+    if (nameLine.childNodes.length) root.appendChild(nameLine);
+
+    // Discord handle — future seam: only rendered when present (absent today).
+    const discord = ((member.discord_handle) || '').trim();
+    if (discord) {
+        const dh = document.createElement('div');
+        dh.className = 'dh-avatar-preview-discord';
+        dh.textContent = discord;
+        root.appendChild(dh);
+    }
+
+    if (sourceLabel) {
+        const src = document.createElement('div');
+        src.className = 'dh-avatar-preview-source';
+        src.textContent = sourceLabel;
+        root.appendChild(src);
+    }
+    return root;
+}
+
+// Attach a hover-preview Bootstrap popover to a real-photo avatar wrap. Called
+// only after the thumbnail successfully loads (so 404->initials never previews)
+// and only on fine pointers. The full-size image is pre-warmed on hover intent
+// so its download overlaps the show-delay and the card appears already filled.
+function attachAvatarPreview(wrapEl, member, sourceLabel, previewPx) {
+    if (!window.bootstrap || !bootstrap.Popover) return;
+    if (bootstrap.Popover.getInstance(wrapEl)) return;  // already attached
+
+    const content = buildAvatarPreviewContent(member, sourceLabel, previewPx);
+    const bigImg = content.querySelector('img');
+    let requested = false;
+
+    new bootstrap.Popover(wrapEl, {
+        html: true,
+        trigger: 'hover focus',
+        placement: 'auto',
+        container: 'body',
+        customClass: 'dh-avatar-preview-popover',
+        delay: { show: 300, hide: 100 },
+        content: content,
+    });
+
+    // Pre-warm the larger image so its download overlaps the 300ms show-delay and
+    // the card is (almost always) already filled by the time it appears. Idempotent
+    // — the fetch fires at most once, then the browser caches it. Gated behind a
+    // short hover-intent timer so a fast sweep down the list doesn't fetch full-size
+    // images for rows the pointer only brushes past.
+    let warmTimer = null;
+    function warm() {
+        if (!requested && bigImg) {
+            requested = true;
+            bigImg.src = `${member.avatar.url}&s=${previewPx}`;
+        }
+    }
+    wrapEl.addEventListener('mouseenter', function() { warmTimer = setTimeout(warm, 150); });
+    wrapEl.addEventListener('mouseleave', function() { clearTimeout(warmTimer); });
+    wrapEl.addEventListener('focus', warm, true);      // keyboard path (catches the header link)
+    wrapEl.addEventListener('show.bs.popover', warm);  // backstop if show beats the timer
+}
+
 // Build a member avatar node sized to `cssPx`, reused by the list and header.
-function buildAvatar(member, cssPx) {
+// opts.previewPx  -> attach the hover-preview popover (fetched at that size)
+// opts.linkFullSize -> wrap the photo in an <a> to the largest remote size
+//                      (header click-through, opens in a new tab)
+function buildAvatar(member, cssPx, opts) {
+    opts = opts || {};
     const avatar = member && member.avatar;
     if (!avatar || !avatar.url) {
         return buildAvatarInitials(member, cssPx);
@@ -1707,27 +1822,39 @@ function buildAvatar(member, cssPx) {
     img.height = cssPx;
     img.loading = 'lazy';
     img.alt = fullName || 'Member avatar';
-    if (sourceLabel) img.title = `Avatar source: ${sourceLabel}`;
+
+    // d=404 (no registered avatar) or any network error -> initials fallback.
+    // Convert the wrapper in place (drops the anchor/img) so it works whether or
+    // not it's in the DOM yet (a cached 404 can fire onerror synchronously).
+    img.addEventListener('error', function() {
+        disposeAvatarPopover(wrap);
+        styleAsInitials(wrap, member, cssPx);
+    });
+    // Only a real, loaded photo earns a preview popover, and only on fine
+    // pointers (touch/mobile falls through with no hover affordance).
+    if (opts.previewPx && window.matchMedia('(pointer: fine)').matches) {
+        img.addEventListener('load', function() {
+            attachAvatarPreview(wrap, member, sourceLabel, opts.previewPx);
+        });
+    }
+
+    // Header click-through: wrap the photo in a link to the largest remote size.
+    let imgHost = wrap;
+    const maxPx = opts.linkFullSize ? AVATAR_SOURCE_MAX[avatar.source] : null;
+    if (maxPx) {
+        const link = document.createElement('a');
+        link.className = 'dh-avatar-link';
+        link.href = `${avatar.url}&s=${maxPx}`;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        wrap.appendChild(link);
+        imgHost = link;
+    }
+    imgHost.appendChild(img);
+
+    // Set src last so the load/error listeners catch a synchronous cached result.
     // Sizeless URL from the server; request 2x for a crisp rounded square.
     img.src = `${avatar.url}&s=${cssPx * 2}`;
-    // d=404 (no registered avatar) or any network error -> initials fallback.
-    // Convert the wrapper in place so it works whether or not it's in the DOM
-    // yet (a cached 404 can fire onerror synchronously) and drops the badge.
-    img.onerror = function() { styleAsInitials(wrap, member, cssPx); };
-    wrap.appendChild(img);
-
-    // Corner source badge — only meaningful once a real photo actually loads,
-    // and revealed on hover via CSS.
-    if (sourceLabel) {
-        const badge = document.createElement('span');
-        badge.className = 'dh-avatar-badge';
-        badge.textContent = sourceLabel.charAt(0);  // "G" for Gravatar
-        badge.title = `Avatar source: ${sourceLabel}`;
-        badge.setAttribute('aria-hidden', 'true');
-        badge.style.display = 'none';
-        img.addEventListener('load', function() { badge.style.display = ''; });
-        wrap.appendChild(badge);
-    }
     return wrap;
 }
 
@@ -1735,7 +1862,7 @@ function buildAvatar(member, cssPx) {
 function buildAvatarCell(member) {
     const td = document.createElement('td');
     td.className = 'dh-avatar-col';
-    td.appendChild(buildAvatar(member, 28));
+    td.appendChild(buildAvatar(member, 28, { previewPx: 256 }));
     return td;
 }
 
@@ -1816,6 +1943,9 @@ function displayResults(members) {
     const searching = !!currentQuery;
     matchHeader.style.display = searching ? 'table-cell' : 'none';
 
+    // Dispose avatar popovers on the outgoing rows before discarding them, so
+    // Bootstrap's element-keyed instances don't leak across re-renders.
+    disposeAvatarPopoversIn(tbody);
     tbody.innerHTML = '';
 
     if (members.length === 0) {
@@ -2675,7 +2805,7 @@ function updateMemberHeaderInfo(member) {
         nameEl.textContent = '';
         emailEl.textContent = '';
         memberIdEl.textContent = '';
-        if (avatarEl) avatarEl.replaceChildren();
+        if (avatarEl) { disposeAvatarPopoversIn(avatarEl); avatarEl.replaceChildren(); }
         if (badgeEl) badgeEl.style.display = 'none';
         return;
     }
@@ -2690,8 +2820,12 @@ function updateMemberHeaderInfo(member) {
     nameEl.textContent = fullName || 'Member';
     emailEl.textContent = email || 'No email on file';
     // Same member row object carries member.avatar ({source,url} or null), so
-    // no extra fetch is needed here. 48px header avatar.
-    if (avatarEl) avatarEl.replaceChildren(buildAvatar(member, 48));
+    // no extra fetch is needed here. 48px header avatar with a 512 hover preview;
+    // clicking the photo opens the full-size image in a new tab.
+    if (avatarEl) {
+        disposeAvatarPopoversIn(avatarEl);
+        avatarEl.replaceChildren(buildAvatar(member, 48, { previewPx: 512, linkFullSize: true }));
+    }
     header.style.display = '';
 
     // Members API doesn't include birthday; fetch identity to set the 21+ badge.
@@ -2770,15 +2904,18 @@ function refreshMemberProfile() {
         const hasStatus = status && !status.error;
         const firstName = hasIdentity ? (identity.first_name || '') : '';
         const lastName = hasIdentity ? (identity.last_name || '') : '';
+        const nickname = hasIdentity ? (identity.nickname || '') : '';
         const email = hasIdentity ? primaryEmailFromIdentity(identity) : '';
         const membershipStatus = hasStatus ? (status.membership_status || '') : '';
 
-        // Refresh the header (also re-fetches identity for the 21+ badge).
+        // Refresh the header (also re-fetches identity for the 21+ badge). The
+        // raw identity carries nickname, so the refreshed card keeps its name line.
         if (hasIdentity) {
             updateMemberHeaderInfo({
                 member_id: reqMemberId,
                 first_name: firstName,
                 last_name: lastName,
+                nickname: nickname,
                 primary_email_address: email,
                 avatar: selectedMemberAvatar,
                 membership_status: membershipStatus,

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -1655,12 +1655,14 @@ function buildStatusCell(rawStatus) {
 // the member's name, and the source. XSS-safe throughout: createElement +
 // textContent only; the source label comes from an allowlist.
 
-// Source -> human label allowlist. The card label is derived from this, never
-// from the raw server value.
-const AVATAR_SOURCE_LABELS = { gravatar: 'Gravatar' };
-// Source -> largest size the provider serves, used for the header click-through
-// (opens the full-size image in a new tab). Gravatar caps at 2048; Discord 4096.
-const AVATAR_SOURCE_MAX = { gravatar: 2048 };
+// Per-source config allowlist. `label` is what the card shows (derived from
+// this, never the raw server value); `maxSize` is the largest size the provider
+// serves, used for the header click-through (full-size image in a new tab).
+// Keep label + maxSize together so a new source can't be half-registered — add
+// the whole entry in one place. Discord (next): { label: 'Discord', maxSize: 4096 }.
+const AVATAR_SOURCES = {
+    gravatar: { label: 'Gravatar', maxSize: 2048 },
+};
 
 // Up-to-2-char initials; falls back to the member ID, then "?".
 function avatarInitials(member) {
@@ -1813,7 +1815,8 @@ function buildAvatar(member, cssPx, opts) {
     wrap.style.width = cssPx + 'px';
     wrap.style.height = cssPx + 'px';
 
-    const sourceLabel = AVATAR_SOURCE_LABELS[avatar.source] || '';
+    const sourceConfig = AVATAR_SOURCES[avatar.source] || {};
+    const sourceLabel = sourceConfig.label || '';
     const fullName = `${((member.first_name) || '').trim()} ${((member.last_name) || '').trim()}`.trim();
 
     const img = document.createElement('img');
@@ -1840,7 +1843,7 @@ function buildAvatar(member, cssPx, opts) {
 
     // Header click-through: wrap the photo in a link to the largest remote size.
     let imgHost = wrap;
-    const maxPx = opts.linkFullSize ? AVATAR_SOURCE_MAX[avatar.source] : null;
+    const maxPx = opts.linkFullSize ? sourceConfig.maxSize : null;
     if (maxPx) {
         const link = document.createElement('a');
         link.className = 'dh-avatar-link';
@@ -2922,9 +2925,9 @@ function refreshMemberProfile() {
             });
         }
 
-        // Sync this member's row in the results table (status icon + names).
-        // Only overwrite cells whose source fetch actually succeeded, so a
-        // failed fetch never blanks a known value. Cells: 0=status, 1=avatar,
+        // Sync this member's row in the results table (status icon + names +
+        // avatar). Only overwrite cells whose source fetch actually succeeded, so
+        // a failed fetch never blanks a known value. Cells: 0=status, 1=avatar,
         // 2=id, 3=first, 4=last.
         document.querySelectorAll('#resultsTableBody tr').forEach(r => {
             if (!r.cells[2] || r.cells[2].textContent != reqMemberId) return;
@@ -2934,6 +2937,22 @@ function refreshMemberProfile() {
             if (hasIdentity) {
                 if (r.cells[3]) r.cells[3].textContent = firstName;
                 if (r.cells[4]) r.cells[4].textContent = lastName;
+                // Rebuild the avatar cell so its hover-preview reflects the edited
+                // name/nickname (its popover content was baked at displayResults
+                // time and is otherwise never refreshed). Dispose the old popover
+                // first. Avatar URL comes from the cached selectedMemberAvatar.
+                if (r.cells[1]) {
+                    disposeAvatarPopoversIn(r.cells[1]);
+                    r.replaceChild(buildAvatarCell({
+                        member_id: reqMemberId,
+                        first_name: firstName,
+                        last_name: lastName,
+                        nickname: nickname,
+                        primary_email_address: email,
+                        avatar: selectedMemberAvatar,
+                        membership_status: membershipStatus,
+                    }), r.cells[1]);
+                }
             }
         });
 

--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -458,6 +458,7 @@ def list_members(page: int = 1, per_page: int = 25,
                 f"""SELECT m.id,
                            m.identity ->> 'first_name' AS first_name,
                            m.identity ->> 'last_name' AS last_name,
+                           m.identity ->> 'nickname' AS nickname,
                            m.identity -> 'emails' -> 0 ->> 'email_address' AS primary_email_address,
                            m.status ->> 'membership_status' AS membership_status,
                            m.status ->> 'stripe_product_id' AS stripe_product_id,
@@ -471,14 +472,15 @@ def list_members(page: int = 1, per_page: int = 25,
             results = cur.fetchall()
 
             for result in results:
-                total = result[6]
+                total = result[7]
                 members.append({
                     "member_id": result[0],
                     "first_name": result[1],
                     "last_name": result[2],
-                    "primary_email_address": result[3],
-                    "membership_status": result[4],
-                    "stripe_product_id": result[5],
+                    "nickname": result[3],
+                    "primary_email_address": result[4],
+                    "membership_status": result[5],
+                    "stripe_product_id": result[6],
                 })
 
             # A past-the-end page returns no rows, so the COUNT(*) OVER() total
@@ -520,6 +522,7 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
                                access,
                                identity ->> 'first_name' AS first_name,
                                identity ->> 'last_name' AS last_name,
+                               identity ->> 'nickname' AS nickname,
                                identity -> 'emails' -> 0 ->> 'email_address' AS primary_email_address,
                                status ->> 'membership_status' AS membership_status,
                                status ->> 'stripe_product_id' AS stripe_product_id,
@@ -534,7 +537,7 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
                         ORDER BY {sort_col} {direction}, id ASC
                         LIMIT  %s OFFSET %s
                     )
-                    SELECT page.id, page.first_name, page.last_name,
+                    SELECT page.id, page.first_name, page.last_name, page.nickname,
                            page.primary_email_address, page.membership_status,
                            page.stripe_product_id, tot.total_count,
                            ( SELECT jsonb_agg(
@@ -550,7 +553,7 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
             results = cur.fetchall()
 
     for result in results:
-        total = result[6]
+        total = result[7]
         # Skip the empty-page sentinel (NULL id) emitted by the tot LEFT JOIN
         # when the requested page is past the end — its only job is to carry total.
         if result[0] is None:
@@ -559,13 +562,14 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
             "member_id": result[0],
             "first_name": result[1],
             "last_name": result[2],
-            "primary_email_address": result[3],
-            "membership_status": result[4],
-            "stripe_product_id": result[5],
+            "nickname": result[3],
+            "primary_email_address": result[4],
+            "membership_status": result[5],
+            "stripe_product_id": result[6],
             # Per-field attribution for the admin "Matched on" column: list of
             # {field, value} ordered strongest-first, or None when nothing
             # attributable (e.g. an access-blob-only digit match).
-            "matches": result[7],
+            "matches": result[8],
         })
 
     logger.debug(f"Paginated search found {len(members)} members (total={total})")


### PR DESCRIPTION
Builds on the avatar framework from #327. Replaces the avatar's minimal hover (corner "G" badge + native title tooltip) with a richer, themed hover-preview popover, and makes the profile-header photo a click-through to its full-size remote image.

## What's new

**Hover-preview popover** (list **256px** / header **512px**)
- Themed Bootstrap popover (reuses the search-tips / status-legend `--bs-popover-*` idiom, so it themes across all 5 themes).
- Card content: enlarged image, a **single name line** — *nickname* (italic) + last name, or `First Last` when there's no nickname — a future Discord-handle line (rendered only when present; empty seam today), and the source label.
- Gated to `matchMedia('(pointer: fine)')` so touch falls through with no popover.
- Only a successfully-loaded real photo gets a popover; `d=404` → initials never previews.

**Pre-warmed image (no blank-then-fill flash)**
- The larger image fetch is kicked off on a ~150ms hover-intent timer (cleared on `mouseleave` so a fast list sweep doesn't fetch full-size images for rows only brushed past), so its download overlaps Bootstrap's 300ms show-delay and the card is **already filled when it appears**. Idempotent — fetched at most once, then browser-cached. No extra network vs. the naive approach; just reordered.

**Header click-through**
- The 48px header photo is wrapped in `<a target="_blank" rel="noopener noreferrer">` to the largest remote size (Gravatar `s=2048`; `AVATAR_SOURCE_MAX` map, Discord 4096 later). List avatars stay unlinked so their click bubbles to the row handler and opens the profile.

**Popover disposal (no leaks)**
- `displayResults` disposes outgoing-row popovers before clearing the tbody, and `updateMemberHeaderInfo` disposes the old header popover before re-rendering — Bootstrap keys instances by element in a strong Map, so undisposed instances would leak across re-renders/re-selects.

**Backend**
- Surfaces `identity.nickname` on the `/api/members` payload (DHService `db.py` `list_members` + `search_members_paginated` row dicts) so the card's name line works for both the list and the header; flows through the admin passthrough verbatim.
- **No schema change** (Python inline SQL) → prod rollout is a DHService redeploy, not a schema migration.

**Styles**
- Retire `.dh-avatar-badge`; add `.dh-avatar-preview-popover` + card styles.

## Verification

Verified via chrome-devtools across all 5 themes (bubblegum / light / dark / midnight / hacker):
- List + header previews render with correct theming/contrast.
- Single name line: *nickname* Last when a nickname exists, else First Last (no redundant second line).
- Pre-warm: fetch starts ~150ms and completes (~233ms) before the 300ms show — card appears filled, confirmed on a cache-cold avatar.
- Header photo click → full-size (`s=2048`) in a new tab; list-avatar click opens the profile (not a new tab).
- Initials and 404 avatars get no popover.
- Popover disposal on re-render confirmed (no leaks); console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)