### PR TITLE
Add clickjacking and content-type security headers to both portals

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -521,6 +521,12 @@ def inject_theme():
 
 @app.after_request
 def set_cache_headers(response):
+    # CSP-001 / INFRA-004: clickjacking + MIME-sniffing protection on EVERY response
+    # (incl. unauthenticated login/signup). frame-ancestors in the <meta> CSP is ignored
+    # by browsers; X-Frame-Options is the header that actually blocks framing.
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     # CACHE-001: prevent caching of authenticated pages / API responses so member
     # data can't be re-served from cache after logout. Static assets stay cacheable.
     if session.get("user") and request.endpoint != "static":

--- a/code/DHAdminPortal/templates/base.html
+++ b/code/DHAdminPortal/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdnjs.cloudflare.com; font-src 'self' cdnjs.cloudflare.com; img-src 'self' data: blob: https://www.gravatar.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' *.b2clogin.com;">
+          content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdnjs.cloudflare.com; font-src 'self' cdnjs.cloudflare.com; img-src 'self' data: blob: https://www.gravatar.com; connect-src 'self'; base-uri 'self'; form-action 'self' *.b2clogin.com;">
     <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='images/favicon-ps1-admin.svg') }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='images/favicon-32x32.png') }}">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', filename='images/favicon-16x16.png') }}">

--- a/code/DHMemberPortal/app.py
+++ b/code/DHMemberPortal/app.py
@@ -664,6 +664,12 @@ def _gate_banned_members():
 
 @app.after_request
 def set_cache_headers(response):
+    # CSP-001 / INFRA-004: clickjacking + MIME-sniffing protection on EVERY response
+    # (incl. unauthenticated login/signup). frame-ancestors in the <meta> CSP is ignored
+    # by browsers; X-Frame-Options is the header that actually blocks framing.
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     # CACHE-001: prevent caching of authenticated pages / API responses so member
     # data can't be re-served from cache after logout. Static assets stay cacheable.
     if session.get("user") and request.endpoint != "static":

--- a/code/DHMemberPortal/templates/base.html
+++ b/code/DHMemberPortal/templates/base.html
@@ -12,7 +12,7 @@
     <meta name="theme-color" content="#009fc2">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net js.stripe.com; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdnjs.cloudflare.com; font-src cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self' api.stripe.com; frame-src js.stripe.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' billing.stripe.com *.b2clogin.com;">
+          content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net js.stripe.com; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdnjs.cloudflare.com; font-src cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self' api.stripe.com; frame-src js.stripe.com; base-uri 'self'; form-action 'self' billing.stripe.com *.b2clogin.com;">
     <title>{% block title %}Pumping Station: One{% endblock %}</title>
     <!-- Bootstrap 5.3 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"


### PR DESCRIPTION
## What

Adds real HTTP security headers to both the member and admin portals:

- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`

They are emitted from the existing `set_cache_headers` `@app.after_request` handler in both portals, set unconditionally (above the authenticated-session gate) so unauthenticated login/signup pages get the same protection.

Also removes the now-dead `frame-ancestors 'none'` directive from both `<meta>` CSP tags. Browsers ignore `frame-ancestors` when delivered via a `<meta>` element (it only works as a real header), so it provided no clickjacking protection and emitted a console warning on every page load. The new `X-Frame-Options` header replaces it. All other CSP directives, including the Stripe allowances, are left intact.

## Why

The portals previously relied on `frame-ancestors 'none'` in a meta tag for clickjacking protection, which browsers ignore, and had no MIME-sniffing protection. These headers must be set at Flask: the portals are not behind the repo gateway, so an nginx `add_header` would never reach browser-facing traffic.

Addresses CWE-1021 (clickjacking) and CWE-693 (protection mechanism failure / missing security headers).

## Testing

Validated on dev (Flask emits these regardless of TLS/auth mode, so dev parity with prod is exact):

- `curl -I` on both portals confirms all three headers, including on the unauthenticated login redirect.
- Browser smoke test: no new console errors, the `frame-ancestors`-ignored warning is gone, and the Stripe pricing table still renders on the signup payment page (`X-Frame-Options` governs the page being framed, not iframes the page embeds, so the Stripe embed is unaffected).
- Both `after_request` handler blocks kept byte-identical; existing cache-header logic unchanged.

## Deployment

No schema or DB change. Rollout is a redeploy of both portal containers. Operator follow-up (not blocking): decide whether the TLS edge should also assert these headers for defense in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)