### PR TITLE
Add no-store cache headers to authenticated portal responses

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -519,6 +519,17 @@ def inject_theme():
     return {"admin_theme": theme}
 
 
+@app.after_request
+def set_cache_headers(response):
+    # CACHE-001: prevent caching of authenticated pages / API responses so member
+    # data can't be re-served from cache after logout. Static assets stay cacheable.
+    if session.get("user") and request.endpoint != "static":
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        response.headers["Pragma"] = "no-cache"
+        response.headers["Expires"] = "0"
+    return response
+
+
 ###############################################################################
 # Permission checking decorator for admin API endpoints
 ###############################################################################

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -662,6 +662,17 @@ def _gate_banned_members():
     return None
 
 
+@app.after_request
+def set_cache_headers(response):
+    # CACHE-001: prevent caching of authenticated pages / API responses so member
+    # data can't be re-served from cache after logout. Static assets stay cacheable.
+    if session.get("user") and request.endpoint != "static":
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        response.headers["Pragma"] = "no-cache"
+        response.headers["Expires"] = "0"
+    return response
+
+
 @app.route('/dashboard/locked')
 def member_locked():
     """Terminal-status landing page for banned members. Non-banned users


### PR DESCRIPTION
## What

Adds a Flask `@app.after_request` handler to **both** portals that stamps no-store cache headers on responses for logged-in users:

```
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Expires: 0
```

## Why

Authenticated dashboard pages and admin API JSON responses (raw member data: names, email, RFID tags, authorizations, etc.) previously set no `Cache-Control` headers. Browsers and intermediate caches could store that content and re-serve it after logout (for example via the back button on a shared machine). This is defense-in-depth against caching of sensitive data.

CWE-525 (Use of Web Browser Cache Containing Sensitive Information), OWASP A05:2021.

## Details

- Gated on `session.get("user")`, so anonymous responses (login, health, signup) are untouched and stay cacheable.
- Flask's `static` endpoint is excluded so CSS/JS/fonts remain cacheable for logged-in users.
- The two handlers are byte-identical, matching the existing discipline for the portals' shared `app_config.py` blocks.
- Written so future header-setting hardening can be added alongside.

## Validation (on dev)

Rebuilt both portals, bounced the gateway, dev-logged in, and checked response headers with curl + the session cookie:

- Member `/dashboard` and admin `/`, `/api/members` (200 JSON), `/api/search`: all three headers present.
- `/static/...` on both portals: only Flask's default `Cache-Control: no-cache` (no `no-store`/`Pragma`/`Expires`) so assets stay cacheable.
- Anonymous `/`: handler is a no-op (no cache headers), behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)