### PR TITLE
Signup: resume stranded pre-payment members + submit interstitial

### DIFF
--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -79,6 +79,27 @@ def index():
         return render_template('dev_login.html', preset_users=MEMBER_DEV_USERS)
     return render_template('landing.html')
 
+def _is_stranded_pre_payment(access_token, member_id):
+    """True if an existing member is `pending` with no Stripe payment on file —
+    i.e. they signed up but never completed checkout, so they should resume at
+    the payment page rather than be sent to login (#283 option B).
+
+    Fail SAFE: on any error fetching status, return False so we fall back to the
+    existing (login / "account exists") behavior rather than mis-routing a real
+    account to payment.
+    """
+    try:
+        status = dhservices.get_member_status(access_token, member_id) or {}
+    except Exception as e:
+        logger.warning(f"Stranded-member check failed for member {member_id}: {e}")
+        return False
+    # None-guard: status->>'membership_status' can be JSON null, and
+    # .get(key, default) returns None (not the default) for an explicit null.
+    membership_status = ((status or {}).get('membership_status') or '').lower()
+    has_stripe = bool((status or {}).get('stripe_product_id')
+                      or (status or {}).get('stripe_subscription_id'))
+    return membership_status == 'pending' and not has_stripe
+
 @app.route('/signup')
 def signup_start():
     """First step of signup - email entry"""
@@ -107,9 +128,17 @@ def signup_check_email():
             dhservices.DH_CLIENT_SECRET
         )
 
-        # If a member already exists for this email, send them to SSO login
+        # If a member already exists for this email, either resume their payment
+        # (if they're stranded pre-payment — signed up but never paid) or send
+        # them to SSO login (a real, paid/active account).
         member_data = dhservices.get_member_id(access_token, email)
         if member_data and member_data.get("member_id"):
+            if _is_stranded_pre_payment(access_token, member_data["member_id"]):
+                # signup_email is already set above; keep it explicit so the
+                # payment redirect's dependency on the session is obvious.
+                session['signup_email'] = email
+                flash('Looks like you already started — let’s finish your payment.', 'info')
+                return redirect(url_for('signup_payment'))
             flash('An account already exists for this email. Please sign in.', 'info')
             return redirect(url_for('login'))
 
@@ -144,10 +173,25 @@ def signup_check_email():
         # On error, show empty form
         return render_template('signup_form.html', email=email, contact_found=False)
 
+@app.route('/signup/loading-preview')
+def signup_loading_preview():
+    """Standalone, shareable preview of the signup loading interstitial.
+
+    Renders the same loader used on the real form (templates/_signup_gather.html)
+    but auto-playing and looping. No form, no submit, no DB writes — purely a
+    demo so the animation can be shared/reviewed via a single URL.
+    """
+    return render_template('signup_loading_preview.html')
+
 @app.route('/signup/payment')
 def signup_payment():
-    """Show payment step with Stripe pricing table"""
-    email = request.args.get('email') or session.get('signup_email')
+    """Show payment step with Stripe pricing table.
+
+    The email is read from the session only (set on every path that routes
+    here), never from a query param — so the plaintext address stays out of
+    the URL and a user-supplied ?email= can't drive the Stripe prefill (#294).
+    """
+    email = session.get('signup_email')
     return render_template('signup_payment.html', email=email)
 
 @app.route('/signup/submit', methods=['POST'])
@@ -254,6 +298,14 @@ def signup_submit():
         # created between the email step and submit) or a direct POST.
         existing_member_id = dhservices.get_member_id(access_token, email).get("member_id")
         if existing_member_id is not None:
+            # A stranded pre-payment member here is almost always a refresh /
+            # double-submit racing themselves: the first (still in-flight) POST
+            # created the row, this re-issued POST sees it. Send them on to
+            # payment instead of dead-ending at the "account exists" form (#283).
+            if _is_stranded_pre_payment(access_token, existing_member_id):
+                session['signup_email'] = email
+                flash('Sign up successful! Please complete payment.', 'success')
+                return redirect(url_for('signup_payment'))
             return _redisplay_form(account_exists=True)
 
         # Server-side username uniqueness gate. /api/check-username is only
@@ -337,8 +389,11 @@ def signup_submit():
                 f"Signup member {member_id}: {label} init failed (continuing): {str(e)}"
             )
 
+    # Carry the email server-side rather than in the URL — signup_payment reads
+    # session['signup_email'] to prefill the Stripe pricing table (A0 / #294).
+    session['signup_email'] = email
     flash('Sign up successful! Please complete payment.', 'success')
-    return redirect(url_for('signup_payment', email=email))
+    return redirect(url_for('signup_payment'))
 
 @app.route("/login")
 def login():

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -80,9 +80,16 @@ def index():
     return render_template('landing.html')
 
 def _is_stranded_pre_payment(access_token, member_id):
