### PR TITLE
Add Flask TRUSTED_HOSTS host-header validation (HOSTFIX-001)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,50 @@
+# Deep Harbor: root environment file (example)
+#
+# Copy to ".env" (gitignored) and fill in:
+#     cp .env.example .env
+#
+# Docker Compose auto-loads ".env" from this directory and substitutes the
+# ${VAR} references in docker-compose.yaml at "docker compose up" time.
+#
+# This file is the intended central home for Deep Harbor configuration: the goal
+# is to migrate the per-service config.ini settings here over time. Today the dev
+# overlay (docker-compose.dev.yml) still injects dev values for some of these, so
+# a default "./dh_dev.sh start" can run without a .env; production always needs
+# the values below set. As config.ini keys move here, set them in .env regardless
+# of environment.
+
+
+###############################################################################
+# DH_SECRET_KEY  - Flask SECRET_KEY (CSRF tokens + signed session cookies)
+###############################################################################
+# How it interacts with AUTH_MODE:
+#   - Dev (AUTH_MODE=dev, set by docker-compose.dev.yml): the dev overlay already
+#     injects a throwaway DH_SECRET_KEY, and app_config.py also falls back to a
+#     built-in dev default. You do NOT need to set this for dev.
+#   - Prod (AUTH_MODE unset / not "dev"): REQUIRED. app_config.py hard-fails at
+#     startup if neither DH_SECRET_KEY nor [flask] secret_key in config.ini is set.
+# Generate one with:  python -c "import secrets; print(secrets.token_hex(32))"
+DH_SECRET_KEY=
+
+###############################################################################
+# DH_TRUSTED_HOSTS  - Host-header allowlist for the portals (HOSTFIX-001)
+###############################################################################
+# Comma-separated list of the PUBLIC hostnames the portals are served on (what a
+# browser puts in the Host header via the reverse proxy). Flask rejects any other
+# Host with 400, so a spoofed Host cannot poison the OAuth redirect_uri / logout
+# redirect. Notes:
+#   - Only applies in prod (AUTH_MODE != dev). Dev disables host filtering.
+#   - "localhost" / "127.0.0.1" are added automatically (for the /health check).
+#   - Multiple hosts are fine; a leading dot matches any subdomain (.example.org).
+#   - Leave BLANK to disable host filtering (no breakage, but the finding stays open).
+#   - Each portal only ever receives its own hostname; listing both is harmless.
+# Example:
+#   DH_TRUSTED_HOSTS=crm.example.org,members.example.org
+DH_TRUSTED_HOSTS=
+
+###############################################################################
+# GIT_VERSION  - build/version stamp (optional)
+###############################################################################
+# Normally exported automatically by ./start_dh.sh and ./dh_dev.sh. Only set it
+# here if you run "docker compose" directly without those wrappers.
+# GIT_VERSION=unknown

--- a/code/DHAdminPortal/app_config.py
+++ b/code/DHAdminPortal/app_config.py
@@ -83,3 +83,32 @@ SESSION_COOKIE_HTTPONLY = True
 # Secure flag: on everywhere except dev (which serves plaintext http://localhost).
 # AUTH_MODE is "dev" only in the docker-compose.dev.yml overlay; unset in prod.
 SESSION_COOKIE_SECURE = AUTH_MODE != "dev"
+
+###############################################################################
+# Trusted Hosts (HOSTFIX-001: Host-header / open-redirect hardening)
+###############################################################################
+# Flask validates the inbound Host (and the X-Forwarded-Host that waitress /
+# ProxyFix promote) against this allowlist and returns 400 on a mismatch, so a
+# spoofed Host cannot poison url_for(_external=True) (the OAuth redirect_uri and
+# post_logout_redirect_uri). Werkzeug strips the port before matching, so bare
+# hostnames cover any port.
+#
+# Dev disables filtering entirely (None) so the multi-host dev setup (localhost
+# plus the reverse-proxied edge) never dead-ends, mirroring SESSION_COOKIE_SECURE
+# being off in dev. In prod the hosts come from DH_TRUSTED_HOSTS (root .env,
+# comma-separated, multiple allowed); "localhost"/127.0.0.1 are unioned in
+# automatically for the Docker /health curl. An unset DH_TRUSTED_HOSTS leaves
+# validation off (current behavior) so a missing config never dead-ends the portal.
+if AUTH_MODE == "dev":
+    TRUSTED_HOSTS = None
+else:
+    _trusted_hosts_raw = os.environ.get("DH_TRUSTED_HOSTS", "")
+    _trusted_hosts = [h.strip() for h in _trusted_hosts_raw.split(",") if h.strip()]
+    TRUSTED_HOSTS = (["localhost", "127.0.0.1"] + _trusted_hosts) if _trusted_hosts else None
+    if TRUSTED_HOSTS is None:
+        from dhs_logging import logger
+        logger.warning(
+            "DH_TRUSTED_HOSTS is not set: Host-header validation is DISABLED "
+            "(HOSTFIX-001). Set DH_TRUSTED_HOSTS to the portal's public "
+            "hostname(s) in production."
+        )

