### PR TITLE
Admin portal: member-list status/level filtering + theme-menu & toolbar polish

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -732,24 +732,29 @@ def api_members():
     sort = request.args.get("sort", "date_added")
     order = request.args.get("order", "desc")
 
-    # Status/level filters (both multi-valued). membership_status drives the
-    # member.identity-visible Status icon, so its filter is always allowed.
-    statuses = request.args.getlist("status") or None
-    levels = request.args.getlist("level") or None
+    # Status/level filters (both multi-valued), keyed by the member-row field
+    # each one targets. Keying by the backing field lets the gating below reuse
+    # _STATUS_GATED_LIST_FIELDS — the same registry that strips row fields and
+    # bars sort keys — instead of a per-filter special case. membership_status
+    # is NOT gated (it drives the member.identity-visible Status icon).
+    filters = {
+        "membership_status": request.args.getlist("status") or None,
+        "membership_level": request.args.getlist("level") or None,
+    }
 
-    # Callers without member.status may neither receive nor SORT BY the gated
-    # status fields — a hand-crafted ?sort=member_since would order the roster by
-    # a field whose values we strip below, leaking its ordering. Bar those sort
-    # keys here (revert to the default sort) before the query runs.
+    # Callers without member.status may neither receive, SORT BY, nor FILTER BY
+    # the gated status fields — a hand-crafted ?sort=member_since would order the
+    # roster by a field whose values we strip below, and a ?level= filter would
+    # leak which members carry a (stripped) level. Bar those sort keys and drop
+    # those filters here, driven off the same registry so a future gated field
+    # can't forget to opt in.
     status_gated = not has_view_permission("member.status")
-    if status_gated and sort in _STATUS_GATED_SORT_KEYS:
-        sort = "date_added"
-        order = "desc"
-    # membership_level is one of the gated fields — drop the level filter for
-    # callers lacking member.status so a filtered query can't leak which members
-    # carry which (stripped) level.
     if status_gated:
-        levels = None
+        if sort in _STATUS_GATED_SORT_KEYS:
+            sort = "date_added"
+            order = "desc"
+        for field in _STATUS_GATED_LIST_FIELDS:
+            filters.pop(field, None)
 
     try:
         access_token = dhservices.get_access_token(
@@ -758,7 +763,8 @@ def api_members():
         )
 
         result = dhservices.list_members(access_token, query, page, per_page, sort, order,
-                                         statuses=statuses, levels=levels)
+                                         statuses=filters.get("membership_status"),
+                                         levels=filters.get("membership_level"))
 
         # Attach a resolved avatar ({source, url} or None) to each member row.
         # The same row object feeds both the results list and the detail header.

--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -732,6 +732,11 @@ def api_members():
     sort = request.args.get("sort", "date_added")
     order = request.args.get("order", "desc")
 
+    # Status/level filters (both multi-valued). membership_status drives the
+    # member.identity-visible Status icon, so its filter is always allowed.
+    statuses = request.args.getlist("status") or None
+    levels = request.args.getlist("level") or None
+
     # Callers without member.status may neither receive nor SORT BY the gated
     # status fields — a hand-crafted ?sort=member_since would order the roster by
     # a field whose values we strip below, leaking its ordering. Bar those sort
@@ -740,6 +745,11 @@ def api_members():
     if status_gated and sort in _STATUS_GATED_SORT_KEYS:
         sort = "date_added"
         order = "desc"
+    # membership_level is one of the gated fields — drop the level filter for
+    # callers lacking member.status so a filtered query can't leak which members
+    # carry which (stripped) level.
+    if status_gated:
+        levels = None
 
     try:
         access_token = dhservices.get_access_token(
@@ -747,7 +757,8 @@ def api_members():
             dhservices.DH_CLIENT_SECRET
         )
 
-        result = dhservices.list_members(access_token, query, page, per_page, sort, order)
+        result = dhservices.list_members(access_token, query, page, per_page, sort, order,
+                                         statuses=statuses, levels=levels)
 
         # Attach a resolved avatar ({source, url} or None) to each member row.
         # The same row object feeds both the results list and the detail header.
@@ -791,6 +802,21 @@ def api_members():
         return result
     except Exception as e:
         logger.error(f"Error listing members: {e}")
+        return {"error": str(e)}, 500
+
+@app.route("/api/member_levels")
+@requires_view_permission("member.status")
+def api_member_levels():
+    """Distinct stored membership_level values for the member-list filter dropdown.
+    Gated behind member.status because membership_level is a status-gated field."""
+    try:
+        access_token = dhservices.get_access_token(
+            dhservices.DH_CLIENT_ID,
+            dhservices.DH_CLIENT_SECRET
+        )
+        return {"levels": dhservices.get_distinct_membership_levels(access_token)}
+    except Exception as e:
+        logger.error(f"Error fetching membership levels: {e}")
         return {"error": str(e)}, 500
 
 @app.route("/api/search")

--- a/code/DHAdminPortal/dhservices.py
+++ b/code/DHAdminPortal/dhservices.py
@@ -48,15 +48,30 @@ def search_members(access_token: str, query: str):
     response.raise_for_status()
     return response.json()
 
-# List members with pagination — supports optional search query
+# List members with pagination — supports optional search query and optional
+# status/level filters (both multi-valued; lists become repeated query params).
 def list_members(access_token: str, query: str = None, page: int = 1,
-                 per_page: int = 25, sort: str = "date_added", order: str = "desc"):
+                 per_page: int = 25, sort: str = "date_added", order: str = "desc",
+                 statuses=None, levels=None):
     url = f"{DH_API_BASE_URL}/v1/member/list/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"page": page, "per_page": per_page, "sort": sort, "order": order}
     if query:
         params["query"] = query
