### PR TITLE
Member portal: activation notices (blocking + welcome) on dashboard home

### DIFF
--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -2,7 +2,7 @@ import re
 import uuid
 import requests
 import json
-from flask import Flask, render_template, session, request, redirect, url_for, make_response, flash
+from flask import Flask, render_template, session, request, redirect, url_for, make_response, flash, abort
 from flask_session import Session
 from flask_wtf.csrf import CSRFProtect, CSRFError
 import msal
@@ -121,6 +121,41 @@ def _is_stranded_pre_payment(access_token, member_id):
     # level even with a null membership_status) aren't sent to re-payment.
     return membership_status == '' and not membership_level
 
+def _dashboard_blocking_gate(access_token, member_id, member_info):
+    """Decide whether /dashboard home should show the non-dismissible activation
+    work-order overlay, and which variant.
+
+    Returns:
+        'payment' — pending member with no Stripe payment on file yet.
+        'idcheck' — pending member who HAS paid but hasn't had an in-person
+                    age/ID check (neither the legacy `id_check_1` nor the new
+                    `id_check_date` is set).
+        None      — no overlay (not pending, already checked, or any error).
+
+    Only pending members are ever gated. Fails SAFE to None on any error
+    fetching status, so an API blip can't trap a member behind a modal that
+    cannot be dismissed.
+    """
+    ms = ((member_info.get('status') or {}).get('membership_status') or '').lower()
+    if ms != 'pending':
+        return None
+    # stripe_product_id / stripe_subscription_id live in the raw `status` JSONB,
+    # which v_member_info (get_full_member_info) does not expose — fetch raw.
+    try:
+        status = dhservices.get_member_status(access_token, member_id) or {}
+    except Exception as e:
+        logger.warning(f"Blocking-gate status fetch failed for member {member_id}: {e}")
+        return None
+    has_stripe = bool(status.get('stripe_product_id')
+                      or status.get('stripe_subscription_id'))
+    if not has_stripe:
+        return 'payment'
+    forms = member_info.get('forms') or {}
+    id_checked = bool((forms.get('id_check_1') or '').strip() or forms.get('id_check_date'))
+    if not id_checked:
+        return 'idcheck'
+    return None
+
 @app.route('/signup')
 def signup_start():
     """First step of signup - email entry"""
@@ -203,6 +238,21 @@ def signup_loading_preview():
     demo so the animation can be shared/reviewed via a single URL.
     """
     return render_template('signup_loading_preview.html')
+
+@app.route('/dashboard/notice-preview')
+def dashboard_notice_preview():
+    """Dev-only standalone preview of the /dashboard activation blocking notice.
+
+    Renders the real partial (_dashboard_blocking_notice.html) over a stub page,
+    toggled via ?case=payment|idcheck. No auth, no DB writes — a visual review
+    tool so the overlay can be shared/reviewed via a single URL. Hidden outside
+    dev so it can't be reached in production."""
+    if AUTH_MODE != 'dev':
+        abort(404)
+    case = request.args.get('case', 'payment')
+    if case not in ('payment', 'idcheck'):
+        case = 'payment'
+    return render_template('dashboard_notice_preview.html', case=case)
 
 @app.route('/signup/payment')
 def signup_payment():
@@ -593,8 +643,18 @@ def member_dashboard():
     if error:
         return error
 
+    info = member_info if isinstance(member_info, dict) else {}
+    gate = _dashboard_blocking_gate(session['access_token'], session['member_id'], info)
+    if gate == 'payment':
+        # signup_payment reads the email from the session ONLY (#294); set it
+        # here so the overlay's "Complete payment" button can route there
+        # without the address ever appearing in the URL.
+        session['signup_email'] = (info.get('identity') or {}).get('primary_email')
+
     return render_template('member_dashboard.html',
-                         status=member_info.get('status', {}) if isinstance(member_info, dict) else {},
+                         status=info.get('status', {}),
+                         gate=gate,
+                         member_id=session['member_id'],
                          user=session.get('user'))
 
 @app.route('/dashboard/profile')

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -6,7 +6,7 @@ from flask import Flask, render_template, session, request, redirect, url_for, m
 from flask_session import Session
 from flask_wtf.csrf import CSRFProtect, CSRFError
 import msal
-from datetime import datetime
+from datetime import datetime, date
 
 # Our stuff
 import dhservices
@@ -156,6 +156,33 @@ def _dashboard_blocking_gate(access_token, member_id, member_info):
         return 'idcheck'
     return None
 
+# A new member sits in "active but no key yet" for only a short window, so the
+# welcome banner is recomputed on every load and dismissal isn't persisted.
+_WELCOME_MAX_AGE_DAYS = 14
+
+def _dashboard_welcome_active_no_key(member_info):
+    """True when /dashboard home should show the dismissible welcome banner:
+    an active member, less than two weeks old, who hasn't had a key activated
+    yet. Self-expiring (stops once they get a key or age past the window).
+
+    Fails closed to False on a missing/unparseable member_since."""
+    status = member_info.get('status') or {}
+    if (status.get('membership_status') or '').lower() != 'active':
+        return False
+    access = member_info.get('access') or {}
+    if access.get('rfid_tags'):  # any key on file → already past this step
+        return False
+    member_since = status.get('member_since')
+    if not member_since:
+        return False
+    try:
+        # v_member_info emits member_since via safe_to_date (ISO date); tolerate
+        # a datetime suffix by taking the leading YYYY-MM-DD.
+        joined = date.fromisoformat(str(member_since)[:10])
+    except ValueError:
+        return False
+    return (date.today() - joined).days < _WELCOME_MAX_AGE_DAYS
+
 @app.route('/signup')
 def signup_start():
     """First step of signup - email entry"""
@@ -250,7 +277,7 @@ def dashboard_notice_preview():
     if AUTH_MODE != 'dev':
         abort(404)
     case = request.args.get('case', 'payment')