--- a/code/DHMemberPortal/app_config.py
+++ b/code/DHMemberPortal/app_config.py
@@ -83,3 +83,32 @@ SESSION_COOKIE_HTTPONLY = True
 # Secure flag: on everywhere except dev (which serves plaintext http://localhost).
 # AUTH_MODE is "dev" only in the docker-compose.dev.yml overlay; unset in prod.
 SESSION_COOKIE_SECURE = AUTH_MODE != "dev"
+
+###############################################################################
+# Trusted Hosts (HOSTFIX-001: Host-header / open-redirect hardening)
+###############################################################################
+# Flask validates the inbound Host (and the X-Forwarded-Host that waitress /
+# ProxyFix promote) against this allowlist and returns 400 on a mismatch, so a
+# spoofed Host cannot poison url_for(_external=True) (the OAuth redirect_uri and
+# post_logout_redirect_uri). Werkzeug strips the port before matching, so bare
+# hostnames cover any port.
+#
+# Dev disables filtering entirely (None) so the multi-host dev setup (localhost
+# plus the reverse-proxied edge) never dead-ends, mirroring SESSION_COOKIE_SECURE
+# being off in dev. In prod the hosts come from DH_TRUSTED_HOSTS (root .env,
+# comma-separated, multiple allowed); "localhost"/127.0.0.1 are unioned in
+# automatically for the Docker /health curl. An unset DH_TRUSTED_HOSTS leaves
+# validation off (current behavior) so a missing config never dead-ends the portal.
+if AUTH_MODE == "dev":
+    TRUSTED_HOSTS = None
+else:
+    _trusted_hosts_raw = os.environ.get("DH_TRUSTED_HOSTS", "")
+    _trusted_hosts = [h.strip() for h in _trusted_hosts_raw.split(",") if h.strip()]
+    TRUSTED_HOSTS = (["localhost", "127.0.0.1"] + _trusted_hosts) if _trusted_hosts else None
+    if TRUSTED_HOSTS is None:
+        from dhs_logging import logger
+        logger.warning(
+            "DH_TRUSTED_HOSTS is not set: Host-header validation is DISABLED "
+            "(HOSTFIX-001). Set DH_TRUSTED_HOSTS to the portal's public "
+            "hostname(s) in production."
+        )

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,7 +74,8 @@ services:
       retries: 3
     environment:
       TZ: "America/Chicago"
-      DH_SECRET_KEY: "${DH_SECRET_KEY}"
+      DH_SECRET_KEY: "${DH_SECRET_KEY:-}"
+      DH_TRUSTED_HOSTS: "${DH_TRUSTED_HOSTS:-}"
     ports:
       - "5002:5002"
     depends_on:
@@ -103,7 +104,8 @@ services:
     container_name: dh_admin_portal
     environment:
       TZ: "America/Chicago"
-      DH_SECRET_KEY: "${DH_SECRET_KEY}"
+      DH_SECRET_KEY: "${DH_SECRET_KEY:-}"
+      DH_TRUSTED_HOSTS: "${DH_TRUSTED_HOSTS:-}"
     
 
   #########################################################


### PR DESCRIPTION
## What

Fixes **HOSTFIX-001** (CWE-601, open redirect). Both portals call `url_for(_external=True)` to build the OAuth `redirect_uri` and the `post_logout_redirect_uri`, which derive from the request `Host` header. The portals sit behind Nginx Proxy Manager on host-networked ports, and waitress is started with `--trusted-proxy=* --trusted-proxy-headers=...x-forwarded-host...`, so a spoofed `Host` / `X-Forwarded-Host` reaching the portal directly could poison those generated URLs.

## How

Adds Flask 3.1 `TRUSTED_HOSTS` validation (Werkzeug rejects an off-allowlist Host with 400 before any view runs), env-gated the same way as the SESSION-002 `SESSION_COOKIE_SECURE` fix:

- **Dev** (`AUTH_MODE=dev`): filtering disabled (`None`) so the multi-host dev setup never dead-ends.
- **Prod**: reads comma-separated `DH_TRUSTED_HOSTS`, unions `localhost`/`127.0.0.1` for the Docker `/health` curl, and logs a startup warning when unset (validation stays off, preserving current behavior, so a missing config never dead-ends the portal).

Also:
- Wires `DH_TRUSTED_HOSTS` into both portal `environment:` blocks in `docker-compose.yaml` (and aligns `DH_SECRET_KEY` to the same `${VAR:-}` form).
- Adds a root `.env.example` documenting `DH_SECRET_KEY` and `DH_TRUSTED_HOSTS`.
- The two `app_config.py` blocks are kept byte-identical.

## Notes

- Multiple domains are supported (comma-separated; leading-dot matches subdomains). No Azure B2C change is needed for existing domains.
- **No schema change.** Production activation is a config step: set `DH_TRUSTED_HOSTS` in the root `.env`. Tracked in #334.

## Verification

- Enforcement confirmed against the installed Flask 3.1.2 / Werkzeug 3.1.6: allowed host (with/without port) returns 200, spoofed `Host`/`X-Forwarded-Host` returns 400, `None` disables filtering.
- Rebuilt both portals on dev: containers healthy, dev login unaffected (filtering off in dev by design), no startup errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)