+    # Filters compose with search, so forward them regardless of query.
+    if statuses:
+        params["status"] = statuses
+    if levels:
+        params["level"] = levels
     response = requests.get(url, headers=headers, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+# Distinct stored membership_level values — drives the member-list filter dropdown.
+def get_distinct_membership_levels(access_token: str):
+    url = f"{DH_API_BASE_URL}/v1/member/membership_levels/distinct/"
+    headers = {"Authorization": f"Bearer {access_token}"}
+    response = requests.get(url, headers=headers, timeout=10)
     response.raise_for_status()
     return response.json()
 

--- a/code/DHAdminPortal/static/styles.css
+++ b/code/DHAdminPortal/static/styles.css
@@ -32,6 +32,61 @@
 }
 th.dh-status-col { cursor: pointer; }
 
+/* --- Member-list filter bar (status pills + level multi-select) ---------- */
+/* All colors come from the per-theme DH palette custom props, so a single rule
+   set themes across all 5 themes (the .dh-status-* icon classes carry the per-
+   status hue). Inactive pills are dimmed; .active lifts them with a theme-accent
+   wash + border. */
+/* Flex here (not the d-flex utility) so the inline display toggle can hide it
+   without fighting Bootstrap's !important. width:fit-content + margin-inline:auto
+   centers the line while it fits; once content exceeds the row it caps at 100%,
+   the auto margins collapse to 0, and items wrap left-aligned. */
+#memberFilterBar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    row-gap: 0.35rem;
+    width: fit-content;
+    max-width: 100%;
+    margin-inline: auto;
+}
+.dh-filter-label { color: var(--text-color); opacity: 0.7; }
+
+.dh-status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.18rem 0.6rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-color);
+    background: var(--card-bg);
+    color: var(--text-color);
+    font-size: 0.85rem;
+    line-height: 1.25;
+    cursor: pointer;
+    opacity: 0.7;
+    transition: opacity 0.12s ease, border-color 0.12s ease, background-color 0.12s ease;
+}
+.dh-status-pill:hover,
+.dh-status-pill:focus-visible { opacity: 1; outline: none; }
+.dh-status-pill.active {
+    opacity: 1;
+    font-weight: 600;
+    border-color: var(--primary-color);
+    background: color-mix(in srgb, var(--primary-color) 14%, var(--card-bg));
+}
+.dh-status-pill .dh-status-icon { font-size: 0.95em; }
+/* The level toggle is a pill too; its glyph inherits the text color. */
+.dh-level-toggle .fa-person-arrow-up-from-line { font-size: 0.85em; opacity: 0.85; }
+
+.dh-clear-filters {
+    font-size: 0.8rem;
+    text-decoration: none;
+    color: var(--primary-color);
+}
+.dh-clear-filters:hover { text-decoration: underline; }
+
 /* --- Member avatars ----------------------------------------------------- */
 /* Narrow, centered avatar column in the results table (between status and ID) */
 .dh-avatar-col {
@@ -170,6 +225,9 @@ th.dh-status-col { cursor: pointer; }
 #columnPicker {
     display: flex;
     align-items: center;
+    /* The toolbar's gap-2 alone leaves this tighter than the info/filter buttons
+       (which add their own 0.35rem margin-right); match that spacing here. */
+    margin-left: 0.35rem;
 }
 
 .dh-columns-menu {
@@ -186,8 +244,51 @@ th.dh-status-col { cursor: pointer; }
     overflow-y: auto;
 }
 .dh-columns-menu .form-check { margin-bottom: 0.15rem; }
-.dh-columns-menu .form-check-label { cursor: pointer; }
+.dh-columns-menu .form-check-label { cursor: pointer; font-size: 0.85rem; }
 .dh-columns-menu .form-check-input:disabled { opacity: 0.6; }
