### PR TITLE
Remove dead _get_member_id_and_json helper in DHService

### DIFF
--- a/code/DHService/v1.py
+++ b/code/DHService/v1.py
@@ -34,12 +34,6 @@ def _create_member_getter(field_name: str, db_func, wrap_key: str = None):
         return {wrap_key: result} if wrap_key else result
     return getter
 
-async def _get_member_id_and_json(request: Request) -> tuple[str, dict]:
-    """Extract member ID from header and parse JSON body."""
-    member_id = request.headers.get("X-Member-ID")
-    data = await request.json()
-    return member_id, data
-
 ###############################################################################
 # Member GET endpoints
 ###############################################################################


### PR DESCRIPTION
## What

Removes the unused `_get_member_id_and_json(request)` helper from `code/DHService/v1.py`. It read `X-Member-ID` as a raw, untyped string and parsed the JSON body, but had **zero callers**.

## Why

All member-mutating POST handlers already take `x_member_id` via `Annotated[int, Header()]` directly in their signatures, so the helper was legacy code representing an untyped path that bypassed the typed convention. Member-id handling in DHService is otherwise a deliberate, FastAPI-validated convention since PR #244:

- **GET** endpoints take `member_id: int` as a query param
- member-mutating **POST** endpoints take `x_member_id` as a typed header

Both return **422** on bad input. This removes the last untyped straggler.

## Verification

- `grep -rn "_get_member_id_and_json" code/DHService/` → only the definition matched (zero callers).
- `python3 -m py_compile code/DHService/v1.py` passes.
- `Request` is still imported/used by the POST handlers (17 references remain), so the import is not orphaned.

Backend-only, no schema change → prod rollout is a DHService redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)