-    """True if an existing member is `pending` with no Stripe payment on file —
-    i.e. they signed up but never completed checkout, so they should resume at
-    the payment page rather than be sent to login (#283 option B).
+    """True if an existing member signed up but never completed checkout, so they
+    should resume at the payment page rather than be sent to login (#283 option B).
+
+    "Stranded" = no Stripe payment on file AND a status of `pending` *or blank*.
+    The blank case matters: signup writes the `status` column as a best-effort
+    scaffolding step that's allowed to fail (see signup_submit), so a half-created
+    member can have a NULL/empty status. get_member_status then returns None and
+    membership_status resolves to '' — that member is the *most* stranded (created,
+    never paid, status write failed), so treat blank the same as `pending` rather
+    than dead-ending them at login.
 
     Fail SAFE: on any error fetching status, return False so we fall back to the
     existing (login / "account exists") behavior rather than mis-routing a real
@@ -98,7 +105,10 @@ def _is_stranded_pre_payment(access_token, member_id):
     membership_status = ((status or {}).get('membership_status') or '').lower()
     has_stripe = bool((status or {}).get('stripe_product_id')
                       or (status or {}).get('stripe_subscription_id'))
-    return membership_status == 'pending' and not has_stripe
+    # Blank status ('') = scaffolding write failed; still a stranded pre-payment
+    # member. A real/paid account always has both a status and Stripe data, so the
+    # `not has_stripe` guard keeps us from mis-routing those to payment.
+    return membership_status in ('pending', '') and not has_stripe
 
 @app.route('/signup')
 def signup_start():

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -83,13 +83,18 @@ def _is_stranded_pre_payment(access_token, member_id):
     """True if an existing member signed up but never completed checkout, so they
     should resume at the payment page rather than be sent to login (#283 option B).
 
-    "Stranded" = no Stripe payment on file AND a status of `pending` *or blank*.
+    "Stranded" = no Stripe payment on file AND a status of `pending`, OR a
+    genuinely empty status (no membership_status AND no membership_level).
     The blank case matters: signup writes the `status` column as a best-effort
     scaffolding step that's allowed to fail (see signup_submit), so a half-created
     member can have a NULL/empty status. get_member_status then returns None and
-    membership_status resolves to '' — that member is the *most* stranded (created,
-    never paid, status write failed), so treat blank the same as `pending` rather
-    than dead-ending them at login.
+    membership_status resolves to ''. But a blank membership_status is also what
+    the `v_member_info` view emits for ANY member whose status column was never
+    populated — including legacy/imported accounts — so we treat blank as stranded
+    ONLY when there is also no membership_level. An established account keeps a
+    level even when membership_status is null, so this won't route a real member
+    to re-payment; anything with a level (or a non-pending status) falls through
+    to the normal "account exists, sign in" path.
 
     Fail SAFE: on any error fetching status, return False so we fall back to the
     existing (login / "account exists") behavior rather than mis-routing a real
@@ -100,15 +105,21 @@ def _is_stranded_pre_payment(access_token, member_id):
     except Exception as e:
         logger.warning(f"Stranded-member check failed for member {member_id}: {e}")
         return False
-    # None-guard: status->>'membership_status' can be JSON null, and
-    # .get(key, default) returns None (not the default) for an explicit null.
+    # None-guard: status->>'membership_status' / ->>'membership_level' can be JSON
+    # null, and .get(key, default) returns None (not the default) for explicit null.
     membership_status = ((status or {}).get('membership_status') or '').lower()
+    membership_level = ((status or {}).get('membership_level') or '').strip()
     has_stripe = bool((status or {}).get('stripe_product_id')
                       or (status or {}).get('stripe_subscription_id'))
-    # Blank status ('') = scaffolding write failed; still a stranded pre-payment
-    # member. A real/paid account always has both a status and Stripe data, so the
-    # `not has_stripe` guard keeps us from mis-routing those to payment.
-    return membership_status in ('pending', '') and not has_stripe
+    if has_stripe:
+        return False  # already paid — never re-route an account to checkout
+    if membership_status == 'pending':
+        return True   # mid-signup, no payment yet
+    # Blank status = the best-effort `status` scaffolding write may have failed,
+    # leaving a genuinely empty column. Only treat that as stranded when there's
+    # also no membership level, so established/legacy accounts (which carry a
+    # level even with a null membership_status) aren't sent to re-payment.
+    return membership_status == '' and not membership_level
 
 @app.route('/signup')
 def signup_start():

--- a/code/DHMemberPortal/static/css/portal.css
+++ b/code/DHMemberPortal/static/css/portal.css
@@ -853,105 +853,272 @@ i.ic-x          { color: #000000 !important; } /* X brand */
 }
 
 /* ===================================================================
-   SIGNUP SUBMIT INTERSTITIAL (/signup form -> payment hand-off)
+   SIGNUP SUBMIT INTERSTITIAL — "SHOP WORK ORDER" (/signup -> payment)
    Full-screen overlay shown while the slow /signup/submit POST runs.
-   Themed via the portal CSS vars so it reads on every theme.
-   =================================================================== */
 
-/* Hidden until JS adds .is-visible. position:fixed covers the whole viewport
- * (and the form beneath, blocking re-clicks during the in-flight POST). */
+   Concept: PS:One builds things out of scrounged parts, so the wait is
+   staged as a fabrication work-order slip on a blueprint workbench. The
+   rotating material becomes an accumulating Bill of Materials — each
+   scavenged part checks off (CNC-green tick) and stacks into the list, so
+   the member watches parts pile up while the POST is in flight. The
+   "don't refresh" line is stamped as a shop hazard placard.
+
+   Palette is intentionally a physical-object palette (manila slip / stencil
+   ink / shop cyan / hazard), NOT the portal theme vars — the slip should
+   look like the same workshop artifact regardless of surrounding chrome.
+   =================================================================== */
 .dh-gather-overlay {
+    /* Local design tokens for the slip (scoped to the overlay). */
+    --shop-manila: #fbf7ee;
+    --shop-ink: #1a1a17;
+    --shop-cyan: #009fc2;
+    --shop-green: #1b9e5a;
+    --shop-hazard: #e5341e;
+    --shop-caution: #f4c20d;
+    --shop-rule: #ddd2bb;     /* hairline on manila */
+    --shop-faint: #8a8275;    /* muted stencil ink */
+    --shop-mono: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", "Courier New", monospace;
+
     display: none;
     position: fixed;
     inset: 0;
     z-index: 1080; /* above Bootstrap's content; below toasts (1090) */
-    /* Frost the page that was underneath rather than hide it: a translucent
-     * wash plus a backdrop blur so the form shows through, blurred. */
-    background-color: rgba(255, 255, 255, 0.55);
-    background-color: color-mix(in srgb, var(--bg-color) 55%, transparent);
-    -webkit-backdrop-filter: blur(8px);
-    backdrop-filter: blur(8px);
-    /* center the card */
+    /* Frost the page underneath, then lay a faint blueprint grid over it so
+     * the backdrop reads as a workbench rather than a generic blur. */
+    background-color: rgba(15, 23, 42, 0.45);
+    background-image:
+        linear-gradient(color-mix(in srgb, var(--shop-cyan) 9%, transparent) 1px, transparent 1px),
+        linear-gradient(90deg, color-mix(in srgb, var(--shop-cyan) 9%, transparent) 1px, transparent 1px);
+    background-size: 26px 26px, 26px 26px;
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
     align-items: center;
     justify-content: center;
-    text-align: center;
     padding: 1.5rem;
 }
 .dh-gather-overlay.is-visible {
     display: flex;
 }
-.dh-gather-card {
-    max-width: 32rem;
-    color: var(--text-color);
-}
-.dh-gather-intro {
-    font-size: 1.1rem;
-    margin-bottom: 0.4rem;
-}
-/* First line gets a headline treatment so the message has a clear lead. */
-.dh-gather-headline {
-    font-size: 1.45rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin-bottom: 0.75rem;
-}
-.dh-gather-label {
-    margin-top: 1.25rem;
-    margin-bottom: 0.75rem;
-    color: var(--secondary-color);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    font-size: 0.9rem;
-}
-/* The rotating material name, centered on its own line under "Scored some…".
- * Cross-fades via the .is-fading opacity toggle (same idiom as
- * .signup-ready-word). Capitalized for a tidy "Scored some… Plywood" look. */
-.dh-gather-term {
-    display: block;
-    margin: 0.5rem auto 0;
-    font-size: 1.6rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    text-transform: capitalize;
-    transition: opacity 0.4s ease;
-}
-.dh-gather-term.is-fading {
-    opacity: 0;
-}
-/* The throbbing icon — swapped together with the term, centered below it.
- * Idle animation is scale + a slight rotate wiggle (transform only); opacity is
- * left to the .is-fading transition so the icon can cross-fade with the term. */
-.dh-gather-icon {
-    display: block;
-    margin: 1rem auto 0;
-    font-size: 3rem;
-    color: var(--primary-color);
-    animation: dh-throb 1.3s ease-in-out infinite;
-    transition: opacity 0.4s ease;
-}
-.dh-gather-icon.is-fading {
-    opacity: 0;
-}
-.dh-gather-warning {
-    margin-top: 2.5rem;
-    font-weight: 700;
-    line-height: 1.5;
-    color: var(--error-color);
+
+/* Decorative spark fountain canvas: fills the overlay, sits behind the slip. */
+.dh-gather-sparks {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+    pointer-events: none;
 }
 
+/* ---- The work-order slip ------------------------------------------------ */
+.dh-gather-slip {
+    position: relative; /* lift above the spark canvas */
+    z-index: 1;
+    width: 100%;
+    max-width: 30rem;
+    background-color: var(--shop-manila);
+    color: var(--shop-ink);
+    border: 1px solid var(--shop-rule);
+    border-top: 5px solid var(--shop-cyan); /* a strip of shop tape */
+    border-radius: 2px;
+    box-shadow: 0 18px 40px -12px rgba(15, 23, 42, 0.55);
+    text-align: left;
+    overflow: hidden;
+}
+
+/* Stencil header: shop name + live job number, justified like a form. */
+.dh-gather-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.65rem 1.15rem;
+    border-bottom: 1px dashed var(--shop-rule);
+    font-family: var(--shop-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+.dh-gather-head-mark { font-weight: 700; }
+.dh-gather-head-mark .dh-gather-dot { color: var(--shop-cyan); }
+.dh-gather-head-job { color: var(--shop-faint); white-space: nowrap; }
+
+.dh-gather-body { padding: 1.15rem 1.15rem 1.25rem; }
+
+/* The one human-voice line — system sans, deliberately contrasting the mono
+ * machine readout below it. */
+.dh-gather-lede {
+    margin: 0 0 1.1rem;
+    font-size: 1.02rem;
+    line-height: 1.45;
+}
+.dh-gather-lede strong { color: var(--shop-cyan); }
+
+/* BOM section heading row: label on the left, running tally on the right. */
+.dh-gather-bom-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+    font-family: var(--shop-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--shop-faint);
+}
+.dh-gather-tally { color: var(--shop-green); font-weight: 700; }
+
+/* The accumulating parts list. Fixed min-height so the slip doesn't jump as
+ * rows come and go. */
+.dh-gather-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    min-height: 7.2rem;
+    font-family: var(--shop-mono);
+    font-size: 0.9rem;
+}
+.dh-gather-row {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.12rem 0;
+}
+/* Acquired rows slide+fade in as they're checked off. */
+.dh-gather-row.is-acquired { animation: dh-row-in 0.32s ease both; }
+.dh-gather-row.is-leaving { animation: dh-row-out 0.32s ease both; }
+.dh-gather-check { color: var(--shop-green); width: 1rem; text-align: center; flex: none; }
+.dh-gather-noun { text-transform: capitalize; }
+/* Dotted leader filling to the trailing part icon — the parts-list tell. */
+.dh-gather-leader {
+    flex: 1 1 auto;
+    border-bottom: 1px dotted var(--shop-rule);
+    transform: translateY(-0.18em);
+}
+/* Absurd shop quantity stamped before the part icon. */
+.dh-gather-qty {
+    flex: none;
+    margin-left: 0.4rem;
+    font-size: 0.72rem;
+    color: var(--shop-faint);
+    white-space: nowrap;
+}
+.dh-gather-chip { color: var(--shop-faint); width: 1.1rem; text-align: center; flex: none; }
+
+/* The live "now acquiring" row, set apart with a cyan tab and bolder ink. */
+.dh-gather-row.dh-gather-current {
+    margin-top: 0.35rem;
+    padding: 0.4rem 0.55rem;
+    background-color: color-mix(in srgb, var(--shop-cyan) 8%, transparent);
+    border-left: 3px solid var(--shop-cyan);
+    border-radius: 0 2px 2px 0;
+    font-weight: 700;
+}
+.dh-gather-current .dh-gather-label {
+    color: var(--shop-cyan);
+    font-size: 0.62rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    flex: none;
+}
+.dh-gather-term {
+    text-transform: capitalize;
+    transition: opacity 0.35s ease;
+}
+.dh-gather-term.is-fading { opacity: 0; }
+/* The throbbing part icon for the current row. */
+.dh-gather-icon {
+    color: var(--shop-cyan);
+    flex: none;
+    animation: dh-throb 1.3s ease-in-out infinite;
+    transition: opacity 0.35s ease;
+}
+.dh-gather-icon.is-fading { opacity: 0; }
+
+/* Hazard placard: stamped caution strip for the "don't refresh" warning. */
+.dh-gather-placard {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    margin-top: 1.15rem;
+    padding: 0.7rem 0.9rem;
+    background-color: var(--shop-caution);
+    color: #2a1d00;
+    border: 2px solid var(--shop-ink);
+    border-radius: 2px;
+    /* caution-tape hatching down the leading edge */
+    box-shadow: inset 6px 0 0 0 var(--shop-ink), inset 12px 0 0 0 var(--shop-caution);
+}
+.dh-gather-placard-icon {
+    font-size: 1.4rem;
+    color: var(--shop-hazard);
+    flex: none;
+}
+.dh-gather-placard-text {
+    font-family: var(--shop-mono);
+    font-size: 0.74rem;
+    line-height: 1.4;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+.dh-gather-placard-text strong { font-weight: 700; }
+
+/* Rotating "shop log" ticker — a faux terminal line with a blinking cursor. */
+.dh-gather-status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1rem 0 0;
+    font-family: var(--shop-mono);
+    font-size: 0.74rem;
+    color: var(--shop-faint);
+}
+.dh-gather-status-label {
+    flex: none;
+    padding: 0.05rem 0.35rem;
+    border: 1px solid var(--shop-rule);
+    border-radius: 2px;
+    font-size: 0.62rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--shop-cyan);
+}
+.dh-gather-status-text { transition: opacity 0.3s ease; }
+.dh-gather-status-text.is-fading { opacity: 0; }
+.dh-gather-status-text::after { content: '\2026'; } /* trailing ellipsis */
+.dh-gather-cursor {
+    flex: none;
+    width: 0.5rem;
+    height: 0.95rem;
+    background-color: var(--shop-cyan);
+    animation: dh-blink 1.05s steps(2, start) infinite;
+}
+
+@keyframes dh-blink {
+    50% { opacity: 0; }
+}
 @keyframes dh-throb {
     0%   { transform: scale(1)    rotate(-4deg); }
     50%  { transform: scale(1.12) rotate(4deg); }
     100% { transform: scale(1)    rotate(-4deg); }
 }
+@keyframes dh-row-in {
+    from { opacity: 0; transform: translateX(-8px); }
+    to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes dh-row-out {
+    from { opacity: 1; transform: translateX(0); }
+    to   { opacity: 0; transform: translateX(8px); }
+}
 
-/* Respect reduced motion: overlay still appears (the "don't refresh" warning
- * must show), but nothing animates — one static material, no throb, no fade. */
+/* Respect reduced motion: the slip + filled BOM + hazard placard still show
+ * (the "don't refresh" warning must always read), but nothing animates. */
 @media (prefers-reduced-motion: reduce) {
-    .dh-gather-icon {
-        animation: none;
-    }
-    .dh-gather-term {
-        transition: none;
-    }
+    .dh-gather-icon { animation: none; }
+    .dh-gather-cursor { animation: none; }
+    .dh-gather-term,
+    .dh-gather-icon,
+    .dh-gather-status-text { transition: none; }
+    .dh-gather-row.is-acquired,
+    .dh-gather-row.is-leaving { animation: none; }
 }

--- a/code/DHMemberPortal/static/css/portal.css
+++ b/code/DHMemberPortal/static/css/portal.css
@@ -984,9 +984,9 @@ i.ic-x          { color: #000000 !important; } /* X brand */
     gap: 0.55rem;
     padding: 0.12rem 0;
 }
-/* Acquired rows slide+fade in as they're checked off. */
+/* Acquired rows slide+fade in as they're checked off. (Over-cap rows are
+ * removed synchronously by JS, so there is no exit animation.) */
 .dh-gather-row.is-acquired { animation: dh-row-in 0.32s ease both; }
-.dh-gather-row.is-leaving { animation: dh-row-out 0.32s ease both; }
 .dh-gather-check { color: var(--shop-green); width: 1rem; text-align: center; flex: none; }
 .dh-gather-noun { text-transform: capitalize; }
 /* Dotted leader filling to the trailing part icon — the parts-list tell. */
@@ -1091,12 +1091,10 @@ i.ic-x          { color: #000000 !important; } /* X brand */
     width: 0.5rem;
     height: 0.95rem;
     background-color: var(--shop-cyan);
-    animation: dh-blink 1.05s steps(2, start) infinite;
+    /* Reuse the shared cursor-blink keyframe (defined for .tagline-cursor). */
+    animation: blink-cursor 1.05s steps(2, start) infinite;
 }
 
-@keyframes dh-blink {
-    50% { opacity: 0; }
-}
 @keyframes dh-throb {
     0%   { transform: scale(1)    rotate(-4deg); }
     50%  { transform: scale(1.12) rotate(4deg); }
@@ -1105,10 +1103,6 @@ i.ic-x          { color: #000000 !important; } /* X brand */
 @keyframes dh-row-in {
     from { opacity: 0; transform: translateX(-8px); }
     to   { opacity: 1; transform: translateX(0); }
-}
-@keyframes dh-row-out {
-    from { opacity: 1; transform: translateX(0); }
-    to   { opacity: 0; transform: translateX(8px); }
 }
 
 /* Respect reduced motion: the slip + filled BOM + hazard placard still show
@@ -1119,6 +1113,5 @@ i.ic-x          { color: #000000 !important; } /* X brand */
     .dh-gather-term,
     .dh-gather-icon,
     .dh-gather-status-text { transition: none; }
-    .dh-gather-row.is-acquired,
-    .dh-gather-row.is-leaving { animation: none; }
+    .dh-gather-row.is-acquired { animation: none; }
 }

--- a/code/DHMemberPortal/static/css/portal.css
+++ b/code/DHMemberPortal/static/css/portal.css
@@ -851,3 +851,107 @@ i.ic-x          { color: #000000 !important; } /* X brand */
         transition: none;
     }
 }
+
+/* ===================================================================
+   SIGNUP SUBMIT INTERSTITIAL (/signup form -> payment hand-off)
+   Full-screen overlay shown while the slow /signup/submit POST runs.
+   Themed via the portal CSS vars so it reads on every theme.
+   =================================================================== */
+
+/* Hidden until JS adds .is-visible. position:fixed covers the whole viewport
+ * (and the form beneath, blocking re-clicks during the in-flight POST). */
+.dh-gather-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 1080; /* above Bootstrap's content; below toasts (1090) */
+    /* Frost the page that was underneath rather than hide it: a translucent
+     * wash plus a backdrop blur so the form shows through, blurred. */
+    background-color: rgba(255, 255, 255, 0.55);
+    background-color: color-mix(in srgb, var(--bg-color) 55%, transparent);
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+    /* center the card */
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 1.5rem;
+}
+.dh-gather-overlay.is-visible {
+    display: flex;
+}
+.dh-gather-card {
+    max-width: 32rem;
+    color: var(--text-color);
+}
+.dh-gather-intro {
+    font-size: 1.1rem;
+    margin-bottom: 0.4rem;
+}
+/* First line gets a headline treatment so the message has a clear lead. */
+.dh-gather-headline {
+    font-size: 1.45rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    margin-bottom: 0.75rem;
+}
+.dh-gather-label {
+    margin-top: 1.25rem;
+    margin-bottom: 0.75rem;
+    color: var(--secondary-color);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.9rem;
+}
+/* The rotating material name, centered on its own line under "Scored some…".
+ * Cross-fades via the .is-fading opacity toggle (same idiom as
+ * .signup-ready-word). Capitalized for a tidy "Scored some… Plywood" look. */
+.dh-gather-term {
+    display: block;
+    margin: 0.5rem auto 0;
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    text-transform: capitalize;
+    transition: opacity 0.4s ease;
+}
+.dh-gather-term.is-fading {
+    opacity: 0;
+}
+/* The throbbing icon — swapped together with the term, centered below it.
+ * Idle animation is scale + a slight rotate wiggle (transform only); opacity is
+ * left to the .is-fading transition so the icon can cross-fade with the term. */
+.dh-gather-icon {
+    display: block;
+    margin: 1rem auto 0;
+    font-size: 3rem;
+    color: var(--primary-color);
+    animation: dh-throb 1.3s ease-in-out infinite;
+    transition: opacity 0.4s ease;
+}
+.dh-gather-icon.is-fading {
+    opacity: 0;
+}
+.dh-gather-warning {
+    margin-top: 2.5rem;
+    font-weight: 700;
+    line-height: 1.5;
+    color: var(--error-color);
+}
+
+@keyframes dh-throb {
+    0%   { transform: scale(1)    rotate(-4deg); }
+    50%  { transform: scale(1.12) rotate(4deg); }
+    100% { transform: scale(1)    rotate(-4deg); }
+}
+
+/* Respect reduced motion: overlay still appears (the "don't refresh" warning
+ * must show), but nothing animates — one static material, no throb, no fade. */
+@media (prefers-reduced-motion: reduce) {
+    .dh-gather-icon {
+        animation: none;
+    }
+    .dh-gather-term {
+        transition: none;
+    }
+}

--- a/code/DHMemberPortal/templates/_signup_gather.html
+++ b/code/DHMemberPortal/templates/_signup_gather.html
@@ -77,6 +77,7 @@
 
     var idx = Math.floor(Math.random() * MATERIALS.length);
     var rotateTimer = null;
+    var submitting = false; // one-shot: true once a valid submit is handed off
 
     // Track the current FA glyph class so we can swap just that token and
     // leave dh-gather-icon / fa-solid / is-fading intact (a full className
@@ -122,6 +123,7 @@
         overlay.setAttribute('aria-hidden', 'true');
         if (rotateTimer) { clearInterval(rotateTimer); rotateTimer = null; }
         if (submitBtn) submitBtn.disabled = false;
+        submitting = false; // allow re-submit after a Back/bfcache return
     }
 
     render(idx);
@@ -131,6 +133,11 @@
             // The shared dh-validate handler (base.html) runs first and calls
             // preventDefault() on invalid input. Only reveal once it passed.
             if (e.defaultPrevented) return;
+            // One-shot guard: a disabled submit button does NOT reliably block
+            // Enter-key implicit submission across browsers, so cancel any second
+            // submit event ourselves rather than dispatching a duplicate POST.
+            if (submitting) { e.preventDefault(); return; }
+            submitting = true;
             showOverlay();
             if (submitBtn) submitBtn.disabled = true; // guard double-click
             // The native POST proceeds; the browser swaps pages when it returns.

--- a/code/DHMemberPortal/templates/_signup_gather.html
+++ b/code/DHMemberPortal/templates/_signup_gather.html
@@ -1,0 +1,150 @@
+{# Signup "gathering materials" submit interstitial — shared markup + behavior.
+   Included from signup_form.html (revealed on a valid form submit) and from
+   signup_loading_preview.html (auto-plays as a standalone shareable demo).
+
+   Include with `gather_autoplay = true` to auto-reveal on load (demo mode);
+   omit it for the real form, where the overlay is revealed only by a valid
+   submit. Position:fixed, so its placement in the DOM doesn't matter — it's
+   included in the scripts block so the submit listener registers AFTER
+   base.html's dh-validate handler (needed for the e.defaultPrevented check).
+   Styling lives in the "SIGNUP SUBMIT INTERSTITIAL" block of portal.css. #}
+<div id="signup-gather-overlay" class="dh-gather-overlay" aria-hidden="true"{% if gather_autoplay %} data-autoplay{% endif %}>
+    <div class="dh-gather-card" role="status" aria-live="polite">
+        <p class="dh-gather-intro dh-gather-headline">We got your PS:1 sign-up info!</p>
+        <p class="dh-gather-intro">We&rsquo;ll start building up your member<br>portal, but we need some stuff first.</p>
+        <p class="dh-gather-intro">Checking Cragslist and Facebutt<br>Marketplace for free materials&hellip;</p>
+        <p class="dh-gather-label">Scored some free&hellip;</p>
+        <p id="signup-gather-term" class="dh-gather-term">plywood</p>
+        <i id="signup-gather-icon" class="fa-solid fa-layer-group dh-gather-icon" aria-hidden="true"></i>
+        <p class="dh-gather-warning">Please don&rsquo;t refresh!<br>We&rsquo;re handing you over<br>to our payment processor.</p>
+    </div>
+</div>
+<script>
+(function () {
+    var overlay = document.getElementById('signup-gather-overlay');
+    var term    = document.getElementById('signup-gather-term');
+    var icon    = document.getElementById('signup-gather-icon');
+    if (!overlay || !term || !icon) return;
+
+    // The form is present on the real signup page, absent in the demo.
+    var form      = document.querySelector('form.dh-validate');
+    var submitBtn = form ? form.querySelector('button[type="submit"]') : null;
+    var autoplay  = overlay.hasAttribute('data-autoplay');
+
+    // Material -> Font Awesome icon. Static, hardcoded allowlist: the icon
+    // className is assembled only from these values, never interpolated from
+    // user/server data (keeps the XSS-safe posture).
+    var MATERIALS = [
+        { noun: 'plywood',           icon: 'fa-layer-group' },
+        { noun: 'acrylic sheets',    icon: 'fa-layer-group' },
+        { noun: 'scrap metal',       icon: 'fa-cubes' },
+        { noun: 'glass',             icon: 'fa-gem' },
+        { noun: 'fabric',            icon: 'fa-shirt' },
+        { noun: 'resin',             icon: 'fa-droplet' },
+        { noun: 'magnets',           icon: 'fa-magnet' },
+        { noun: 'hardware',          icon: 'fa-screwdriver-wrench' },
+        { noun: 'hand tools',        icon: 'fa-screwdriver-wrench' },
+        { noun: 'toolboxes',         icon: 'fa-toolbox' },
+        { noun: 'wrenches',          icon: 'fa-wrench' },
+        { noun: 'hammers',           icon: 'fa-hammer' },
+        { noun: 'screwdrivers',      icon: 'fa-screwdriver' },
+        { noun: 'measuring tools',   icon: 'fa-ruler-combined' },
+        { noun: '3D printers',       icon: 'fa-print' },
+        { noun: 'microscopes',       icon: 'fa-microscope' },
+        { noun: 'oil cans',          icon: 'fa-oil-can' },
+        { noun: 'chips',             icon: 'fa-microchip' },
+        { noun: 'wires',             icon: 'fa-network-wired' },
+        { noun: 'cables',            icon: 'fa-plug' },
+        { noun: 'batteries',         icon: 'fa-battery-half' },
+        { noun: 'LEDs',              icon: 'fa-lightbulb' },
+        { noun: 'fans',              icon: 'fa-fan' },
+        { noun: 'meters',            icon: 'fa-gauge-high' },
+        { noun: 'computers',         icon: 'fa-computer' },
+        { noun: 'monitors',          icon: 'fa-tv' },
+        { noun: 'keyboards',         icon: 'fa-keyboard' },
+        { noun: 'servers',           icon: 'fa-server' },
+        { noun: 'totes',             icon: 'fa-boxes-stacked' },
+        { noun: 'parts bins',        icon: 'fa-box-open' },
+        { noun: 'pallets',           icon: 'fa-pallet' },
+        { noun: 'hand trucks',       icon: 'fa-dolly' },
+        { noun: 'safety glasses',    icon: 'fa-glasses' },
+        { noun: 'hard hats',         icon: 'fa-helmet-safety' },
+        { noun: 'fire extinguishers', icon: 'fa-fire-extinguisher' }
+    ];
+
+    var reduceMotion = window.matchMedia
+        && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    var idx = Math.floor(Math.random() * MATERIALS.length);
+    var rotateTimer = null;
+
+    // Track the current FA glyph class so we can swap just that token and
+    // leave dh-gather-icon / fa-solid / is-fading intact (a full className
+    // reassign would wipe is-fading mid-fade and pop the new icon in).
+    var currentIconClass = 'fa-layer-group'; // matches the markup default
+    function render(i) {
+        term.textContent = MATERIALS[i].noun;
+        if (currentIconClass) icon.classList.remove(currentIconClass);
+        currentIconClass = MATERIALS[i].icon; // from the hardcoded list only
+        icon.classList.add(currentIconClass);
+    }
+
+    function nextIndex() {
+        var n = idx;
+        while (n === idx && MATERIALS.length > 1) {
+            n = Math.floor(Math.random() * MATERIALS.length);
+        }
+        return n;
+    }
+
+    function startRotation() {
+        if (reduceMotion || rotateTimer) return; // static single material under reduced motion
+        rotateTimer = setInterval(function () {
+            term.classList.add('is-fading');
+            icon.classList.add('is-fading');
+            setTimeout(function () {
+                idx = nextIndex();
+                render(idx); // preserves is-fading, so the new pair fades in
+                term.classList.remove('is-fading');
+                icon.classList.remove('is-fading');
+            }, 400); // matches the .dh-gather-term/.dh-gather-icon opacity transition
+        }, 2000);
+    }
+
+    function showOverlay() {
+        overlay.classList.add('is-visible');
+        overlay.setAttribute('aria-hidden', 'false');
+        startRotation();
+    }
+
+    function hideOverlay() {
+        overlay.classList.remove('is-visible');
+        overlay.setAttribute('aria-hidden', 'true');
+        if (rotateTimer) { clearInterval(rotateTimer); rotateTimer = null; }
+        if (submitBtn) submitBtn.disabled = false;
+    }
+
+    render(idx);
+
+    if (form) {
+        form.addEventListener('submit', function (e) {
+            // The shared dh-validate handler (base.html) runs first and calls
+            // preventDefault() on invalid input. Only reveal once it passed.
+            if (e.defaultPrevented) return;
+            showOverlay();
+            if (submitBtn) submitBtn.disabled = true; // guard double-click
+            // The native POST proceeds; the browser swaps pages when it returns.
+        });
+    }
+
+    // If this page is restored from the bfcache (Back button after reaching
+    // payment), make sure the overlay isn't stuck visible.
+    window.addEventListener('pageshow', function (evt) {
+        if (evt.persisted) hideOverlay();
+    });
+    window.addEventListener('popstate', hideOverlay);
+
+    // Standalone demo page: play immediately on load.
+    if (autoplay) showOverlay();
+})();
+</script>

--- a/code/DHMemberPortal/templates/_signup_gather.html
+++ b/code/DHMemberPortal/templates/_signup_gather.html
@@ -1,37 +1,79 @@
-{# Signup "gathering materials" submit interstitial — shared markup + behavior.
+{# Signup submit interstitial — "Shop Work Order" (shared markup + behavior).
    Included from signup_form.html (revealed on a valid form submit) and from
    signup_loading_preview.html (auto-plays as a standalone shareable demo).
+
+   Concept: PS:One builds out of scrounged parts, so the wait is staged as a
+   fabrication work-order slip. The rotating material is an accumulating Bill
+   of Materials — each scavenged part checks off and stacks into the list.
 
    Include with `gather_autoplay = true` to auto-reveal on load (demo mode);
    omit it for the real form, where the overlay is revealed only by a valid
    submit. Position:fixed, so its placement in the DOM doesn't matter — it's
    included in the scripts block so the submit listener registers AFTER
    base.html's dh-validate handler (needed for the e.defaultPrevented check).
-   Styling lives in the "SIGNUP SUBMIT INTERSTITIAL" block of portal.css. #}
+   Styling lives in the "SHOP WORK ORDER" block of portal.css. #}
 <div id="signup-gather-overlay" class="dh-gather-overlay" aria-hidden="true"{% if gather_autoplay %} data-autoplay{% endif %}>
-    <div class="dh-gather-card" role="status" aria-live="polite">
-        <p class="dh-gather-intro dh-gather-headline">We got your PS:1 sign-up info!</p>
-        <p class="dh-gather-intro">We&rsquo;ll start building up your member<br>portal, but we need some stuff first.</p>
-        <p class="dh-gather-intro">Checking Cragslist and Facebutt<br>Marketplace for free materials&hellip;</p>
-        <p class="dh-gather-label">Scored some free&hellip;</p>
-        <p id="signup-gather-term" class="dh-gather-term">plywood</p>
-        <i id="signup-gather-icon" class="fa-solid fa-layer-group dh-gather-icon" aria-hidden="true"></i>
-        <p class="dh-gather-warning">Please don&rsquo;t refresh!<br>We&rsquo;re handing you over<br>to our payment processor.</p>
+    {# Decorative spark fountain behind the slip — something's being welded back
+       there. Canvas-drawn, aria-hidden, never started under reduced motion. #}
+    <canvas id="signup-gather-sparks" class="dh-gather-sparks" aria-hidden="true"></canvas>
+    <div class="dh-gather-slip" role="status" aria-live="polite">
+        <div class="dh-gather-head">
+            <span class="dh-gather-head-mark">PS<span class="dh-gather-dot">:</span>ONE shop <span class="dh-gather-dot">&middot;</span> work order</span>
+            <span class="dh-gather-head-job">JOB <span id="signup-gather-job">#0000</span></span>
+        </div>
+        <div class="dh-gather-body">
+            <p class="dh-gather-lede">
+                Got it! We&rsquo;re building your <strong>member portal</strong> out
+                of whatever we can scrounge. Checking Cragslist and Facebutt
+                Marketplace for free materials&hellip;
+            </p>
+
+            <div class="dh-gather-bom-head">
+                <span>Bill of Materials</span>
+                <span><span id="signup-gather-tally" class="dh-gather-tally">0</span> scavenged</span>
+            </div>
+
+            <ul id="signup-gather-list" class="dh-gather-list">
+                {# Acquired rows are inserted here by JS; the live row is last. #}
+                <li class="dh-gather-row dh-gather-current">
+                    <span class="dh-gather-label">Acquiring</span>
+                    <span id="signup-gather-term" class="dh-gather-term">plywood</span>
+                    <span class="dh-gather-leader" aria-hidden="true"></span>
+                    <i id="signup-gather-icon" class="fa-solid fa-layer-group dh-gather-icon" aria-hidden="true"></i>
+                </li>
+            </ul>
+
+            <p class="dh-gather-status" aria-hidden="true">
+                <span class="dh-gather-status-label">Shop log</span>
+                <span id="signup-gather-status" class="dh-gather-status-text">Negotiating with the raccoons</span><span class="dh-gather-cursor"></span>
+            </p>
+
+            <div class="dh-gather-placard">
+                <i class="fa-solid fa-triangle-exclamation dh-gather-placard-icon" aria-hidden="true"></i>
+                <span class="dh-gather-placard-text">
+                    <strong>Do not refresh.</strong> We&rsquo;re handing you to our payment processor.
+                </span>
+            </div>
+        </div>
     </div>
 </div>
 <script>
 (function () {
     var overlay = document.getElementById('signup-gather-overlay');
+    var list    = document.getElementById('signup-gather-list');
+    var current = list ? list.querySelector('.dh-gather-current') : null;
     var term    = document.getElementById('signup-gather-term');
     var icon    = document.getElementById('signup-gather-icon');
-    if (!overlay || !term || !icon) return;
+    var tally   = document.getElementById('signup-gather-tally');
+    var jobEl   = document.getElementById('signup-gather-job');
+    if (!overlay || !list || !current || !term || !icon || !tally) return;
 
     // The form is present on the real signup page, absent in the demo.
     var form      = document.querySelector('form.dh-validate');
     var submitBtn = form ? form.querySelector('button[type="submit"]') : null;
     var autoplay  = overlay.hasAttribute('data-autoplay');
 
-    // Material -> Font Awesome icon. Static, hardcoded allowlist: the icon
+    // Material -> Font Awesome icon. Static, hardcoded allowlist: every icon
     // className is assembled only from these values, never interpolated from
     // user/server data (keeps the XSS-safe posture).
     var MATERIALS = [
@@ -69,64 +111,296 @@
         { noun: 'hand trucks',       icon: 'fa-dolly' },
         { noun: 'safety glasses',    icon: 'fa-glasses' },
         { noun: 'hard hats',         icon: 'fa-helmet-safety' },
-        { noun: 'fire extinguishers', icon: 'fa-fire-extinguisher' }
+        { noun: 'fire extinguishers', icon: 'fa-fire-extinguisher' },
+        // ...and the stuff PS:One will "definitely" scrounge up for free.
+        { noun: 'flux capacitors',        icon: 'fa-bolt' },
+        { noun: 'a jar of magic smoke',   icon: 'fa-smog' },
+        { noun: 'unobtanium',             icon: 'fa-atom' },
+        { noun: 'blinker fluid',          icon: 'fa-droplet' },
+        { noun: 'skyhooks',               icon: 'fa-anchor' },
+        { noun: 'a board stretcher',      icon: 'fa-ruler-horizontal' },
+        { noun: 'tartan paint',           icon: 'fa-fill-drip' },
+        { noun: 'a roll of grid squares', icon: 'fa-table-cells' },
+        { noun: 'muffler bearings',       icon: 'fa-gear' },
+        { noun: 'left-handed screwdrivers', icon: 'fa-screwdriver' },
+        { noun: 'compressed air (uncompressed)', icon: 'fa-wind' },
+        { noun: 'the lost 10mm socket',   icon: 'fa-circle-notch' },
+        { noun: 'infinite PLA',           icon: 'fa-infinity' },
+        { noun: 'pixel dust',             icon: 'fa-wand-magic-sparkles' },
+        { noun: 'a USB cable (orientation unknown)', icon: 'fa-plug' },
+        { noun: 'elbow grease',           icon: 'fa-jar' },
+        { noun: 'a haunted oscilloscope', icon: 'fa-ghost' }
     ];
+
+    // Absurd shop quantities, stamped onto each scavenged part. Plain strings,
+    // rendered via textContent only.
+    var QUANTITIES = [
+        '1 smidge', '3 gross', "a baker's dozen", '∞', '0.5 raccoons',
+        '2 metric tons', 'a fistful', 'a heap', '12 furlongs', 'some',
+        'a wheelbarrow', '404', 'a pinch', '1.21 GW', 'a truckload',
+        'qty: yes', 'a metric butt-ton', '6.02e23'
+    ];
+
+    // Rotating "shop log" status lines. Plain strings, textContent only.
+    var STATUSES = [
+        'Negotiating with the raccoons', 'Bribing the laser cutter',
+        'Waking up the 3D printer', 'Untangling the extension cords',
+        'Looking for the 10mm socket', 'Charging the flux capacitor',
+        'Sweeping up the sparks', 'Dusting off the oscilloscope',
+        'Feeding the shop cat', 'Rerouting the magic smoke',
+        'Calibrating the vibe', 'Consulting the wiki',
+        'Applying percussive maintenance', 'Greasing the elbows'
+    ];
+
+    var MAX_VISIBLE = 4; // acquired rows kept on screen; older ones drop off the top
 
     var reduceMotion = window.matchMedia
         && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     var idx = Math.floor(Math.random() * MATERIALS.length);
+    var shownIdx = [];       // material indices currently on screen (acquired rows)
+    var count = 0;           // running "scavenged" tally
     var rotateTimer = null;
-    var submitting = false; // one-shot: true once a valid submit is handed off
+    var statusEl    = document.getElementById('signup-gather-status');
+    var statusTimer = null;
+    var statusIdx   = Math.floor(Math.random() * STATUSES.length);
+    var submitting = false;  // one-shot: true once a valid submit is handed off
 
-    // Track the current FA glyph class so we can swap just that token and
-    // leave dh-gather-icon / fa-solid / is-fading intact (a full className
-    // reassign would wipe is-fading mid-fade and pop the new icon in).
+    // Track the current FA glyph class so we can swap just that token and leave
+    // dh-gather-icon / fa-solid / is-fading intact (a full className reassign
+    // would wipe is-fading mid-fade and pop the new icon in).
     var currentIconClass = 'fa-layer-group'; // matches the markup default
-    function render(i) {
+    function renderCurrent(i) {
         term.textContent = MATERIALS[i].noun;
         if (currentIconClass) icon.classList.remove(currentIconClass);
         currentIconClass = MATERIALS[i].icon; // from the hardcoded list only
         icon.classList.add(currentIconClass);
     }
 
+    // Build one checked-off "acquired" row. XSS-safe: text via textContent,
+    // icon className only from the hardcoded MATERIALS allowlist.
+    function buildAcquiredRow(material) {
+        var li = document.createElement('li');
+        li.className = 'dh-gather-row is-acquired';
+
+        var check = document.createElement('i');
+        check.className = 'fa-solid fa-check dh-gather-check';
+        check.setAttribute('aria-hidden', 'true');
+
+        var noun = document.createElement('span');
+        noun.className = 'dh-gather-noun';
+        noun.textContent = material.noun;
+
+        var leader = document.createElement('span');
+        leader.className = 'dh-gather-leader';
+        leader.setAttribute('aria-hidden', 'true');
+
+        var qty = document.createElement('span');
+        qty.className = 'dh-gather-qty';
+        qty.textContent = QUANTITIES[Math.floor(Math.random() * QUANTITIES.length)];
+
+        var chip = document.createElement('i');
+        chip.className = 'fa-solid ' + material.icon + ' dh-gather-chip';
+        chip.setAttribute('aria-hidden', 'true');
+
+        li.appendChild(check);
+        li.appendChild(noun);
+        li.appendChild(leader);
+        li.appendChild(qty);
+        li.appendChild(chip);
+        return li;
+    }
+
+    function recordAcquired(i) {
+        list.insertBefore(buildAcquiredRow(MATERIALS[i]), current);
+        shownIdx.push(i);
+        // Cap the visible history; drop the oldest acquired row(s) off the top.
+        var rows = list.querySelectorAll('.dh-gather-row.is-acquired');
+        for (var k = 0; k < rows.length - MAX_VISIBLE; k++) {
+            rows[k].remove();
+        }
+        while (shownIdx.length > MAX_VISIBLE) shownIdx.shift();
+        count += 1;
+        tally.textContent = String(count);
+    }
+
+    // Pick a material not currently on screen (live row + visible acquired rows),
+    // so the same part never appears twice at once. Falls back to "anything but
+    // the live row" if the list is somehow larger than the catalog.
     function nextIndex() {
-        var n = idx;
-        while (n === idx && MATERIALS.length > 1) {
+        var n = Math.floor(Math.random() * MATERIALS.length);
+        if (MATERIALS.length <= MAX_VISIBLE + 1) {
+            while (n === idx && MATERIALS.length > 1) {
+                n = Math.floor(Math.random() * MATERIALS.length);
+            }
+            return n;
+        }
+        while (n === idx || shownIdx.indexOf(n) !== -1) {
             n = Math.floor(Math.random() * MATERIALS.length);
         }
         return n;
     }
 
     function startRotation() {
-        if (reduceMotion || rotateTimer) return; // static single material under reduced motion
+        if (reduceMotion || rotateTimer) return; // static list under reduced motion
         rotateTimer = setInterval(function () {
             term.classList.add('is-fading');
             icon.classList.add('is-fading');
             setTimeout(function () {
+                recordAcquired(idx); // the live part is now scavenged
                 idx = nextIndex();
-                render(idx); // preserves is-fading, so the new pair fades in
+                renderCurrent(idx); // preserves is-fading, so the new pair fades in
                 term.classList.remove('is-fading');
                 icon.classList.remove('is-fading');
-            }, 400); // matches the .dh-gather-term/.dh-gather-icon opacity transition
-        }, 2000);
+            }, 350); // matches the .dh-gather-term/.dh-gather-icon opacity transition
+        }, 1800);
+    }
+
+    // Rotating "shop log" ticker. Static single line under reduced motion.
+    function startStatus() {
+        if (!statusEl || reduceMotion || statusTimer) return;
+        statusTimer = setInterval(function () {
+            statusEl.classList.add('is-fading');
+            setTimeout(function () {
+                statusIdx = (statusIdx + 1 + Math.floor(Math.random() * (STATUSES.length - 1))) % STATUSES.length;
+                statusEl.textContent = STATUSES[statusIdx];
+                statusEl.classList.remove('is-fading');
+            }, 300);
+        }, 2600);
     }
 
     function showOverlay() {
         overlay.classList.add('is-visible');
         overlay.setAttribute('aria-hidden', 'false');
         startRotation();
+        startStatus();
+        startSparks();
     }
 
     function hideOverlay() {
         overlay.classList.remove('is-visible');
         overlay.setAttribute('aria-hidden', 'true');
         if (rotateTimer) { clearInterval(rotateTimer); rotateTimer = null; }
+        if (statusTimer) { clearInterval(statusTimer); statusTimer = null; }
+        stopSparks();
         if (submitBtn) submitBtn.disabled = false;
         submitting = false; // allow re-submit after a Back/bfcache return
     }
 
-    render(idx);
+    /* ---- Background spark fountain (decorative) -------------------------------
+       A welder/grinder going at it behind the slip: bursts of warm particles
+       arc up from behind the top edge and rain back down. Canvas + rAF, capped
+       and additive-blended. Never runs under reduced motion; torn down on hide
+       so it can't leak a rAF loop after the page swaps. */
+    var sparkCanvas = document.getElementById('signup-gather-sparks');
+    var sparkCtx    = (sparkCanvas && sparkCanvas.getContext) ? sparkCanvas.getContext('2d') : null;
+    var particles   = [];
+    var sparkRaf    = null;
+    var burstTimer  = null;
+    var emitters    = [];
+
+    function sizeSparkCanvas() {
+        if (!sparkCtx) return;
+        var w = sparkCanvas.clientWidth, h = sparkCanvas.clientHeight;
+        if (!w || !h) return;
+        var dpr = Math.min(window.devicePixelRatio || 1, 2);
+        sparkCanvas.width  = Math.round(w * dpr);
+        sparkCanvas.height = Math.round(h * dpr);
+        sparkCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        // Anchor emitters to the slip silhouette so sparks fountain out from
+        // behind it regardless of viewport size. Four origins: the top corners
+        // throw tall fountains; the mid-side vents spray outward with a low lift.
+        // `dir` = horizontal sign, `up` = how much of the kick goes upward.
+        var slip = overlay.querySelector('.dh-gather-slip');
+        var r = slip ? slip.getBoundingClientRect()
+                     : { left: w * 0.32, right: w * 0.68, top: h * 0.32,
+                         bottom: h * 0.68, width: w * 0.36, height: h * 0.36 };
+        emitters = [
+            { x: r.left  + r.width * 0.18, y: r.top + 4,             dir: -1, up: 1.0 },
+            { x: r.right - r.width * 0.18, y: r.top + 4,             dir:  1, up: 1.0 },
+            { x: r.left  + 4,              y: r.top + r.height * 0.55, dir: -1, up: 0.4 },
+            { x: r.right - 4,              y: r.top + r.height * 0.55, dir:  1, up: 0.4 }
+        ];
+    }
+
+    function spawnBurst() {
+        if (!emitters.length) return;
+        var e = emitters[Math.floor(Math.random() * emitters.length)];
+        var n = 8 + Math.floor(Math.random() * 9);
+        for (var i = 0; i < n; i++) {
+            var speed = 3 + Math.random() * 6;
+            particles.push({
+                x: e.x, y: e.y, px: e.x, py: e.y,
+                vx: (e.dir * (0.4 + Math.random() * 0.6)) * speed,
+                vy: -(0.2 + e.up * (0.45 + Math.random() * 0.65)) * speed,
+                life: 0, maxLife: 42 + Math.random() * 46,
+                size: 0.8 + Math.random() * 1.5
+            });
+        }
+    }
+
+    function stepSparks() {
+        if (!sparkCtx) return;
+        var w = sparkCanvas.clientWidth, h = sparkCanvas.clientHeight;
+        sparkCtx.clearRect(0, 0, w, h);
+        sparkCtx.globalCompositeOperation = 'lighter';
+        sparkCtx.lineCap = 'round';
+        for (var i = particles.length - 1; i >= 0; i--) {
+            var p = particles[i];
+            p.px = p.x; p.py = p.y;
+            p.vy += 0.16;   // gravity
+            p.vx *= 0.99;   // air drag
+            p.vy *= 0.99;
+            p.x += p.vx; p.y += p.vy;
+            p.life++;
+            var t = p.life / p.maxLife;
+            if (t >= 1 || p.y > h + 24) { particles.splice(i, 1); continue; }
+            // White-hot, cooling to orange-red as it ages.
+            var hue   = 48 - t * 33;
+            var light = 78 - t * 40;
+            sparkCtx.strokeStyle = 'hsla(' + hue + ', 100%, ' + light + '%, ' + (1 - t) + ')';
+            sparkCtx.lineWidth = p.size;
+            sparkCtx.beginPath();
+            sparkCtx.moveTo(p.px, p.py);
+            sparkCtx.lineTo(p.x, p.y);
+            sparkCtx.stroke();
+        }
+        sparkCtx.globalCompositeOperation = 'source-over';
+        sparkRaf = window.requestAnimationFrame(stepSparks);
+    }
+
+    function startSparks() {
+        if (reduceMotion || !sparkCtx || sparkRaf) return;
+        sizeSparkCanvas();
+        spawnBurst();
+        burstTimer = setInterval(spawnBurst, 1400 + Math.random() * 900);
+        sparkRaf = window.requestAnimationFrame(stepSparks);
+    }
+
+    function stopSparks() {
+        if (sparkRaf)   { window.cancelAnimationFrame(sparkRaf); sparkRaf = null; }
+        if (burstTimer) { clearInterval(burstTimer); burstTimer = null; }
+        particles.length = 0;
+        if (sparkCtx) sparkCtx.clearRect(0, 0, sparkCanvas.clientWidth, sparkCanvas.clientHeight);
+    }
+
+    // Keep emitters/resolution aligned to the slip when the viewport changes
+    // while the overlay is up.
+    window.addEventListener('resize', function () { if (sparkRaf) sizeSparkCanvas(); });
+
+    // Flavor job number, e.g. "#3F9A". Cosmetic only.
+    if (jobEl) {
+        var hex = Math.floor(Math.random() * 0x10000).toString(16).toUpperCase();
+        jobEl.textContent = '#' + ('0000' + hex).slice(-4);
+    }
+
+    // Seed the list so it isn't empty at reveal: pre-shelve a couple of parts
+    // distinct from the live one (and each other).
+    renderCurrent(idx);
+    if (statusEl) statusEl.textContent = STATUSES[statusIdx];
+    for (var s = 0; s < 2; s++) {
+        recordAcquired(nextIndex()); // each pick avoids the live row + already-seeded
+    }
 
     if (form) {
         form.addEventListener('submit', function (e) {

--- a/code/DHMemberPortal/templates/_signup_gather.html
+++ b/code/DHMemberPortal/templates/_signup_gather.html
@@ -16,7 +16,11 @@
     {# Decorative spark fountain behind the slip — something's being welded back
        there. Canvas-drawn, aria-hidden, never started under reduced motion. #}
     <canvas id="signup-gather-sparks" class="dh-gather-sparks" aria-hidden="true"></canvas>
-    <div class="dh-gather-slip" role="status" aria-live="polite">
+    {# Screen readers get ONE concise polite announcement (set on reveal). The
+       animated slip below is aria-hidden so the per-second BOM/tally churn
+       doesn't flood the SR queue and bury the "don't refresh" message. #}
+    <p id="signup-gather-sr" class="visually-hidden" role="status" aria-live="polite"></p>
+    <div class="dh-gather-slip" aria-hidden="true">
         <div class="dh-gather-head">
             <span class="dh-gather-head-mark">PS<span class="dh-gather-dot">:</span>ONE shop <span class="dh-gather-dot">&middot;</span> work order</span>
             <span class="dh-gather-head-job">JOB <span id="signup-gather-job">#0000</span></span>
@@ -43,7 +47,7 @@
                 </li>
             </ul>
 
-            <p class="dh-gather-status" aria-hidden="true">
+            <p class="dh-gather-status">
                 <span class="dh-gather-status-label">Shop log</span>
                 <span id="signup-gather-status" class="dh-gather-status-text">Negotiating with the raccoons</span><span class="dh-gather-cursor"></span>
             </p>
@@ -154,8 +158,12 @@
 
     var MAX_VISIBLE = 4; // acquired rows kept on screen; older ones drop off the top
 
-    var reduceMotion = window.matchMedia
-        && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    // Re-read at call time rather than snapshotting once, so a mid-session OS
+    // toggle is respected on the next reveal; a change-listener below also stops
+    // any in-flight motion immediately.
+    var motionMq = window.matchMedia
+        ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+    function prefersReducedMotion() { return !!(motionMq && motionMq.matches); }
 
     var idx = Math.floor(Math.random() * MATERIALS.length);
     var shownIdx = [];       // material indices currently on screen (acquired rows)
@@ -164,6 +172,7 @@
     var statusEl    = document.getElementById('signup-gather-status');
     var statusTimer = null;
     var statusIdx   = Math.floor(Math.random() * STATUSES.length);
+    var srEl        = document.getElementById('signup-gather-sr');
     var submitting = false;  // one-shot: true once a valid submit is handed off
 
     // Track the current FA glyph class so we can swap just that token and leave
@@ -214,35 +223,45 @@
     function recordAcquired(i) {
         list.insertBefore(buildAcquiredRow(MATERIALS[i]), current);
         shownIdx.push(i);
-        // Cap the visible history; drop the oldest acquired row(s) off the top.
-        var rows = list.querySelectorAll('.dh-gather-row.is-acquired');
-        for (var k = 0; k < rows.length - MAX_VISIBLE; k++) {
-            rows[k].remove();
-        }
-        while (shownIdx.length > MAX_VISIBLE) shownIdx.shift();
         count += 1;
         tally.textContent = String(count);
+        // Single cap: trim shownIdx and the DOM together. The oldest acquired
+        // row is the list's first child (the live row is always last).
+        while (shownIdx.length > MAX_VISIBLE) {
+            shownIdx.shift();
+            if (list.firstElementChild && list.firstElementChild !== current) {
+                list.removeChild(list.firstElementChild);
+            }
+        }
     }
 
     // Pick a material not currently on screen (live row + visible acquired rows),
-    // so the same part never appears twice at once. Falls back to "anything but
-    // the live row" if the list is somehow larger than the catalog.
+    // so the same part never appears twice at once. Bounded retry so a future
+    // shrink of MATERIALS below the visible window can't spin forever.
     function nextIndex() {
-        var n = Math.floor(Math.random() * MATERIALS.length);
-        if (MATERIALS.length <= MAX_VISIBLE + 1) {
-            while (n === idx && MATERIALS.length > 1) {
-                n = Math.floor(Math.random() * MATERIALS.length);
-            }
-            return n;
-        }
-        while (n === idx || shownIdx.indexOf(n) !== -1) {
+        var n = idx, tries = 0;
+        do {
             n = Math.floor(Math.random() * MATERIALS.length);
-        }
+        } while ((n === idx || shownIdx.indexOf(n) !== -1) && ++tries < 50);
         return n;
     }
 
+    // Reset to a fresh slip: clear acquired rows + counters, pick a new live
+    // part, and pre-shelve a couple so it isn't empty at reveal. Called on every
+    // showOverlay() so a re-reveal never resumes mid-history with a stale tally.
+    function seedBOM() {
+        var old = list.querySelectorAll('.dh-gather-row.is-acquired');
+        for (var k = 0; k < old.length; k++) old[k].remove();
+        shownIdx = [];
+        count = 0;
+        tally.textContent = '0';
+        idx = Math.floor(Math.random() * MATERIALS.length);
+        renderCurrent(idx);
+        for (var s = 0; s < 2; s++) recordAcquired(nextIndex());
+    }
+
     function startRotation() {
-        if (reduceMotion || rotateTimer) return; // static list under reduced motion
+        if (prefersReducedMotion() || rotateTimer) return; // static list under reduced motion
         rotateTimer = setInterval(function () {
             term.classList.add('is-fading');
             icon.classList.add('is-fading');
@@ -258,7 +277,7 @@
 
     // Rotating "shop log" ticker. Static single line under reduced motion.
     function startStatus() {
-        if (!statusEl || reduceMotion || statusTimer) return;
+        if (!statusEl || prefersReducedMotion() || statusTimer) return;
         statusTimer = setInterval(function () {
             statusEl.classList.add('is-fading');
             setTimeout(function () {
@@ -270,8 +289,11 @@
     }
 
     function showOverlay() {
+        if (overlay.classList.contains('is-visible')) return; // top-level re-entrancy guard
+        seedBOM();                                            // fresh slip on every reveal
         overlay.classList.add('is-visible');
         overlay.setAttribute('aria-hidden', 'false');
+        if (srEl) srEl.textContent = "Building your member portal. Please don't refresh. We're handing you to the payment processor.";
         startRotation();
         startStatus();
         startSparks();
@@ -283,6 +305,7 @@
         if (rotateTimer) { clearInterval(rotateTimer); rotateTimer = null; }
         if (statusTimer) { clearInterval(statusTimer); statusTimer = null; }
         stopSparks();
+        if (srEl) srEl.textContent = ''; // clear so the next reveal re-announces
         if (submitBtn) submitBtn.disabled = false;
         submitting = false; // allow re-submit after a Back/bfcache return
     }
@@ -291,12 +314,13 @@
        A welder/grinder going at it behind the slip: bursts of warm particles
        arc up from behind the top edge and rain back down. Canvas + rAF, capped
        and additive-blended. Never runs under reduced motion; torn down on hide
-       so it can't leak a rAF loop after the page swaps. */
+       (and paused while the tab is hidden) so it can't leak a perpetual loop. */
     var sparkCanvas = document.getElementById('signup-gather-sparks');
     var sparkCtx    = (sparkCanvas && sparkCanvas.getContext) ? sparkCanvas.getContext('2d') : null;
     var particles   = [];
     var sparkRaf    = null;
     var burstTimer  = null;
+    var resizeRaf   = null;
     var emitters    = [];
 
     function sizeSparkCanvas() {
@@ -304,9 +328,14 @@
         var w = sparkCanvas.clientWidth, h = sparkCanvas.clientHeight;
         if (!w || !h) return;
         var dpr = Math.min(window.devicePixelRatio || 1, 2);
-        sparkCanvas.width  = Math.round(w * dpr);
-        sparkCanvas.height = Math.round(h * dpr);
-        sparkCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        var pw = Math.round(w * dpr), ph = Math.round(h * dpr);
+        // Only reallocate the backing store when the pixel size actually changed —
+        // assigning canvas.width/height clears the canvas and resets ctx state.
+        if (sparkCanvas.width !== pw || sparkCanvas.height !== ph) {
+            sparkCanvas.width  = pw;
+            sparkCanvas.height = ph;
+            sparkCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        }
         // Anchor emitters to the slip silhouette so sparks fountain out from
         // behind it regardless of viewport size. Four origins: the top corners
         // throw tall fountains; the mid-side vents spray outward with a low lift.
@@ -324,6 +353,7 @@
     }
 
     function spawnBurst() {
+        if (!emitters.length) sizeSparkCanvas(); // retry if the first sizing read 0
         if (!emitters.length) return;
         var e = emitters[Math.floor(Math.random() * emitters.length)];
         var n = 8 + Math.floor(Math.random() * 9);
@@ -337,10 +367,14 @@
                 size: 0.8 + Math.random() * 1.5
             });
         }
+        // Kick the draw loop back on if it self-paused while idle.
+        if (!sparkRaf && !prefersReducedMotion()) {
+            sparkRaf = window.requestAnimationFrame(stepSparks);
+        }
     }
 
     function stepSparks() {
-        if (!sparkCtx) return;
+        if (!sparkCtx) { sparkRaf = null; return; }
         var w = sparkCanvas.clientWidth, h = sparkCanvas.clientHeight;
         sparkCtx.clearRect(0, 0, w, h);
         sparkCtx.globalCompositeOperation = 'lighter';
@@ -366,15 +400,16 @@
             sparkCtx.stroke();
         }
         sparkCtx.globalCompositeOperation = 'source-over';
-        sparkRaf = window.requestAnimationFrame(stepSparks);
+        // Self-pause when idle so we don't burn a frame budget drawing nothing
+        // (the autoplay preview page never hides). spawnBurst restarts the loop.
+        sparkRaf = particles.length ? window.requestAnimationFrame(stepSparks) : null;
     }
 
     function startSparks() {
-        if (reduceMotion || !sparkCtx || sparkRaf) return;
+        if (prefersReducedMotion() || !sparkCtx || burstTimer) return; // burstTimer = "already running"
         sizeSparkCanvas();
-        spawnBurst();
+        spawnBurst(); // also starts the rAF loop
         burstTimer = setInterval(spawnBurst, 1400 + Math.random() * 900);
-        sparkRaf = window.requestAnimationFrame(stepSparks);
     }
 
     function stopSparks() {
@@ -384,9 +419,33 @@
         if (sparkCtx) sparkCtx.clearRect(0, 0, sparkCanvas.clientWidth, sparkCanvas.clientHeight);
     }
 
-    // Keep emitters/resolution aligned to the slip when the viewport changes
-    // while the overlay is up.
-    window.addEventListener('resize', function () { if (sparkRaf) sizeSparkCanvas(); });
+    // Keep emitters/resolution aligned to the slip on viewport change, but only
+    // while sparks are active and coalesced to one recompute per frame (avoids a
+    // backing-store realloc storm during a drag-resize).
+    window.addEventListener('resize', function () {
+        if (!burstTimer || resizeRaf) return;
+        resizeRaf = window.requestAnimationFrame(function () {
+            resizeRaf = null;
+            sizeSparkCanvas();
+        });
+    });
+
+    // Pause the per-frame spark loop while the tab is backgrounded so the
+    // autoplay preview doesn't burn CPU/GPU in the background.
+    document.addEventListener('visibilitychange', function () {
+        if (!overlay.classList.contains('is-visible')) return;
+        if (document.hidden) stopSparks(); else startSparks();
+    });
+
+    // If the user flips on reduced-motion mid-session, stop in-flight motion now.
+    if (motionMq && motionMq.addEventListener) {
+        motionMq.addEventListener('change', function () {
+            if (!prefersReducedMotion()) return;
+            if (rotateTimer) { clearInterval(rotateTimer); rotateTimer = null; }
+            if (statusTimer) { clearInterval(statusTimer); statusTimer = null; }
+            stopSparks();
+        });
+    }
 
     // Flavor job number, e.g. "#3F9A". Cosmetic only.
     if (jobEl) {
@@ -394,13 +453,10 @@
         jobEl.textContent = '#' + ('0000' + hex).slice(-4);
     }
 
-    // Seed the list so it isn't empty at reveal: pre-shelve a couple of parts
-    // distinct from the live one (and each other).
+    // Initial (still-hidden) state; showOverlay() reseeds a fresh slip on every
+    // reveal, so no acquired rows are built until the overlay is actually shown.
     renderCurrent(idx);
     if (statusEl) statusEl.textContent = STATUSES[statusIdx];
-    for (var s = 0; s < 2; s++) {
-        recordAcquired(nextIndex()); // each pick avoids the live row + already-seeded
-    }
 
     if (form) {
         form.addEventListener('submit', function (e) {

--- a/code/DHMemberPortal/templates/signup_form.html
+++ b/code/DHMemberPortal/templates/signup_form.html
@@ -235,4 +235,8 @@
             try { input.showPicker(); } catch (_) { /* already open or blocked */ }
         });
     </script>
+
+    {# Submit interstitial (revealed on a valid submit). Shared with the
+       standalone preview page; see _signup_gather.html. #}
+    {% include '_signup_gather.html' %}
 {% endblock %}

--- a/code/DHMemberPortal/templates/signup_loading_preview.html
+++ b/code/DHMemberPortal/templates/signup_loading_preview.html
@@ -1,0 +1,23 @@
+{# Standalone, shareable preview of the signup "gathering materials" loading
+   interstitial. Reuses the exact same markup/behavior/styles as the real form
+   (via _signup_gather.html) but auto-plays on load. No form, no submit, no DB
+   writes — purely a demo of the loader. #}
+{% extends "base.html" %}
+{% block title %}Loading Preview - Pumping Station: One{% endblock %}
+{% block page_title %}Signup Loading Preview{% endblock %}
+{% block content %}
+            <div class="col-md-10 col-lg-8">
+                <div class="card">
+                    <div class="card-body">
+                        <p class="text-muted mb-0">
+                            This is a standalone preview of the signup loading screen.
+                            It plays automatically and loops.
+                        </p>
+                    </div>
+                </div>
+            </div>
+{% endblock %}
+{% block scripts %}
+    {% set gather_autoplay = true %}
+    {% include '_signup_gather.html' %}
+{% endblock %}


### PR DESCRIPTION
## Summary

Member-portal-only fixes for the **#283** failure mode — members who complete the signup form but never reach Stripe, ending up as `pending` (or status-less) rows with no subscription and no way forward. PR #284 fixed the single-submit happy path; this closes the gaps it left and gives the slow submit a proper loading interstitial.

### 1. Stranded-member resume gate (option B from #283, never built)

`_is_stranded_pre_payment(access_token, member_id)` decides whether an existing member signed up but never paid, and if so routes them to `/signup/payment` instead of dead-ending. "Stranded" = no `stripe_product_id`/`stripe_subscription_id` **and** either:
- a `pending` membership_status, or
- a **genuinely empty** status (no membership_status **and** no membership_level).

The blank case matters because the `status` column is a best-effort scaffolding write that's allowed to fail — a half-created member can have a NULL status. But blank membership_status is *also* what `v_member_info` emits for any never-populated account (incl. legacy/imported), so the blank branch additionally requires **no membership_level** — an established account always carries a level even with a null status, so this won't route a real member to re-payment. Short-circuits on `has_stripe` and explicit `pending`; fails **safe** (any error fetching status → prior behavior).

Gated at both decision points that previously stranded these members:
- **`signup_check_email`** — was: an existing member always redirected to login.
- **`signup_submit`** — was: an existing member always re-rendered the "account exists — sign in" form. This is the branch a **refresh / double-submit** trips (the in-flight POST commits the row; the re-issued POST sees it).

Genuinely existing paid/active accounts still go to login (verified against a paid `pending` fixture).

### 2. Keep the email out of the URL (closes #294)

The payment redirects previously put the plaintext email in the URL (`?email=`). Now the email rides `session['signup_email']` and `signup_payment` reads the **session only**. Stripe prefill still works; a user-supplied `?email=` can no longer drive it.

### 3. Submit interstitial — "Shop Work Order"

A full-screen loader shown the instant a valid submit fires, while the slow `/signup/submit` POST runs underneath (overlay-on-native-submit — no fetch plumbing; degrades gracefully with no JS). It discourages the refresh that causes the double-submit in the first place.

Rather than a generic spinner, the wait is staged as a PS:One fabrication **work-order slip**: the rotating material becomes an accumulating **Bill of Materials** (each scavenged part checks off and stacks in, with an absurd shop quantity), a faux **"Shop Log"** ticker rotates flavor lines, and a canvas **spark fountain** welds away behind the slip. The "don't refresh" line is a stamped hazard placard. Identity is a manila/stencil-mono/shop-cyan/hazard palette scoped to the overlay.

- Reveal gated on `e.defaultPrevented`, so an invalid submit never shows it; one-shot guard blocks duplicate POSTs (incl. Enter-key implicit submit).
- **XSS-safe throughout** — DOM built via `createElement`/`textContent`; every icon className comes from a hardcoded allowlist, never interpolated.
- Respects `prefers-reduced-motion` (re-read live, with a `change` listener); bfcache/`popstate` guard prevents a stuck overlay on Back; the slip re-seeds fresh on every reveal.
- The spark loop self-pauses when idle and while the tab is hidden (no perpetual rAF); resize is rAF-coalesced.
- Extracted to a shared partial (`_signup_gather.html`) so the real form and a standalone **`/signup/loading-preview`** demo route can't drift.

### 4. Hardening (self-review pass)

A multi-angle review of the above produced fixes folded into this branch:
- **Accessibility:** the animated slip is `aria-hidden`; screen readers get a single concise polite announcement on reveal instead of the per-second BOM/tally churn flooding the SR queue.
- **Resume gate:** the blank-status narrowing in §1 (no longer routes established/legacy accounts to re-payment).
- **Efficiency:** self-pausing spark rAF + pause-on-hidden-tab; debounced resize that skips the canvas realloc when size is unchanged.
- **Cleanup:** removed dead `is-leaving`/`dh-row-out` CSS and a duplicate blink keyframe (reuses the shared `blink-cursor`); single source of truth for the BOM row cap; `nextIndex` collapsed to one bounded loop.

No schema or DHService changes.

## Files

- `code/DHMemberPortal/app.py` — resume helper + two gates, session-only email, `/signup/loading-preview` route
- `code/DHMemberPortal/templates/_signup_gather.html` *(new)* — shared loader markup + JS (work order, BOM, sparks, ticker)
- `code/DHMemberPortal/templates/signup_loading_preview.html` *(new)* — standalone preview
- `code/DHMemberPortal/templates/signup_form.html` — includes the loader partial
- `code/DHMemberPortal/static/css/portal.css` — `.dh-gather-*` "Shop Work Order" styles

## Testing (on dev, via chrome-devtools)

- [x] Happy path → `/signup/payment`, no `?email=`, Stripe prefilled from session
- [x] Stranded `pending` member re-enters email → payment (Fix A), no duplicate row
- [x] Double-submit (Back + resubmit) of stranded member → payment (Fix B), no duplicate row
- [x] Paid `pending` member (has Stripe data) → login, not payment (gate declines)
- [x] Blank-status branch requires no membership_level (established/legacy accounts → login)
- [x] Loader: reveal only on valid submit; BOM accumulation capped + de-duped; spark fountain; shop-log ticker
- [x] `prefers-reduced-motion`, bfcache/popstate guard, reset-on-reveal; SR announcement set/cleared correctly
- [x] Spark rAF self-pauses when idle (~106 vs ~180 frames/3s measured); no new console errors; desktop + 390px mobile
- [x] Standalone preview route shares the exact same markup/CSS/JS as the real loader
- [x] Test members cleaned off the dev DB afterward

## Notes / follow-ups

- The resume "let's finish your payment" flash doesn't render — `signup_payment.html` has no flash block (pre-existing). Users still land on payment; surfacing the flash there is a small optional follow-up.
- `/signup/loading-preview` is an unauthenticated demo route. Harmless, but could be gated to dev later if it shouldn't ship to prod.
- This implements option B from #283; options C/D (DHService returning real 5xx / a single transactional signup endpoint) remain for the planned signup redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