-    if case not in ('payment', 'idcheck'):
+    if case not in ('payment', 'idcheck', 'welcome'):
         case = 'payment'
     return render_template('dashboard_notice_preview.html', case=case)
 
@@ -651,9 +678,14 @@ def member_dashboard():
         # without the address ever appearing in the URL.
         session['signup_email'] = (info.get('identity') or {}).get('primary_email')
 
+    # Welcome banner only matters for active members, so it can't co-occur with
+    # the pending-only blocking gate; compute it only when not gated.
+    welcome = (not gate) and _dashboard_welcome_active_no_key(info)
+
     return render_template('member_dashboard.html',
                          status=info.get('status', {}),
                          gate=gate,
+                         welcome=welcome,
                          member_id=session['member_id'],
                          user=session.get('user'))
 

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -156,14 +156,24 @@ def _dashboard_blocking_gate(access_token, member_id, member_info):
         return 'idcheck'
     return None
 
-# A new member sits in "active but no key yet" for only a short window, so the
-# welcome banner is recomputed on every load and dismissal isn't persisted.
-_WELCOME_MAX_AGE_DAYS = 14
+# A new member sits in "active but no key yet" only briefly, so the welcome
+# banner is recomputed on every load and dismissal isn't persisted.
+#
+# NOTE: this window is measured from `member_since` (the signup/join date), NOT
+# from when the member was activated, because no activation timestamp is stored
+# today. A member who stays pending longer than this window before an admin
+# activates them will therefore never see the welcome banner. The real
+# self-expiry is "got a key" (the rfid_tags check below); the window only stops
+# the banner showing forever to an established member who never registered a
+# key. Window kept generous so realistic (including slow) onboarding is covered.
+# A precise fix would key off a stored activated-at date (follow-up ticket).
+_WELCOME_MAX_AGE_DAYS = 30
 
 def _dashboard_welcome_active_no_key(member_info):
     """True when /dashboard home should show the dismissible welcome banner:
-    an active member, less than two weeks old, who hasn't had a key activated
-    yet. Self-expiring (stops once they get a key or age past the window).
+    an active member who joined within _WELCOME_MAX_AGE_DAYS and hasn't had a
+    key activated yet. Self-expiring (stops once they get a key or age past the
+    window). See the note on _WELCOME_MAX_AGE_DAYS re: join-date vs activation.
 
     Fails closed to False on a missing/unparseable member_since."""
     status = member_info.get('status') or {}
@@ -270,9 +280,9 @@ def signup_loading_preview():
 def dashboard_notice_preview():
     """Dev-only standalone preview of the /dashboard activation blocking notice.
 
-    Renders the real partial (_dashboard_blocking_notice.html) over a stub page,
-    toggled via ?case=payment|idcheck. No auth, no DB writes — a visual review
-    tool so the overlay can be shared/reviewed via a single URL. Hidden outside
+    Renders the real partials over a stub page, toggled via
+    ?case=payment|idcheck|welcome. No auth, no DB writes — a visual review
+    tool so the notices can be shared/reviewed via a single URL. Hidden outside
     dev so it can't be reached in production."""
     if AUTH_MODE != 'dev':
         abort(404)

