### PR TITLE
Set Secure flag on session cookies (env-gated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ python -c "import secrets; print(secrets.token_hex(32))"
 ```
 In the dev environment this is handled automatically — you don't need to do anything.
 
+In production the portals set the session cookie with the `Secure` flag automatically (it is enabled whenever `AUTH_MODE` is not `dev`, which is the case in any non-dev deployment). This means the portals **must be served over HTTPS**: terminate TLS at a reverse proxy in front of them. If a portal is reached over plain HTTP in a non-dev configuration, browsers drop the session cookie and login will not complete.
+
 Also note that Pumping Station One uses [Azure B2C](https://learn.microsoft.com/en-us/azure/active-directory-b2c/overview) for identity management; if you are not using Azure B2C, you will need to modify the authentication and authorization code in both the DHAdminPortal and DHMemberPortal components to reflect your identity management system.
 
 > **Looking to set up a dev environment?** See [DEV_SETUP.md](DEV_SETUP.md) — it handles config files, seed data, and auth bypass automatically. The guide below is for production deployments.

--- a/code/DHAdminPortal/app_config.py
+++ b/code/DHAdminPortal/app_config.py
@@ -80,3 +80,6 @@ else:
 
 SESSION_COOKIE_SAMESITE = "Lax"
 SESSION_COOKIE_HTTPONLY = True
+# Secure flag: on everywhere except dev (which serves plaintext http://localhost).
+# AUTH_MODE is "dev" only in the docker-compose.dev.yml overlay; unset in prod.
+SESSION_COOKIE_SECURE = AUTH_MODE != "dev"

--- a/code/DHMemberPortal/app_config.py
+++ b/code/DHMemberPortal/app_config.py
@@ -80,3 +80,6 @@ else:
 
 SESSION_COOKIE_SAMESITE = "Lax"
 SESSION_COOKIE_HTTPONLY = True
+# Secure flag: on everywhere except dev (which serves plaintext http://localhost).
+# AUTH_MODE is "dev" only in the docker-compose.dev.yml overlay; unset in prod.
+SESSION_COOKIE_SECURE = AUTH_MODE != "dev"


### PR DESCRIPTION
## What

Both portals set `HttpOnly` and `SameSite=Lax` on the Flask `session` cookie but never set `SESSION_COOKIE_SECURE`, so the cookie shipped without the `Secure` flag. This adds it, gated by environment.

## How

```python
# code/DHMemberPortal/app_config.py and code/DHAdminPortal/app_config.py (kept identical)
SESSION_COOKIE_SECURE = AUTH_MODE != "dev"
```

- **Prod** (`AUTH_MODE` unset, anything that isn't `dev`): `Secure` is **on** automatically. No env var to set at deploy time.
- **Dev** (`AUTH_MODE=dev`): `Secure` is **off**, so login keeps working over plaintext `http://localhost`.

The gate keys off `AUTH_MODE` rather than `request.is_secure` on purpose: the internal nginx sees plain HTTP behind the TLS-terminating reverse proxy, so `request.is_secure` would be `False` even in production and Flask's auto-detection would silently fail to set the flag.

## Deployment note

This makes HTTPS a hard requirement in production: because the `Secure` flag is on whenever `AUTH_MODE` is not `dev`, a portal reached over plain HTTP in a non-dev config will have its session cookie dropped by the browser and login will not complete. Production already terminates TLS at the reverse proxy, so no action is needed there. README updated to document this.

No schema change. No new env var.

## Verification

Rebuilt both portal images on dev and confirmed:

| Check | Member | Admin |
|---|---|---|
| `SESSION_COOKIE_SECURE` with `AUTH_MODE=dev` | `False` | `False` |
| `HttpOnly` / `SameSite` | `True` / `Lax` | `True` / `Lax` |
| Dev login end-to-end over plaintext HTTP | lands dashboard, 200 | lands index, 200 |
| `Set-Cookie` on `session` | `HttpOnly; SameSite=Lax`, no `Secure` | same |

Prod branch logic verified: `AUTH_MODE != "dev"` is `True` for any non-dev value (`""`, `production`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)