+/* Section heading for the column/level dropdowns — matches the search-tips
+   popover header exactly: a full-bleed tinted bar (primary-accent wash), 1rem/600
+   primary text, divider under it. Negative margins break out of the menu's p-2 so
+   the bar spans edge-to-edge; top corners inherit the menu's radius. */
+.dh-menu-heading {
+    font-weight: 600;
+    font-size: 1rem;
+    color: var(--primary-color);
+    background: color-mix(in srgb, var(--primary-color) 12%, var(--card-bg));
+    margin: -0.5rem -0.5rem 0.4rem;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
+}
+
+/* Theme-switcher toggle icon — slightly larger than the default nav-link size.
+   line-height:1 keeps its line box (and thus the navbar height) from growing with
+   the larger glyph; the icon still renders at 1.2rem. */
+#themeDropdown { font-size: 1.2rem; line-height: 1; }
+
+/* Active-theme marker in the theme menu: a trailing check + bold + faint tint so
+   it's clear which theme is selected. Off-items keep the check slot reserved (via
+   opacity, not display) so the row text doesn't shift between selections. */
+.dh-theme-item { display: flex; align-items: center; }
+.dh-theme-check { margin-left: auto; padding-left: 1.25rem; opacity: 0; color: var(--primary-color); }
+.dh-theme-item.dh-theme-active { font-weight: 600; }
+.dh-theme-item.dh-theme-active .dh-theme-check { opacity: 1; }
+.dh-theme-item.dh-theme-active { background-color: color-mix(in srgb, var(--primary-color) 12%, transparent); }
+
+/* Theme-switcher dropdown header — same tinted section-bar idiom as
+   .dh-menu-heading, but adapted for the default .dropdown-menu (no p-2, so no
+   horizontal break-out) and keeping the menu's existing font size. */
+.dh-theme-heading {
+    font-weight: 600;
+    color: var(--primary-color);
+    background: color-mix(in srgb, var(--primary-color) 12%, var(--card-bg));
+    margin: -0.5rem 0 0.4rem;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
+}
 .dh-columns-reset {
     color: var(--primary-color);
     text-decoration: none;
@@ -748,7 +849,7 @@ body.sidebar-open .body-content {
     font-size: 1.4rem;
     cursor: pointer;
     opacity: 0.75;
-    transition: opacity 0.15s ease, filter 0.15s ease;
+    transition: opacity 0.15s ease;
     flex-shrink: 0;
     user-select: none;
     margin-left: 0.25rem;
@@ -756,10 +857,9 @@ body.sidebar-open .body-content {
 
 .dh-refresh-btn:hover {
     opacity: 1;
-    filter: drop-shadow(0 0 4px currentColor);
 }
 
-/* Theme-specific refresh button hover glow */
+/* Theme-specific refresh button color */
 [data-theme="bubblegum"] .dh-refresh-btn { color: #d63384; }
 [data-theme="light"] .dh-refresh-btn { color: var(--primary-color); }
 [data-theme="dark"] .dh-refresh-btn { color: var(--primary-color); }
@@ -780,8 +880,14 @@ body.sidebar-open .body-content {
     flex-shrink: 0;
     color: inherit;
 }
+/* Highlight on hover + keyboard focus only — a mouse click leaves :focus behind,
+   which would keep the icon lit after the action (e.g. the filter toggle staying
+   "on" after closing the bar). :focus-visible excludes mouse focus. */
 .dh-search-help-btn:hover,
-.dh-search-help-btn:focus { opacity: 1; outline: none; }
+.dh-search-help-btn:focus-visible { opacity: 1; }
+.dh-search-help-btn:focus { outline: none; }
+/* Filter toggle reads as "on" while the filter line is open. */
+.dh-search-help-btn.active { opacity: 1; }
 [data-theme="bubblegum"] .dh-search-help-btn { color: #d63384; }
 [data-theme="light"] .dh-search-help-btn { color: var(--primary-color); }
 [data-theme="dark"] .dh-search-help-btn { color: var(--primary-color); }

--- a/code/DHAdminPortal/templates/base.html
+++ b/code/DHAdminPortal/templates/base.html
@@ -94,19 +94,20 @@
                     <li class="nav-item dropdown">
                         <a class="nav-link" href="#" id="themeDropdown" role="button"
                            data-bs-toggle="dropdown" aria-expanded="false" title="Switch theme">
-                            <i class="fa-solid fa-palette"></i>
+                            <i class="fa-solid fa-paintbrush"></i>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="themeDropdown">
-                            <li><a class="dropdown-item" href="#" onclick="setTheme('bubblegum'); return false;">
-                                <i class="fa-solid fa-candy-cane me-2"></i>Bubblegum</a></li>
-                            <li><a class="dropdown-item" href="#" onclick="setTheme('light'); return false;">
-                                <i class="fa-solid fa-sun me-2"></i>Light</a></li>
-                            <li><a class="dropdown-item" href="#" onclick="setTheme('dark'); return false;">
-                                <i class="fa-solid fa-moon me-2"></i>Dark</a></li>
-                            <li><a class="dropdown-item" href="#" onclick="setTheme('midnight'); return false;">
-                                <i class="fa-solid fa-star me-2"></i>Midnight</a></li>
-                            <li><a class="dropdown-item" href="#" onclick="setTheme('hacker'); return false;">
-                                <i class="fa-solid fa-terminal me-2"></i>Hacker</a></li>
+                            <li class="dh-theme-heading">Theme</li>
+                            <li><a class="dropdown-item dh-theme-item" href="#" data-theme-value="bubblegum" onclick="setTheme('bubblegum'); return false;">
+                                <i class="fa-solid fa-heart me-2"></i>Bubblegum<i class="fa-solid fa-check dh-theme-check"></i></a></li>
+                            <li><a class="dropdown-item dh-theme-item" href="#" data-theme-value="light" onclick="setTheme('light'); return false;">
+                                <i class="fa-solid fa-lightbulb me-2"></i>Lights On<i class="fa-solid fa-check dh-theme-check"></i></a></li>
+                            <li><a class="dropdown-item dh-theme-item" href="#" data-theme-value="dark" onclick="setTheme('dark'); return false;">
+                                <i class="fa-solid fa-fire me-2"></i>Kitchen 17<i class="fa-solid fa-check dh-theme-check"></i></a></li>
+                            <li><a class="dropdown-item dh-theme-item" href="#" data-theme-value="midnight" onclick="setTheme('midnight'); return false;">
+                                <i class="fa-solid fa-star me-2"></i>Locke's Dream<i class="fa-solid fa-check dh-theme-check"></i></a></li>
+                            <li><a class="dropdown-item dh-theme-item" href="#" data-theme-value="hacker" onclick="setTheme('hacker'); return false;">
+                                <i class="fa-solid fa-terminal me-2"></i>Hacker<i class="fa-solid fa-check dh-theme-check"></i></a></li>
                         </ul>
                     </li>
                 </ul>
@@ -148,11 +149,21 @@
 
     <!-- Theme switcher -->
     <script>
+    // Mark the dropdown item for the live theme (data-theme on <html>, set by the
+    // cookie-driven FOUC script) so it's clear which theme is active.
+    function markActiveTheme() {
+        var cur = document.documentElement.getAttribute('data-theme');
+        document.querySelectorAll('.dh-theme-item').forEach(function (el) {
+            el.classList.toggle('dh-theme-active', el.getAttribute('data-theme-value') === cur);
+        });
+    }
     function setTheme(theme) {
         if (theme !== 'bubblegum' && theme !== 'light' && theme !== 'dark' && theme !== 'midnight' && theme !== 'hacker') theme = 'bubblegum';
         document.documentElement.setAttribute('data-theme', theme);
         document.cookie = 'dh_admin_theme=' + theme + ';path=/;max-age=31536000;SameSite=Lax';
+        markActiveTheme();
     }
+    document.addEventListener('DOMContentLoaded', markActiveTheme);
     </script>
 
     <!-- Validation toast (shared across all forms) -->

--- a/code/DHAdminPortal/templates/index.html
+++ b/code/DHAdminPortal/templates/index.html
@@ -36,6 +36,11 @@
                 <button type="button" class="dh-search-help-btn" id="searchHelpBtn" aria-label="Search tips">
                     <i class="fa-solid fa-circle-info"></i>
                 </button>
+                <!-- Toggle the member-list filter line (pills + level). Hidden by
+                     default; hiding it resets any active filters. -->
+                <button type="button" class="dh-search-help-btn" id="filterToggleBtn" onclick="toggleFilterBar()" aria-expanded="false" aria-label="Toggle filters" title="Filter members">
+                    <i class="fa-solid fa-filter"></i>
+                </button>
                 <div class="input-group">
                     <input type="search" class="form-control" id="memberSearch" placeholder="Search for a member..." autocapitalize="none" autocorrect="off" autocomplete="off" spellcheck="false" onkeydown="if(event.key==='Enter')searchMembers()">
                     <button class="btn btn-primary cute-signin" type="button" id="searchButton" onclick="searchMembers()" aria-label="Search" title="Search"><i class="fa-solid fa-magnifying-glass"></i></button>
@@ -97,6 +102,23 @@
     <!-- Left panel: results table + pagination -->
     <div id="resultsPanel" class="flex-grow-1" style="min-width: 0;">
         <div id="resultsSection" style="display: none;">
+            <!-- Member-list filters: status pills (always) + level multi-select
+                 (only for member.status viewers). Pills built by buildStatusPills();
+                 the level checklist by initLevelFilter() from /api/member_levels.
+                 Filters compose with the search query and ride the URL. Hidden by
+                 default (no d-flex utility class — its !important would defeat the
+                 inline display toggle); flex/centering live in #memberFilterBar CSS. -->
+            <div id="memberFilterBar" class="mb-2 px-2 pt-2" style="display: none;">
+                <span class="dh-filter-label small">Filter:</span>
+                <div id="statusPills" class="d-flex gap-1 flex-wrap" role="group" aria-label="Filter by status"></div>
+                <div class="dropdown" id="levelFilter" style="display: none;">
+                    <button type="button" class="dh-status-pill dh-level-toggle" id="levelFilterBtn" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false" title="Filter by membership level">
+                        <i class="fa-solid fa-person-arrow-up-from-line" aria-hidden="true"></i> <span id="levelFilterLabel">Level</span>
+                    </button>
+                    <div class="dropdown-menu dh-columns-menu p-2" id="levelFilterMenu" aria-labelledby="levelFilterBtn"></div>
+                </div>
+                <button type="button" class="btn btn-sm btn-link dh-clear-filters p-0" id="clearFiltersBtn" onclick="clearAllFilters()">Clear filters</button>
+            </div>
             <div class="table-responsive" style="overflow-x: auto;">
                 <table class="table table-striped table-hover mb-0">
                     <thead class="sticky-top bg-white">
@@ -1560,11 +1582,21 @@ function fallbackSortIfActiveColumnHidden() {
     return false;
 }
 
+// Small bold accent heading for the filter/column dropdown menus — mirrors the
+// search-tips popover's section-lead formatting.
+function buildMenuHeading(text) {
+    const h = document.createElement('div');
+    h.className = 'dh-menu-heading';
+    h.textContent = text;
+    return h;
+}
+
 // Populate the column-picker dropdown checklist + Reset action (once, on load).
 function initColumnPicker() {
     const menu = document.getElementById('columnPickerMenu');
     if (!menu) return;
     menu.innerHTML = '';
+    menu.appendChild(buildMenuHeading('Columns'));
     MEMBER_COLUMNS.forEach(col => {
         const wrap = document.createElement('div');
         wrap.className = 'form-check';
@@ -1779,6 +1811,12 @@ let currentOrder = 'desc';
 let perPage = parseInt(localStorage.getItem('dh-per-page'), 10) || 20;
 let selectedMemberId = null;
 
+// Member-list filter state (status pills + level multi-select). Both ride the URL
+// and compose with the search query. See buildStatusPills()/initLevelFilter().
+let activeStatusFilters = new Set();  // subset of STATUS_FILTER_VALUES
+let activeLevelFilters = new Set();   // exact membership_level strings
+let filterBarVisible = false;         // the filter line is toggled by the toolbar filter icon
+
 // Logging-notice banner: dismissible, remembered per-browser in localStorage
 
 function dismissLoggingNotice() {
@@ -1822,6 +1860,9 @@ function loadMembers(page) {
     params.set('sort', currentSort);
     params.set('order', currentOrder);
     if (currentQuery) params.set('query', currentQuery);
+    // Filters compose with the query (browse + search both filtered).
+    activeStatusFilters.forEach(s => params.append('status', s));
+    activeLevelFilters.forEach(l => params.append('level', l));
 
     // Show loading state on search button
     const searchBtn = document.getElementById('searchButton');
@@ -1958,6 +1999,176 @@ function buildStatusCell(rawStatus) {
     icon.setAttribute('aria-label', meta.label);
     td.appendChild(icon);
     return td;
+}
+
+// --- Member-list filters (status pills + level multi-select) --------------
+// Filters compose with the search query (both browse and search are filtered)
+// and ride the URL. Status pills are the 4 real states + an "Other/Unknown"
+// bucket (NULL/blank/inactive/non-standard) that mirrors the column's grey icon.
+// The status set is the server allowlist + the `other` sentinel — kept in lockstep
+// with DHService _MEMBERSHIP_STATUS_FILTER_VALUES.
+const STATUS_FILTER_VALUES = ['active', 'pending', 'suspended', 'banned', 'other'];
+
+// Icon/color/label for a filter key. `other` reuses the grey question-mark glyph
+// (STATUS_ICON_DEFAULT); the four canonical keys reuse STATUS_ICONS verbatim, so
+// pills and table icons can never drift.
+function statusFilterMeta(key) {
+    if (key === 'other') {
+        return { icon: STATUS_ICON_DEFAULT.icon, cls: STATUS_ICON_DEFAULT.cls, label: 'Other/Unknown' };
+    }
+    const m = STATUS_ICONS[key];
+    return { icon: m.icon, cls: m.cls, label: m.label };
+}
+
+// Build the status pill row once (XSS-safe: createElement/textContent, classes
+// from the allowlist only — never interpolate a raw status).
+function buildStatusPills() {
+    const host = document.getElementById('statusPills');
+    if (!host) return;
+    host.replaceChildren();
+    STATUS_FILTER_VALUES.forEach(key => {
+        const meta = statusFilterMeta(key);
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'dh-status-pill';
+        btn.dataset.status = key;
+        btn.setAttribute('aria-pressed', 'false');
+        const icon = document.createElement('i');
+        icon.className = `fa-solid ${meta.icon} dh-status-icon ${meta.cls}`;
+        icon.setAttribute('aria-hidden', 'true');
+        btn.appendChild(icon);
+        const lbl = document.createElement('span');
+        lbl.textContent = meta.label;
+        btn.appendChild(lbl);
+        btn.addEventListener('click', () => toggleStatusFilter(key));
+        host.appendChild(btn);
+    });
+}
+
+function toggleStatusFilter(key) {
+    if (activeStatusFilters.has(key)) activeStatusFilters.delete(key);
+    else activeStatusFilters.add(key);
+    syncFilterBarUI();
+    loadMembers(1);  // reset to page 1 — the filtered set may not have the current page
+}
+
+// Level multi-select dropdown. membership_level is a member.status-gated field,
+// so the control is only built for admins who can see it (the server also drops
+// the level filter for callers lacking member.status). Populated once from
+// /api/member_levels with the distinct stored level values.
+let _levelFilterInited = false;
+function initLevelFilter() {
+    const wrap = document.getElementById('levelFilter');
+    if (!wrap || _levelFilterInited) return;
+    if (!(canViewTab('member.status') || canChangeTab('member.status'))) {
+        wrap.remove();
+        _levelFilterInited = true;
+        return;
+    }
+    _levelFilterInited = true;
+    wrap.style.display = '';
+    fetch('/api/member_levels')
+        .then(r => r.ok ? r.json() : Promise.reject(new Error('levels')))
+        .then(data => {
+            const levels = (data && data.levels) || [];
+            const menu = document.getElementById('levelFilterMenu');
+            if (!menu) return;
+            menu.replaceChildren();
+            menu.appendChild(buildMenuHeading('Membership level'));
+            if (!levels.length) {
+                const empty = document.createElement('div');
+                empty.className = 'small text-muted px-1';
+                empty.textContent = 'No levels available';
+                menu.appendChild(empty);
+                return;
+            }
+            levels.forEach((lvl, i) => {
+                const row = document.createElement('div');
+                row.className = 'form-check';
+                const input = document.createElement('input');
+                input.type = 'checkbox';
+                input.className = 'form-check-input';
+                input.id = 'levelchk-' + i;
+                input.value = lvl;
+                input.checked = activeLevelFilters.has(lvl);
+                input.addEventListener('change', () => toggleLevelFilter(lvl, input.checked));
+                const label = document.createElement('label');
+                label.className = 'form-check-label';
+                label.htmlFor = 'levelchk-' + i;
+                label.textContent = lvl;
+                row.appendChild(input);
+                row.appendChild(label);
+                menu.appendChild(row);
+            });
+            syncFilterBarUI();  // reflect any level filters restored from the URL
+        })
+        .catch(() => { /* leave the toggle with an empty menu; status pills still work */ });
+}
+
+function toggleLevelFilter(lvl, checked) {
+    if (checked) activeLevelFilters.add(lvl);
+    else activeLevelFilters.delete(lvl);
+    syncFilterBarUI();
+    loadMembers(1);
+}
+
+function clearAllFilters() {
+    if (!activeStatusFilters.size && !activeLevelFilters.size) return;  // nothing to clear
+    activeStatusFilters.clear();
+    activeLevelFilters.clear();
+    syncFilterBarUI();
+    loadMembers(1);
+}
+
+// Reflect active filters in pills, level checkboxes/label, and the Clear link.
+function syncFilterBarUI() {
+    document.querySelectorAll('#statusPills .dh-status-pill').forEach(btn => {
+        const on = activeStatusFilters.has(btn.dataset.status);
+        btn.classList.toggle('active', on);
+        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+    });
+    document.querySelectorAll('#levelFilterMenu input[type="checkbox"]').forEach(cb => {
+        cb.checked = activeLevelFilters.has(cb.value);
+    });
+    const lblEl = document.getElementById('levelFilterLabel');
+    if (lblEl) lblEl.textContent = activeLevelFilters.size ? `Level (${activeLevelFilters.size})` : 'Level';
+    const lvlBtn = document.getElementById('levelFilterBtn');
+    if (lvlBtn) lvlBtn.classList.toggle('active', activeLevelFilters.size > 0);
+}
+
+// Show/hide the whole filter line via the toolbar filter icon. Reflects state
+// onto the line (inline display, no !important to fight) and the toggle button.
+function applyFilterBarVisibility() {
+    const bar = document.getElementById('memberFilterBar');
+    if (bar) bar.style.display = filterBarVisible ? '' : 'none';
+    const btn = document.getElementById('filterToggleBtn');
+    if (btn) {
+        btn.classList.toggle('active', filterBarVisible);
+        btn.setAttribute('aria-expanded', filterBarVisible ? 'true' : 'false');
+    }
+}
+
+// Toggle the filter line. Hiding it RESETS any active filters (and refetches
+// only if something was actually set). Active filters force it open elsewhere
+// (restoreFromURL), so a refreshed/shared filtered view always shows its controls.
+function toggleFilterBar() {
+    if (filterBarVisible) {
+        filterBarVisible = false;
+        applyFilterBarVisibility();
+        const had = activeStatusFilters.size || activeLevelFilters.size;
+        activeStatusFilters.clear();
+        activeLevelFilters.clear();
+        syncFilterBarUI();
+        if (had) loadMembers(1);
+    } else {
+        filterBarVisible = true;
+        applyFilterBarVisibility();
+    }
+}
+
+function initMemberFilters() {
+    buildStatusPills();
+    initLevelFilter();
 }
 
 // --- Member avatars -------------------------------------------------------
@@ -2429,6 +2640,9 @@ function buildURL() {
     if (currentSort !== 'date_added' && !(currentQuery && currentSort === 'rank')) params.set('sort', currentSort);
     if (currentOrder !== 'desc') params.set('order', currentOrder);
     if (selectedMemberId) params.set('member', selectedMemberId);
+    // Capture the full search+filter state so a shared link reproduces it.
+    activeStatusFilters.forEach(s => params.append('status', s));
+    activeLevelFilters.forEach(l => params.append('level', l));
     return params.toString() ? `/?${params.toString()}` : '/';
 }
 
@@ -2453,6 +2667,19 @@ function restoreFromURL() {
     currentSort = params.get('sort') || (currentQuery ? 'rank' : 'id');
     currentOrder = params.get('order') || 'desc';
     const memberId = params.get('member');
+
+    // Rehydrate filters. Status is validated against the allowlist so a
+    // hand-edited URL can't inject a bogus pill; unknown levels simply match
+    // nothing server-side. syncFilterBarUI reflects them onto the controls
+    // (level checkboxes are re-synced when initLevelFilter's fetch resolves).
+    activeStatusFilters = new Set(
+        params.getAll('status').map(s => s.toLowerCase()).filter(s => STATUS_FILTER_VALUES.includes(s)));
+    activeLevelFilters = new Set(params.getAll('level'));
+    syncFilterBarUI();
+    // Active filters force the line open (refresh / shared link); otherwise it
+    // stays hidden behind the toolbar filter icon.
+    filterBarVisible = activeStatusFilters.size > 0 || activeLevelFilters.size > 0;
+    applyFilterBarVisibility();
 
     // A URL can carry a sort for a column the saved column prefs don't show
     // (e.g. a shared link, or columns were since hidden). Reconcile so we never
@@ -2480,6 +2707,11 @@ function restoreFromURL() {
         _restoringFromHistory = false;
     });
 }
+
+// Build the filter bar (status pills + level dropdown) BEFORE restoreFromURL so
+// the controls exist when restore rehydrates filter state from the URL. Listeners
+// fire in registration order.
+document.addEventListener('DOMContentLoaded', initMemberFilters);
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', restoreFromURL);

--- a/code/DHService/db.py
+++ b/code/DHService/db.py
@@ -451,6 +451,55 @@ def _validate_sort(sort: str, order: str, allowlist: dict, default_sort: str) ->
     direction = "ASC NULLS LAST" if order.lower() == "asc" else "DESC NULLS LAST"
     return col, direction
 
+# Allowlist of real membership_status values that get an exact-match filter pill.
+# `inactive` is intentionally absent — it is not a real state; it falls into the
+# `other` bucket (below) along with blank/null/non-standard values. This frozenset
+# is the SQL-injection boundary for the status filter, mirroring the sort allowlists.
+_MEMBERSHIP_STATUS_FILTER_VALUES = frozenset({"active", "pending", "suspended", "banned"})
+
+# Sentinel (not a stored value) for the "Other/Unknown" status pill: matches NULL or
+# any normalized status not in the canonical set above.
+_MEMBERSHIP_STATUS_OTHER = "other"
+
+
+def _build_member_filter(statuses, levels, *, status_col: str, level_col: str) -> tuple[list[str], list]:
+    """Build parameterized WHERE fragments for the member-list status/level filters.
+
+    Returns (clauses, params): clauses join with AND, params extend the execute
+    tuple in order. `status_col`/`level_col` are caller-supplied SQL expressions
+    (e.g. "m.status ->> 'membership_status'" on the browse path, or the bare
+    "membership_status" CTE alias on the search path) — they are NOT user input.
+    User values only ever reach SQL as %s parameters, never interpolated.
+    """
+    clauses: list[str] = []
+    params: list = []
+
+    # --- Status (canonical values + `other` sentinel) ---
+    if statuses:
+        normalized = {(s or "").strip().lower() for s in statuses}
+        known = sorted(normalized & _MEMBERSHIP_STATUS_FILTER_VALUES)
+        want_other = _MEMBERSHIP_STATUS_OTHER in normalized
+        subs: list[str] = []
+        if known:
+            subs.append(f"lower(btrim({status_col})) = ANY(%s)")
+            params.append(known)
+        if want_other:
+            # blank / NULL / `inactive` / anything non-canonical → the column's grey bucket.
+            subs.append(f"({status_col} IS NULL OR lower(btrim({status_col})) <> ALL(%s))")
+            params.append(sorted(_MEMBERSHIP_STATUS_FILTER_VALUES))
+        if subs:
+            clauses.append("(" + " OR ".join(subs) + ")")
+
+    # --- Membership level (multi-select, exact match) ---
+    if levels:
+        cleaned = sorted({lvl for lvl in levels if lvl})
+        if cleaned:
+            clauses.append(f"{level_col} = ANY(%s)")
+            params.append(cleaned)
+
+    return clauses, params
+
+
 def _is_searchable_query(query: str) -> bool:
     """Reject pathological search queries (under 2 chars, or no word character).
 
@@ -477,10 +526,19 @@ def _paginated_response(members: list[dict], total: int, page: int, per_page: in
     }
 
 def list_members(page: int = 1, per_page: int = 25,
-                 sort: str = "date_added", order: str = "desc") -> dict:
-    logger.debug(f"Listing members page={page} per_page={per_page} sort={sort} order={order}")
+                 sort: str = "date_added", order: str = "desc",
+                 statuses=None, levels=None) -> dict:
+    logger.debug(f"Listing members page={page} per_page={per_page} sort={sort} order={order} "
+                 f"statuses={statuses} levels={levels}")
     sort_col, direction = _validate_sort(sort, order, _MEMBER_SORT_COLUMNS, "date_added")
     offset = (page - 1) * per_page
+
+    filter_clauses, filter_params = _build_member_filter(
+        statuses, levels,
+        status_col="m.status ->> 'membership_status'",
+        level_col="m.status ->> 'membership_level'",
+    )
+    where_sql = ("WHERE " + " AND ".join(filter_clauses)) if filter_clauses else ""
 
     members = []
     total = 0
@@ -501,6 +559,7 @@ def list_members(page: int = 1, per_page: int = 25,
                            m.status ->> 'stripe_product_id' AS stripe_product_id,
                            COUNT(*) OVER() AS total_count
                     FROM   member m
+                    {where_sql}
                     -- `, m.id ASC` is a deterministic tiebreaker: many sort
                     -- columns are low-cardinality (pronouns, membership_level)
                     -- and _blank_to_null collapses every blank into one NULL
@@ -511,7 +570,7 @@ def list_members(page: int = 1, per_page: int = 25,
                     ORDER BY {sort_col} {direction}, m.id ASC
                     LIMIT  %s OFFSET %s
                 """,
-                (per_page, offset),
+                (*filter_params, per_page, offset),
             )
             results = cur.fetchall()
 
@@ -534,23 +593,37 @@ def list_members(page: int = 1, per_page: int = 25,
 
             # A past-the-end page returns no rows, so the COUNT(*) OVER() total
             # never comes back — fetch it directly so the response still reports
-            # the real member count instead of 0.
+            # the real (filtered) member count instead of 0. Reuse the same
+            # WHERE/params so a filtered high page reports the filtered total.
             if not results:
-                cur.execute("SELECT COUNT(*) FROM member")
+                cur.execute(f"SELECT COUNT(*) FROM member m {where_sql}", filter_params)
                 total = cur.fetchone()[0]
 
     logger.debug(f"Listed {len(members)} members (total={total})")
     return _paginated_response(members, total, page, per_page)
 
 def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
-                             sort: str = "rank", order: str = "desc") -> dict:
-    logger.debug(f"Paginated search query_len={len(query or '')} page={page} per_page={per_page} sort={sort} order={order}")
+                             sort: str = "rank", order: str = "desc",
+                             statuses=None, levels=None) -> dict:
+    logger.debug(f"Paginated search query_len={len(query or '')} page={page} per_page={per_page} "
+                 f"sort={sort} order={order} statuses={statuses} levels={levels}")
     # Guard pathological queries (short/punctuation-only) so they return an empty
     # page instead of dumping the whole roster.
     if not _is_searchable_query(query):
         return _paginated_response([], 0, page, per_page)
     sort_col, direction = _validate_sort(sort, order, _SEARCH_SORT_COLUMNS, "rank")
     offset = (page - 1) * per_page
+
+    # Compose the status/level filter on top of the ranked search results. The
+    # predicate lands in a `filtered` CTE between `base` and `tot`/`page`, so the
+    # ranking SRF is untouched and totals/pagination stay filter-aware. Columns
+    # reference the bare `base` aliases (membership_status/membership_level).
+    filter_clauses, filter_params = _build_member_filter(
+        statuses, levels,
+        status_col="membership_status",
+        level_col="membership_level",
+    )
+    where_sql = ("WHERE " + " AND ".join(filter_clauses)) if filter_clauses else ""
 
     members = []
     total = 0
@@ -583,11 +656,15 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
                                rank
                         FROM   search_members_by_identity_and_access(%s)
                     ),
+                    filtered AS (
+                        SELECT * FROM base
+                        {where_sql}
+                    ),
                     tot AS (
-                        SELECT COUNT(*) AS total_count FROM base
+                        SELECT COUNT(*) AS total_count FROM filtered
                     ),
                     page AS (
-                        SELECT * FROM base
+                        SELECT * FROM filtered
                         ORDER BY {sort_col} {direction}, id ASC
                         LIMIT  %s OFFSET %s
                     )
@@ -605,7 +682,10 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
                     FROM   tot LEFT JOIN page ON true
                     ORDER BY {sort_col} {direction}, page.id ASC
                 """,
-                (query, per_page, offset, query),
+                # Param order tracks position in the SQL text: base(%s=query),
+                # then the `filtered` CTE's WHERE params, then page LIMIT/OFFSET,
+                # then the match-attribution subquery(%s=query).
+                (query, *filter_params, per_page, offset, query),
             )
             results = cur.fetchall()
 
@@ -636,6 +716,24 @@ def search_members_paginated(query: str, page: int = 1, per_page: int = 25,
 
     logger.debug(f"Paginated search found {len(members)} members (total={total})")
     return _paginated_response(members, total, page, per_page)
+
+def get_distinct_membership_levels() -> list[str]:
+    """Return the distinct, non-blank membership_level values actually stored on
+    members, sorted. Drives the member-list level filter dropdown. Uses the real
+    stored values (not membership_types_lookup) so every option returns rows even
+    for legacy/typo levels not present in the lookup table.
+    """
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """SELECT DISTINCT status ->> 'membership_level' AS level
+                   FROM   member
+                   WHERE  NULLIF(btrim(status ->> 'membership_level'), '') IS NOT NULL
+                   ORDER  BY level"""
+            )
+            levels = [row[0] for row in cur.fetchall()]
+    logger.debug(f"Found {len(levels)} distinct membership levels")
+    return levels
 
 def add_update_identity(identity_dict, member_id=None):
     # When member_id is provided by the caller (standard update path), update

--- a/code/DHService/v1.py
+++ b/code/DHService/v1.py
@@ -8,7 +8,7 @@ from time import time
 from typing import Annotated
 
 import bcrypt
-from fastapi import Depends, HTTPException, Request, Header
+from fastapi import Depends, HTTPException, Request, Header, Query
 from pydantic import ValidationError
 
 from fastapiapp import app
@@ -74,13 +74,25 @@ async def search_members(current_user: AuthenticatedClient, query: str):
 @app.get("/v1/member/list/")
 async def list_members(current_user: AuthenticatedClient,
                        query: str = None, page: int = 1, per_page: int = 25,
-                       sort: str = "date_added", order: str = "desc"):
-    """List members with pagination. Optionally filter by search query."""
+                       sort: str = "date_added", order: str = "desc",
+                       status: list[str] | None = Query(default=None),
+                       level: list[str] | None = Query(default=None)):
+    """List members with pagination. Optionally filter by search query, and by
+    membership status / level (both multi-valued). Status/level filters compose
+    on top of the search query when one is present (browse + search both filtered).
+    """
     page = max(1, page)
     per_page = max(1, min(per_page, 100))
     if query:
-        return db.search_members_paginated(query, page, per_page, sort, order)
-    return db.list_members(page, per_page, sort, order)
+        return db.search_members_paginated(query, page, per_page, sort, order,
+                                           statuses=status, levels=level)
+    return db.list_members(page, per_page, sort, order,
+                           statuses=status, levels=level)
+
+@app.get("/v1/member/membership_levels/distinct/")
+async def get_distinct_membership_levels(current_user: AuthenticatedClient):
+    """Distinct stored membership_level values, for the member-list filter dropdown."""
+    return db.get_distinct_membership_levels()
 
 @app.get("/v1/member/username_check/")
 async def check_member_username(current_user: AuthenticatedClient, username: str):


### PR DESCRIPTION
## Member-list filtering

Adds **status + membership_level filtering** to the admin member list. Filters **compose with the fuzzy search** (both browse and search are filtered), ride the **URL** (shareable / back-forward), and require **no schema change** (inline SQL → DHService redeploy).

- **Status pills** — `active / pending / suspended / banned` + an **Other/Unknown** bucket (matches `NULL`/blank/`inactive`/non-standard, lining up exactly with the status column's grey icon).
- **Membership level** — multi-select checkbox dropdown, populated from the distinct stored values.
- **Toolbar filter icon** toggles the filter line: hiding it **resets** filters; **active filters force it open** on refresh/shared link. The line is **centered until the row is constrained**, then left-aligns.
- Level is **gated behind `member.status`** (the dropdown is hidden and the filter dropped server-side for callers lacking it), mirroring the existing status-field gating.

### Backend
- `_build_member_filter()` in `db.py` — status via an **allowlist** (`= ANY` / `<> ALL` for the Other bucket), level via `= ANY`, all **parameterized** (the allowlist is the injection boundary). Spliced into `list_members` (WHERE + past-end count) and `search_members_paginated` (a `filtered` CTE between `base` and `tot`/`page` — the ranked SRF is untouched).
- New `get_distinct_membership_levels()` → `/v1/member/membership_levels/distinct/` → `/api/member_levels`.

## Theme-menu & toolbar polish

`base.html` is shared, so the theme changes apply portal-wide.

- **Paintbrush** theme toggle (line-height capped so the larger icon doesn't grow the navbar), a **"Theme" section header**, and a clear **active-theme marker** (check + bold + tint).
- Theme icon/label updates: **Bubblegum** heart, **Lights On** (lightbulb), **Kitchen 17** (fire), **Locke's Dream**. The `data-theme` values/cookie are unchanged.
- Column & level dropdowns gained **tinted section headers** matching the search-tips popover.
- Removed the refresh-button hover glow; `:focus-visible` so a mouse click no longer leaves the filter icon lit; evened the refresh↔columns toolbar spacing.

## Testing
- **API**: status (single/multi/other), level (ANY), compose with search, past-end totals reflect the filtered set, and an injection attempt (`status=active'OR'1=1`) is safely dropped by the allowlist.
- **Browser (chrome-devtools, all 5 themes)**: pill/level toggles + URL state + reload rehydration (incl. the async level checkbox), empty-state, clear, filter-line show/hide reset, centered/constrained layout, active-theme marker live-updates, navbar height unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)