--- a/code/DHMemberPortal/static/css/portal.css
+++ b/code/DHMemberPortal/static/css/portal.css
@@ -1123,9 +1123,11 @@ i.ic-x          { color: #000000 !important; } /* X brand */
    variants ('payment' / 'idcheck') chosen server-side; see
    _dashboard_blocking_notice.html.
    =================================================================== */
-.dh-wo-overlay {
+.dh-wo-overlay,
+.dh-welcome {
     /* Work-order tokens — manila/cream dropped for a clean white slip; only the
-       caution yellow (placard), hazard red, cyan tape, and green checks stay. */
+       caution yellow (placard), hazard red, cyan tape, and green checks stay.
+       Shared by the blocking overlay and the inline welcome banner. */
     --shop-paper: #ffffff;
     --shop-ink: #1e293b;
     --shop-cyan: #009fc2;
@@ -1135,7 +1137,9 @@ i.ic-x          { color: #000000 !important; } /* X brand */
     --shop-rule: #e2e8f0;
     --shop-faint: #64748b;
     --shop-mono: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", "Courier New", monospace;
+}
 
+.dh-wo-overlay {
     position: fixed;
     inset: 0;
     z-index: 1085; /* above Bootstrap offcanvas (1045) & gather (1080), below toasts (1090) */
@@ -1331,3 +1335,34 @@ i.ic-x          { color: #000000 !important; } /* X brand */
 @media (prefers-reduced-motion: reduce) {
     .dh-wo-btn { transition: none; }
 }
+
+/* ---- Welcome banner: inline "build complete" (green) variant -----------
+   Same slip styling, but rendered inline in the dashboard content (no overlay,
+   no backdrop) and dismissible. Green tape + a positive green placard. */
+.dh-welcome { margin-bottom: 1.5rem; }
+.dh-welcome .dh-wo-slip { max-width: none; margin: 0; } /* full content width */
+.dh-wo-slip--ok { border-top-color: var(--shop-green); } /* green tape, not cyan */
+.dh-welcome .dh-wo-jobhead .stamp { color: var(--shop-green); } /* "Almost there" */
+.dh-welcome-lede { margin: 0 0 1.1rem; font-size: 1.02rem; line-height: 1.5; }
+
+/* Positive placard — green, sentence case, readable (not an uppercase stamp). */
+.dh-wo-placard--ok {
+    background-color: color-mix(in srgb, var(--shop-green) 12%, #fff);
+    color: var(--shop-ink);
+    border-color: var(--shop-green);
+    box-shadow: inset 6px 0 0 0 var(--shop-green),
+                inset 12px 0 0 0 color-mix(in srgb, var(--shop-green) 12%, #fff);
+}
+.dh-wo-placard--ok i { color: var(--shop-green); }
+.dh-wo-placard--ok .dh-wo-placard-text {
+    font-family: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-transform: none;
+    line-height: 1.45;
+}
+
+/* Green Continue button, a touch larger than the cyan action button. */
+.dh-wo-btn--ok { background-color: var(--shop-green); }
+.dh-welcome .dh-wo-btn { font-size: 0.9rem; padding: 0.7rem 1.8rem; }

--- a/code/DHMemberPortal/static/css/portal.css
+++ b/code/DHMemberPortal/static/css/portal.css
@@ -1115,3 +1115,219 @@ i.ic-x          { color: #000000 !important; } /* X brand */
     .dh-gather-status-text { transition: none; }
     .dh-gather-row.is-acquired { animation: none; }
 }
+
+/* ===================================================================
+   BLOCKING ACTIVATION NOTICE  (/dashboard home, pending members)
+   A non-dismissible "work order on hold" slip — same shop language as
+   the signup loader, but static and clean (no manila/animation). Two
+   variants ('payment' / 'idcheck') chosen server-side; see
+   _dashboard_blocking_notice.html.
+   =================================================================== */
+.dh-wo-overlay {
+    /* Work-order tokens — manila/cream dropped for a clean white slip; only the
+       caution yellow (placard), hazard red, cyan tape, and green checks stay. */
+    --shop-paper: #ffffff;
+    --shop-ink: #1e293b;
+    --shop-cyan: #009fc2;
+    --shop-green: #1b9e5a;
+    --shop-hazard: #e5341e;
+    --shop-caution: #f4c20d;
+    --shop-rule: #e2e8f0;
+    --shop-faint: #64748b;
+    --shop-mono: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", "Courier New", monospace;
+
+    position: fixed;
+    inset: 0;
+    z-index: 1085; /* above Bootstrap offcanvas (1045) & gather (1080), below toasts (1090) */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    /* Frost the dashboard underneath, then lay a faint blueprint grid over it. */
+    background-color: rgba(15, 23, 42, 0.5);
+    background-image:
+        linear-gradient(color-mix(in srgb, var(--shop-cyan) 9%, transparent) 1px, transparent 1px),
+        linear-gradient(90deg, color-mix(in srgb, var(--shop-cyan) 9%, transparent) 1px, transparent 1px);
+    background-size: 26px 26px, 26px 26px;
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
+    pointer-events: auto; /* eat every click beneath — nothing under the slip is reachable */
+    overflow-y: auto;
+}
+
+/* ---- the work-order slip ---- */
+.dh-wo-slip {
+    position: relative;
+    width: 100%;
+    max-width: 31rem;
+    margin: auto;
+    background-color: var(--shop-paper);
+    color: var(--shop-ink);
+    border: 1px solid var(--shop-rule);
+    border-top: 5px solid var(--shop-cyan); /* a strip of shop tape */
+    border-radius: 2px;
+    box-shadow: 0 18px 40px -12px rgba(15, 23, 42, 0.55);
+    text-align: left;
+    overflow: hidden;
+}
+
+/* Stencil header: shop mark + job number. */
+.dh-wo-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.65rem 1.15rem;
+    border-bottom: 1px dashed var(--shop-rule);
+    font-family: var(--shop-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+.dh-wo-head-mark { font-weight: 700; }
+.dh-wo-head-mark .dot { color: var(--shop-cyan); }
+.dh-wo-head-job { color: var(--shop-faint); white-space: nowrap; }
+
+.dh-wo-body { padding: 1.15rem 1.25rem 1.3rem; }
+
+/* Job checklist — the parts-list visual language from the BOM. */
+.dh-wo-jobhead {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 0.55rem;
+    font-family: var(--shop-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--shop-faint);
+}
+.dh-wo-jobhead .stamp { color: var(--shop-hazard); font-weight: 700; }
+
+.dh-wo-list {
+    list-style: none;
+    margin: 0 0 1.1rem;
+    padding: 0;
+    font-family: var(--shop-mono);
+    font-size: 0.9rem;
+}
+.dh-wo-row { display: flex; align-items: center; gap: 0.55rem; padding: 0.14rem 0; }
+/* Scoped class (NOT Bootstrap's .mark text-highlight utility). */
+.dh-wo-row .dh-wo-mark { width: 1rem; text-align: center; flex: none; }
+.dh-wo-row.done .dh-wo-mark { color: var(--shop-green); }
+.dh-wo-row.done .noun { color: var(--shop-ink); }
+.dh-wo-row.pending { color: var(--shop-faint); }
+.dh-wo-row.pending .dh-wo-mark { color: var(--shop-faint); }
+.dh-wo-leader {
+    flex: 1 1 auto;
+    border-bottom: 1px dotted var(--shop-rule);
+    transform: translateY(-0.18em);
+}
+.dh-wo-tag {
+    flex: none;
+    font-size: 0.62rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--shop-faint);
+}
+/* The blocked step gets the cyan "current" tab from the loader. */
+.dh-wo-row.current {
+    margin: 0.3rem 0;
+    padding: 0.4rem 0.55rem;
+    background-color: color-mix(in srgb, var(--shop-cyan) 8%, transparent);
+    border-left: 3px solid var(--shop-cyan);
+    border-radius: 0 2px 2px 0;
+    font-weight: 700;
+}
+.dh-wo-row.current .dh-wo-mark { color: var(--shop-cyan); }
+.dh-wo-row.current .dh-wo-tag { color: var(--shop-cyan); }
+
+/* Hazard placard — the stamped hold reason (the only yellow left). */
+.dh-wo-placard {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    margin: 0 0 1.1rem;
+    padding: 0.7rem 0.9rem;
+    background-color: var(--shop-caution);
+    color: #2a1d00;
+    border: 2px solid var(--shop-ink);
+    border-radius: 2px;
+    /* caution-tape hatching down the leading edge */
+    box-shadow: inset 6px 0 0 0 var(--shop-ink), inset 12px 0 0 0 var(--shop-caution);
+}
+.dh-wo-placard i { font-size: 1.4rem; color: var(--shop-hazard); flex: none; }
+.dh-wo-placard-text {
+    font-family: var(--shop-mono);
+    font-size: 0.74rem;
+    line-height: 1.4;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    font-weight: 700;
+}
+
+/* Human-voice instruction — sans, contrasts the mono machine readout. */
+.dh-wo-instr { margin: 0 0 1.2rem; font-size: 1.02rem; line-height: 1.5; }
+
+/* Actions — centered button + email link. */
+.dh-wo-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    align-items: center;
+    text-align: center;
+}
+.dh-wo-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--shop-mono);
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    text-decoration: none;
+    padding: 0.6rem 1.1rem;
+    border-radius: 2px;
+    border: 2px solid var(--shop-ink);
+    background-color: var(--shop-cyan);
+    color: #fff;
+    cursor: pointer;
+    box-shadow: 2px 2px 0 0 var(--shop-ink);
+    transition: transform 0.05s ease, box-shadow 0.05s ease;
+}
+.dh-wo-btn:hover {
+    color: #fff;
+    transform: translate(1px, 1px);
+    box-shadow: 1px 1px 0 0 var(--shop-ink);
+}
+.dh-wo-link {
+    font-family: var(--shop-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--shop-ink);
+    text-decoration: none;
+    font-weight: 700;
+    border-bottom: 1px dotted var(--shop-faint);
+}
+.dh-wo-link i { margin-right: 0.4rem; color: var(--shop-cyan); }
+.dh-wo-link:hover { color: var(--shop-cyan); }
+
+.dh-wo-foot {
+    margin-top: 1.2rem;
+    padding-top: 0.85rem;
+    border-top: 1px dashed var(--shop-rule);
+    font-family: var(--shop-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+.dh-wo-foot a { color: var(--shop-faint); text-decoration: none; }
+.dh-wo-foot a:hover { color: var(--shop-ink); }
+.dh-wo-foot i { margin-right: 0.35rem; }
+
+/* Disable the button's press-shift under reduced motion (it's the only motion). */
+@media (prefers-reduced-motion: reduce) {
+    .dh-wo-btn { transition: none; }
+}

--- a/code/DHMemberPortal/templates/_activation_steps.html
+++ b/code/DHMemberPortal/templates/_activation_steps.html
@@ -1,0 +1,50 @@
+{# Shared activation-progress checklist for the dashboard activation alerts
+   (the two pending work-order overlays + the active "almost there" welcome
+   banner). One definition so the step labels can't drift between alerts.
+
+   `current` is the step the member is stuck on:
+     'payment'     -> Payment received  (pending, unpaid)
+     'agecheck'    -> Age check          (pending, paid, no ID check)
+     'activatekey' -> Activate key       (active, no key yet)
+   Earlier steps render done; later steps render queued. 'account' and
+   'complete' are never passed as `current` (entry / terminal states). #}
+{% macro activation_steps(current) %}
+{% set order = ['account', 'payment', 'agecheck', 'activatekey', 'complete'] %}
+{% set labels = {
+  'account': 'Account created',
+  'payment': 'Payment received',
+  'agecheck': 'Age check',
+  'activatekey': 'Activate key',
+  'complete': 'Onboarding complete'
+} %}
+{% set current_tag = {'payment': 'waiting', 'agecheck': 'inspect', 'activatekey': 'last step'} %}
+{% set current_icon = {'payment': 'fa-solid fa-wrench', 'agecheck': 'fa-solid fa-wrench', 'activatekey': 'fa-solid fa-key'} %}
+{% set ci = order.index(current) %}
+<ul class="dh-wo-list" aria-hidden="true">
+  {% for key in order %}
+  {% set i = loop.index0 %}
+  {% if i < ci %}
+  <li class="dh-wo-row done">
+    <span class="dh-wo-mark"><i class="fa-solid fa-check"></i></span>
+    <span class="noun">{{ labels[key] }}</span>
+    <span class="dh-wo-leader"></span>
+    <span class="dh-wo-tag">done</span>
+  </li>
+  {% elif i == ci %}
+  <li class="dh-wo-row current">
+    <span class="dh-wo-mark"><i class="{{ current_icon[key] }}"></i></span>
+    <span class="noun">{{ labels[key] }}</span>
+    <span class="dh-wo-leader"></span>
+    <span class="dh-wo-tag">{{ current_tag[key] }}</span>
+  </li>
+  {% else %}
+  <li class="dh-wo-row pending">
+    <span class="dh-wo-mark"><i class="fa-regular fa-circle"></i></span>
+    <span class="noun">{{ labels[key] }}</span>
+    <span class="dh-wo-leader"></span>
+    <span class="dh-wo-tag">queued</span>
+  </li>
+  {% endif %}
+  {% endfor %}
+</ul>
+{% endmacro %}

--- a/code/DHMemberPortal/templates/_activation_steps.html
+++ b/code/DHMemberPortal/templates/_activation_steps.html
@@ -1,6 +1,12 @@
-{# Shared activation-progress checklist for the dashboard activation alerts
-   (the two pending work-order overlays + the active "almost there" welcome
-   banner). One definition so the step labels can't drift between alerts.
+{# Shared work-order markup for the dashboard activation alerts (the two pending
+   work-order overlays + the active "almost there" welcome banner). One
+   definition each so the step labels, slip header, and job-head can't drift
+   between alerts.
+
+   Macros:
+     activation_steps(current) - the progress checklist (see below)
+     wo_head(member_id)        - the stencil slip header (shop mark + JOB no.)
+     wo_jobhead(stamp)         - the "Membership activation / <stamp>" sub-head
 
    `current` is the step the member is stuck on:
      'payment'     -> Payment received  (pending, unpaid)
@@ -47,4 +53,22 @@
   {% endif %}
   {% endfor %}
 </ul>
+{% endmacro %}
+
+{# Stencil slip header: shop mark + job number (member id). #}
+{% macro wo_head(member_id) %}
+<div class="dh-wo-head">
+  <span class="dh-wo-head-mark">PS<span class="dot">:</span>1 <span class="dot">&middot;</span> New Member</span>
+  <span class="dh-wo-head-job">JOB <span>#{{ member_id }}</span></span>
+</div>
+{% endmacro %}
+
+{# "Membership activation / <stamp>" sub-head. `stamp` is the right-side label
+   ("On hold", "Almost there"); its color is driven by the surrounding theme via
+   CSS (.dh-wo-jobhead .stamp / .dh-welcome .dh-wo-jobhead .stamp). #}
+{% macro wo_jobhead(stamp) %}
+<div class="dh-wo-jobhead">
+  <span>Membership activation</span>
+  <span class="stamp">{{ stamp }}</span>
+</div>
 {% endmacro %}

--- a/code/DHMemberPortal/templates/_dashboard_base.html
+++ b/code/DHMemberPortal/templates/_dashboard_base.html
@@ -72,7 +72,10 @@
             {% endif %}
             {% endwith %}
 
-            {% if status %}{% include '_dashboard_status_banner.html' %}{% endif %}
+            {# `gate` (the blocking activation overlay) is set only on /dashboard
+               home; when it's up, suppress the softer pending banner so they
+               don't stack. `gate` is undefined (falsy) on every other page. #}
+            {% if status and not gate %}{% include '_dashboard_status_banner.html' %}{% endif %}
 
             {% block dashboard_content %}{% endblock %}
         </main>

--- a/code/DHMemberPortal/templates/_dashboard_blocking_notice.html
+++ b/code/DHMemberPortal/templates/_dashboard_blocking_notice.html
@@ -1,0 +1,88 @@
+{# Non-dismissible activation work-order overlay, shown ONLY on /dashboard home
+   for pending members. `gate` is 'payment' or 'idcheck' (decided server-side in
+   member_dashboard via _dashboard_blocking_gate); `member_id` stamps the job no.
+
+   Intentionally NOT dismissible: no close button, no backdrop-click handler, no
+   Escape handler. Clearing the blocker (complete payment / get age-verified) or
+   logging out is the only way past it. The overlay is position:fixed and eats
+   all clicks beneath, so the member can't reach the tiles/menu underneath.
+   Styling: the "BLOCKING ACTIVATION NOTICE" block in portal.css (reuses the
+   shop work-order language from the signup loader). #}
+<div class="dh-wo-overlay" role="dialog" aria-modal="true"
+     aria-labelledby="dhWoStamp" aria-describedby="dhWoInstr">
+  <div class="dh-wo-slip">
+    <div class="dh-wo-head">
+      <span class="dh-wo-head-mark">PS<span class="dot">:</span>1 <span class="dot">&middot;</span> New Member</span>
+      <span class="dh-wo-head-job">JOB <span>#{{ member_id }}</span></span>
+    </div>
+    <div class="dh-wo-body">
+
+      <div class="dh-wo-jobhead">
+        <span>Membership activation</span>
+        <span class="stamp">On hold</span>
+      </div>
+
+      <ul class="dh-wo-list" aria-hidden="true">
+        <li class="dh-wo-row done">
+          <span class="dh-wo-mark"><i class="fa-solid fa-check"></i></span>
+          <span class="noun">Account created</span>
+          <span class="dh-wo-leader"></span>
+          <span class="dh-wo-tag">done</span>
+        </li>
+        {% if gate == 'payment' %}
+        <li class="dh-wo-row current">
+          <span class="dh-wo-mark"><i class="fa-solid fa-wrench"></i></span>
+          <span class="noun">Payment received</span>
+          <span class="dh-wo-leader"></span>
+          <span class="dh-wo-tag">waiting</span>
+        </li>
+        <li class="dh-wo-row pending">
+          <span class="dh-wo-mark"><i class="fa-regular fa-circle"></i></span>
+          <span class="noun">Age check</span>
+          <span class="dh-wo-leader"></span>
+          <span class="dh-wo-tag">queued</span>
+        </li>
+        {% else %}
+        <li class="dh-wo-row done">
+          <span class="dh-wo-mark"><i class="fa-solid fa-check"></i></span>
+          <span class="noun">Payment received</span>
+          <span class="dh-wo-leader"></span>
+          <span class="dh-wo-tag">done</span>
+        </li>
+        <li class="dh-wo-row current">
+          <span class="dh-wo-mark"><i class="fa-solid fa-wrench"></i></span>
+          <span class="noun">Age check</span>
+          <span class="dh-wo-leader"></span>
+          <span class="dh-wo-tag">inspect</span>
+        </li>
+        {% endif %}
+        <li class="dh-wo-row pending">
+          <span class="dh-wo-mark"><i class="fa-regular fa-circle"></i></span>
+          <span class="noun">Membership activated</span>
+          <span class="dh-wo-leader"></span>
+          <span class="dh-wo-tag">queued</span>
+        </li>
+      </ul>
+
+      <div class="dh-wo-placard">
+        <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+        <span class="dh-wo-placard-text" id="dhWoStamp">{{ 'Payment due' if gate == 'payment' else 'Pending age check' }}</span>
+      </div>
+
+      <p class="dh-wo-instr" id="dhWoInstr">
+        {% if gate == 'payment' %}Please complete your payment before continuing. If you have already paid, ask a volunteer for help.{% else %}Your account isn't active yet, please see a volunteer to have your age verified before continuing.{% endif %}
+      </p>
+
+      <div class="dh-wo-actions">
+        {% if gate == 'payment' %}
+        <a class="dh-wo-btn" href="{{ url_for('signup_payment') }}"><i class="fa-solid fa-credit-card"></i> Complete payment</a>
+        {% endif %}
+        <a class="dh-wo-link" href="mailto:info@pumpingstationone.org"><i class="fa-solid fa-envelope"></i>Email for help</a>
+      </div>
+
+      <div class="dh-wo-foot">
+        <a href="{{ url_for('logout') }}"><i class="fa-solid fa-arrow-right-from-bracket"></i> Log out</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/code/DHMemberPortal/templates/_dashboard_blocking_notice.html
+++ b/code/DHMemberPortal/templates/_dashboard_blocking_notice.html
@@ -8,20 +8,14 @@
    all clicks beneath, so the member can't reach the tiles/menu underneath.
    Styling: the "BLOCKING ACTIVATION NOTICE" block in portal.css (reuses the
    shop work-order language from the signup loader). #}
-{% from '_activation_steps.html' import activation_steps %}
+{% from '_activation_steps.html' import activation_steps, wo_head, wo_jobhead %}
 <div class="dh-wo-overlay" role="dialog" aria-modal="true"
      aria-labelledby="dhWoStamp" aria-describedby="dhWoInstr">
   <div class="dh-wo-slip">
-    <div class="dh-wo-head">
-      <span class="dh-wo-head-mark">PS<span class="dot">:</span>1 <span class="dot">&middot;</span> New Member</span>
-      <span class="dh-wo-head-job">JOB <span>#{{ member_id }}</span></span>
-    </div>
+    {{ wo_head(member_id) }}
     <div class="dh-wo-body">
 
-      <div class="dh-wo-jobhead">
-        <span>Membership activation</span>
-        <span class="stamp">On hold</span>
-      </div>
+      {{ wo_jobhead('On hold') }}
 
       {{ activation_steps('payment' if gate == 'payment' else 'agecheck') }}
 

--- a/code/DHMemberPortal/templates/_dashboard_blocking_notice.html
+++ b/code/DHMemberPortal/templates/_dashboard_blocking_notice.html
@@ -8,6 +8,7 @@
    all clicks beneath, so the member can't reach the tiles/menu underneath.
    Styling: the "BLOCKING ACTIVATION NOTICE" block in portal.css (reuses the
    shop work-order language from the signup loader). #}
+{% from '_activation_steps.html' import activation_steps %}
 <div class="dh-wo-overlay" role="dialog" aria-modal="true"
      aria-labelledby="dhWoStamp" aria-describedby="dhWoInstr">
   <div class="dh-wo-slip">
@@ -22,47 +23,7 @@
         <span class="stamp">On hold</span>
       </div>
 
-      <ul class="dh-wo-list" aria-hidden="true">
-        <li class="dh-wo-row done">
-          <span class="dh-wo-mark"><i class="fa-solid fa-check"></i></span>
-          <span class="noun">Account created</span>
-          <span class="dh-wo-leader"></span>
-          <span class="dh-wo-tag">done</span>
-        </li>
-        {% if gate == 'payment' %}
-        <li class="dh-wo-row current">
-          <span class="dh-wo-mark"><i class="fa-solid fa-wrench"></i></span>
-          <span class="noun">Payment received</span>
-          <span class="dh-wo-leader"></span>
-          <span class="dh-wo-tag">waiting</span>
-        </li>
-        <li class="dh-wo-row pending">
-          <span class="dh-wo-mark"><i class="fa-regular fa-circle"></i></span>
-          <span class="noun">Age check</span>
-          <span class="dh-wo-leader"></span>
-          <span class="dh-wo-tag">queued</span>
-        </li>
-        {% else %}
-        <li class="dh-wo-row done">
-          <span class="dh-wo-mark"><i class="fa-solid fa-check"></i></span>
-          <span class="noun">Payment received</span>
-          <span class="dh-wo-leader"></span>
-          <span class="dh-wo-tag">done</span>
-        </li>
-        <li class="dh-wo-row current">
-          <span class="dh-wo-mark"><i class="fa-solid fa-wrench"></i></span>
-          <span class="noun">Age check</span>
-          <span class="dh-wo-leader"></span>
-          <span class="dh-wo-tag">inspect</span>
-        </li>
-        {% endif %}
-        <li class="dh-wo-row pending">
-          <span class="dh-wo-mark"><i class="fa-regular fa-circle"></i></span>
-          <span class="noun">Membership activated</span>
-          <span class="dh-wo-leader"></span>
-          <span class="dh-wo-tag">queued</span>
-        </li>
-      </ul>
+      {{ activation_steps('payment' if gate == 'payment' else 'agecheck') }}
 
       <div class="dh-wo-placard">
         <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>

--- a/code/DHMemberPortal/templates/_dashboard_welcome_notice.html
+++ b/code/DHMemberPortal/templates/_dashboard_welcome_notice.html
@@ -5,19 +5,13 @@
    dismiss it). The banner re-renders every load until they get a key or age
    out of the window. Styled as a green "build complete" variant of the work-
    order slip. NOTE: no em-dashes in copy (project style). #}
-{% from '_activation_steps.html' import activation_steps %}
+{% from '_activation_steps.html' import activation_steps, wo_head, wo_jobhead %}
 <div class="dh-welcome" id="dhWelcome" role="region" aria-label="Welcome to your member portal">
   <div class="dh-wo-slip dh-wo-slip--ok">
-    <div class="dh-wo-head">
-      <span class="dh-wo-head-mark">PS<span class="dot">:</span>1 <span class="dot">&middot;</span> New Member</span>
-      <span class="dh-wo-head-job">JOB <span>#{{ member_id }}</span></span>
-    </div>
+    {{ wo_head(member_id) }}
     <div class="dh-wo-body">
 
-      <div class="dh-wo-jobhead">
-        <span>Membership activation</span>
-        <span class="stamp">Almost there</span>
-      </div>
+      {{ wo_jobhead('Almost there') }}
 
       <p class="dh-welcome-lede">
         Welcome to your PS:1 member portal! Bookmark this page now. It has the

--- a/code/DHMemberPortal/templates/_dashboard_welcome_notice.html
+++ b/code/DHMemberPortal/templates/_dashboard_welcome_notice.html
@@ -1,0 +1,55 @@
+{# Welcome banner, shown ONLY on /dashboard home for a brand-new active member
+   who hasn't had a key activated yet (see _dashboard_welcome_active_no_key).
+   Inline (NOT an overlay) so the member can scroll the dashboard underneath;
+   "Continue" smooth-scrolls the page just past this banner (it does NOT
+   dismiss it). The banner re-renders every load until they get a key or age
+   out of the window. Styled as a green "build complete" variant of the work-
+   order slip. NOTE: no em-dashes in copy (project style). #}
+{% from '_activation_steps.html' import activation_steps %}
+<div class="dh-welcome" id="dhWelcome" role="region" aria-label="Welcome to your member portal">
+  <div class="dh-wo-slip dh-wo-slip--ok">
+    <div class="dh-wo-head">
+      <span class="dh-wo-head-mark">PS<span class="dot">:</span>1 <span class="dot">&middot;</span> New Member</span>
+      <span class="dh-wo-head-job">JOB <span>#{{ member_id }}</span></span>
+    </div>
+    <div class="dh-wo-body">
+
+      <div class="dh-wo-jobhead">
+        <span>Membership activation</span>
+        <span class="stamp">Almost there</span>
+      </div>
+
+      <p class="dh-welcome-lede">
+        Welcome to your PS:1 member portal! Bookmark this page now. It has the
+        resources you&rsquo;ll need to get the most out of the space and
+        community. Scroll down for links on getting authorized on equipment,
+        learning how to be an excellent member, connecting with the community on
+        Discord, and other useful tools.
+      </p>
+
+      {{ activation_steps('activatekey') }}
+
+      <div class="dh-wo-placard dh-wo-placard--ok">
+        <i class="fa-solid fa-key" aria-hidden="true"></i>
+        <span class="dh-wo-placard-text">You&rsquo;re not done onboarding just yet. Your last step is to talk with a volunteer to activate a key.</span>
+      </div>
+
+      <div class="dh-wo-actions">
+        <button type="button" class="dh-wo-btn dh-wo-btn--ok" id="dhWelcomeContinue">Continue</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  (function () {
+    var btn = document.getElementById('dhWelcomeContinue');
+    var banner = document.getElementById('dhWelcome');
+    if (!btn || !banner) return;
+    // Continue scrolls the page just past the banner (does NOT dismiss it).
+    btn.addEventListener('click', function () {
+      var top = banner.getBoundingClientRect().bottom + window.scrollY;
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      window.scrollTo({ top: top, behavior: reduce ? 'auto' : 'smooth' });
+    });
+  })();
+</script>

--- a/code/DHMemberPortal/templates/_signup_gather.html
+++ b/code/DHMemberPortal/templates/_signup_gather.html
@@ -22,7 +22,7 @@
     <p id="signup-gather-sr" class="visually-hidden" role="status" aria-live="polite"></p>
     <div class="dh-gather-slip" aria-hidden="true">
         <div class="dh-gather-head">
-            <span class="dh-gather-head-mark">PS<span class="dh-gather-dot">:</span>ONE shop <span class="dh-gather-dot">&middot;</span> work order</span>
+            <span class="dh-gather-head-mark">PS<span class="dh-gather-dot">:</span>1 <span class="dh-gather-dot">&middot;</span> New Member</span>
             <span class="dh-gather-head-job">JOB <span id="signup-gather-job">#0000</span></span>
         </div>
         <div class="dh-gather-body">

--- a/code/DHMemberPortal/templates/dashboard_notice_preview.html
+++ b/code/DHMemberPortal/templates/dashboard_notice_preview.html
@@ -1,6 +1,6 @@
-{# Dev-only standalone preview of the /dashboard activation blocking notice.
-   Renders the real partial (_dashboard_blocking_notice.html) over a stub page,
-   toggled via ?case=payment|idcheck. No auth, no DB — visual review only. #}
+{# Dev-only standalone preview of the /dashboard activation notices. Renders the
+   real partials (_dashboard_blocking_notice.html / _dashboard_welcome_notice.html)
+   over a stub page, toggled via ?case=payment|idcheck|welcome. No auth, no DB. #}
 {% extends "base.html" %}
 {% block title %}Activation Notice Preview - Pumping Station: One{% endblock %}
 {% block page_title %}Activation Notice Preview{% endblock %}

--- a/code/DHMemberPortal/templates/dashboard_notice_preview.html
+++ b/code/DHMemberPortal/templates/dashboard_notice_preview.html
@@ -9,15 +9,22 @@
                 <div class="card">
                     <div class="card-body">
                         <p class="mb-0">
-                            Dev-only preview of the dashboard activation notice. Switch case:
+                            Dev-only preview of the dashboard activation notices. Switch case:
                             <a href="?case=payment">payment</a> &middot;
-                            <a href="?case=idcheck">idcheck</a>
+                            <a href="?case=idcheck">idcheck</a> &middot;
+                            <a href="?case=welcome">welcome</a>
                             &mdash; currently showing <strong>{{ case }}</strong>.
                         </p>
                     </div>
                 </div>
             </div>
-            {% with gate = case, member_id = '1024' %}
-                {% include '_dashboard_blocking_notice.html' %}
-            {% endwith %}
+            {% if case == 'welcome' %}
+                {% with welcome = true, member_id = '1024' %}
+                    {% include '_dashboard_welcome_notice.html' %}
+                {% endwith %}
+            {% else %}
+                {% with gate = case, member_id = '1024' %}
+                    {% include '_dashboard_blocking_notice.html' %}
+                {% endwith %}
+            {% endif %}
 {% endblock %}

--- a/code/DHMemberPortal/templates/dashboard_notice_preview.html
+++ b/code/DHMemberPortal/templates/dashboard_notice_preview.html
@@ -1,0 +1,23 @@
+{# Dev-only standalone preview of the /dashboard activation blocking notice.
+   Renders the real partial (_dashboard_blocking_notice.html) over a stub page,
+   toggled via ?case=payment|idcheck. No auth, no DB — visual review only. #}
+{% extends "base.html" %}
+{% block title %}Activation Notice Preview - Pumping Station: One{% endblock %}
+{% block page_title %}Activation Notice Preview{% endblock %}
+{% block content %}
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <p class="mb-0">
+                            Dev-only preview of the dashboard activation notice. Switch case:
+                            <a href="?case=payment">payment</a> &middot;
+                            <a href="?case=idcheck">idcheck</a>
+                            &mdash; currently showing <strong>{{ case }}</strong>.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            {% with gate = case, member_id = '1024' %}
+                {% include '_dashboard_blocking_notice.html' %}
+            {% endwith %}
+{% endblock %}

--- a/code/DHMemberPortal/templates/member_dashboard.html
+++ b/code/DHMemberPortal/templates/member_dashboard.html
@@ -3,6 +3,8 @@
 {% block page_title %}<i class="fa-solid fa-house ic-dashboard"></i> Member Dashboard{% endblock %}
 {% block dashboard_content %}
 
+            {% if gate %}{% include '_dashboard_blocking_notice.html' %}{% endif %}
+
             <!-- Membership -->
             <div class="menu-section">
                 <h2>Your Membership</h2>

--- a/code/DHMemberPortal/templates/member_dashboard.html
+++ b/code/DHMemberPortal/templates/member_dashboard.html
@@ -4,6 +4,7 @@
 {% block dashboard_content %}
 
             {% if gate %}{% include '_dashboard_blocking_notice.html' %}{% endif %}
+            {% if welcome %}{% include '_dashboard_welcome_notice.html' %}{% endif %}
 
             <!-- Membership -->
             <div class="menu-section">


### PR DESCRIPTION
## What

Adds activation-state notices to the member-portal `/dashboard` home, styled in the shop work-order language of the signup loader.

### Pending members (non-dismissible blocking overlay)
A full-viewport, blurred-backdrop overlay shown only on `/dashboard` home that eats all clicks beneath (sidebar/tiles unreachable); a Log out link stays reachable. Two mutually-exclusive cases:
- **payment** — pending with no Stripe payment on file. "Complete payment" button (routes to the signup payment page with the email set in session only, never the URL, per #294) + "Email for help".
- **idcheck** — pending, paid, but no in-person age/ID check yet (neither legacy `id_check_1` nor `id_check_date`). "Email for help" only.

The softer pending status banner is suppressed on home while the overlay is up so they don't stack. The gate fails safe to no-overlay on any status-fetch error, so an API blip can't trap a member behind a modal that can't be dismissed. Active/suspended/inactive see nothing; banned still hit the existing lockout.

### New active members (dismiss-free welcome banner)
Inline green "build complete" banner for an active member who joined within 30 days and has no key yet (no `rfid_tags`). Welcome copy + the activation checklist with "Activate key" as the highlighted last step. The "Continue" button smooth-scrolls the page past the banner to the resources below (it does not dismiss; re-renders each load until they get a key or age out). Self-expiring, and computed only when the pending gate is absent, so the two never co-occur.

Note: the window is measured from `member_since` (join date), not from activation, because no activation timestamp is stored today. A member who stays pending longer than the window before being activated will not see the banner; the real self-expiry is getting a key. A precise fix would key off a stored activated-at date (follow-up).

### Shared checklist
The activation checklist is a shared Jinja macro so labels stay in sync across all three alerts. Five steps: Account created / Payment received / Age check / Activate key / Onboarding complete. The slip header and "Membership activation" sub-head are likewise shared macros so they can't drift between the overlay and the welcome banner.

### Also
- The signup loading interstitial header changes from "PS:ONE shop . work order" to "PS:1 . New Member" (matches the new notices).
- Dev-only `/dashboard/notice-preview?case=payment|idcheck|welcome` route for visual review (hidden outside dev).

## Scope / deploy
Member portal only. No schema change, no DHService change. Reuses existing `get_full_member_info` / `get_member_status`. Deploy = DHMemberPortal redeploy.

## Code review follow-up
Addressed three findings from review (latest commit):
- **Welcome window widened 14 -> 30 days** so members who take longer to be activated still see the banner; documented that it is keyed to join date (no activation timestamp exists) and that the real self-expiry is getting a key.
- **Deduplicated the slip header / sub-head** into shared `wo_head()` / `wo_jobhead()` macros alongside the existing checklist macro. Confirmed render output is byte-identical aside from inter-tag whitespace (no DOM/visual change).
- **Fixed the preview route docstring/comment** to list the `welcome` case.

## Testing
Verified on dev across all states. Layered pass: render-equality check proving the macro extraction is behavior-preserving; logic tests (24/24) of the gate decision matrix and the welcome window boundaries (29d shown, 30d/31d hidden, fail-safe on bad/missing data, status-fetch error -> no overlay); HTTP tests of the preview route for every case (including bad input falling back to payment); and full login -> `/dashboard` end-to-end from real seed members: both pending cases fire (payment / idcheck), the welcome banner fires for an active+recent+keyless member with a working Continue button, active members with a key see nothing, the pending banner still shows on sub-pages, and a banned member still redirects to the lockout page.

Screenshots to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
