### PR TITLE
Add view-permission decorators to two admin reference endpoints

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -1164,22 +1164,24 @@ def api_member_access():
         return {"error": str(e)}, 500
 
 @app.route("/api/authorizations/available")
+@requires_view_permission("member.authorizations")
 def api_available_authorizations():
     if not session.get("user"):
         return {"error": "Not authenticated"}, 401
-    
+
     try:
         access_token = dhservices.get_access_token(
-            dhservices.DH_CLIENT_ID, 
+            dhservices.DH_CLIENT_ID,
             dhservices.DH_CLIENT_SECRET
         )
         available_auths = dhservices.get_available_authorizations(access_token)
         return available_auths
     except Exception as e:
-        print(f"Error getting available authorizations: {e}")
+        logger.error(f"Error getting available authorizations: {e}")
         return {"error": str(e)}, 500
 
 @app.route("/api/membership_levels/available")
+@requires_view_permission("member.status")
 def api_available_membership_levels():
     if not session.get("user"):
         return {"error": "Not authenticated"}, 401
@@ -1192,7 +1194,7 @@ def api_available_membership_levels():
         levels = dhservices.get_available_membership_levels(access_token)
         return levels
     except Exception as e:
-        print(f"Error getting available membership levels: {e}")
+        logger.error(f"Error getting available membership levels: {e}")
         return {"error": str(e)}, 500
 
 # POST endpoints for updating member data


### PR DESCRIPTION
## Summary

Two admin-portal GET endpoints guarded only with a manual `session.get("user")` authentication check and were missing the `@requires_view_permission(...)` authorization decorator that every sibling `/api/member/*` route carries:

- `GET /api/authorizations/available`
- `GET /api/membership_levels/available`

As a result, any authenticated admin-portal user could read both reference lists regardless of their assigned role.

## Changes

- Gate the authorizations list on `member.authorizations` (consumed by the Auths tab) and the membership-levels list on `member.status` (consumed by the Status tab). Permissions were verified against the consuming UI so no legitimate tab user is locked out.
- Swap both `print()` error calls to `logger.error()` per the project logging convention.

CWE-862 (Missing Authorization), OWASP A01:2021. Low severity (reference data only, no PII or mutation); closes a consistency gap with the existing permission boundary.

## Validation (on dev)

Logged in as four roles and hit both endpoints:

| Role | `/authorizations/available` | `/membership_levels/available` |
|---|---|---|
| Administrator | 200 (data) | 200 (data) |
| Authorizer | 200 | 403 |
| ID Check | 403 | 200 |
| Treasurer | 403 | 200 |

Each 403 emitted the expected "Permission denied" warning log. Confirms both the deny path and no regression for legitimate tab users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)