### PR TITLE
Add timeout to admin portal DHService HTTP calls

### DIFF
--- a/code/DHAdminPortal/dhservices.py
+++ b/code/DHAdminPortal/dhservices.py
@@ -26,7 +26,7 @@ DH_CLIENT_SECRET = config.get("dh_services", "client_secret")
 # credentials flow
 def get_access_token(username: str, password: str) -> str:
     url = f"{DH_API_BASE_URL}/token"
-    response = requests.post(url, data={"username": username, "password": password})
+    response = requests.post(url, data={"username": username, "password": password}, timeout=10)
     response.raise_for_status()
     return response.json()["access_token"]
 
@@ -34,7 +34,7 @@ def get_access_token(username: str, password: str) -> str:
 def get_member_id(access_token: str, email_address: str):
     url = f"{DH_API_BASE_URL}/v1/member/id"
     headers = {"Authorization": f"Bearer {access_token}"}
-    response = requests.get(url, headers=headers, params={"email_address": email_address})
+    response = requests.get(url, headers=headers, params={"email_address": email_address}, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -44,7 +44,7 @@ def search_members(access_token: str, query: str):
     print(f"Searching for member '{query}' at {url}...")
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"query": query}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -82,7 +82,7 @@ def is_username_taken(access_token: str, username: str) -> bool:
     logger.debug(f"Checking if username '{username}' is taken...")
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"username": username}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     data = response.json()
     return not data.get("available", False)
@@ -92,7 +92,7 @@ def get_member_identity(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/identity/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -103,7 +103,7 @@ def get_full_member_info(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/full_info/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -132,7 +132,7 @@ def get_member_roles(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/roles/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -141,7 +141,7 @@ def get_member_status(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/status/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -150,7 +150,7 @@ def get_member_forms(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/forms/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -159,7 +159,7 @@ def get_member_connections(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/connections/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -168,7 +168,7 @@ def get_member_extras(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/extras/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -177,7 +177,7 @@ def get_member_authorizations(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/authorizations/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -186,7 +186,7 @@ def get_member_notes(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/notes/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -194,7 +194,7 @@ def get_member_access(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/access/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -202,7 +202,7 @@ def get_member_entry_logs(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/entry_logs/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -211,21 +211,21 @@ def get_member_last_updated(access_token: str, member_id: str):
     url = f"{DH_API_BASE_URL}/v1/member/last_updated/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"member_id": member_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()
 
 def get_available_authorizations(access_token: str):
     url = f"{DH_API_BASE_URL}/v1/authorizations/available/"
     headers = {"Authorization": f"Bearer {access_token}"}
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=10)
     response.raise_for_status()
     return response.json()
 
 def get_available_membership_levels(access_token: str):
     url = f"{DH_API_BASE_URL}/v1/membership_levels/available/"
     headers = {"Authorization": f"Bearer {access_token}"}
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -235,7 +235,7 @@ def get_available_membership_levels(access_token: str):
 def add_member(access_token: str, identity_data: dict):
     url = f"{DH_API_BASE_URL}/v1/member/identity/"
     headers = {"Authorization": f"Bearer {access_token}"}
-    response = requests.post(url, headers=headers, json=identity_data)
+    response = requests.post(url, headers=headers, json=identity_data, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -244,7 +244,7 @@ def update_member_status(access_token: str, member_id: str, status_data: dict):
     headers = {"Authorization": f"Bearer {access_token}"}
     headers["X-Member-ID"] = str(member_id)
     params = {"member_id": member_id}
-    response = requests.post(url, headers=headers, params=params, json=status_data)
+    response = requests.post(url, headers=headers, params=params, json=status_data, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -253,7 +253,7 @@ def update_member_identity(access_token: str, member_id: str, identity_data: dic
     headers = {"Authorization": f"Bearer {access_token}"}
     headers["X-Member-ID"] = str(member_id)
     params = {"member_id": member_id}
-    response = requests.post(url, headers=headers, params=params, json=identity_data)
+    response = requests.post(url, headers=headers, params=params, json=identity_data, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -266,7 +266,7 @@ def update_member_extras(access_token: str, member_id: str, extras_data: dict):
     headers = {"Authorization": f"Bearer {access_token}"}
     headers["X-Member-ID"] = str(member_id)
     params = {"member_id": member_id}
-    response = requests.post(url, headers=headers, params=params, json=extras_data)
+    response = requests.post(url, headers=headers, params=params, json=extras_data, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -277,7 +277,7 @@ def update_member_authorizations(access_token: str, member_id: str, auth_data: d
         "x-member-id": member_id  # FastAPI expects dashes, not underscores, which came as a big surprise
     }
     logger.debug(f"Sending authorization update - member_id: {member_id}, data: {auth_data}")
-    response = requests.post(url, headers=headers, json=auth_data)
+    response = requests.post(url, headers=headers, json=auth_data, timeout=10)
     logger.debug(f"Response status: {response.status_code}")
     if not response.ok:
         logger.error(f"Error response: {response.text}")
@@ -289,7 +289,7 @@ def update_member_notes(access_token: str, member_id: str, notes_data: dict):
     headers = {"Authorization": f"Bearer {access_token}"}
     headers["X-Member-ID"] = str(member_id)
     params = {"member_id": member_id}
-    response = requests.post(url, headers=headers, params=params, json=notes_data)
+    response = requests.post(url, headers=headers, params=params, json=notes_data, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -298,7 +298,7 @@ def update_member_access(access_token: str, member_id: str, access_data: dict):
     headers = {"Authorization": f"Bearer {access_token}"}
     headers["X-Member-ID"] = str(member_id)
     params = {"member_id": member_id}
-    response = requests.post(url, headers=headers, params=params, json=access_data)
+    response = requests.post(url, headers=headers, params=params, json=access_data, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -307,7 +307,7 @@ def update_member_forms(access_token: str, member_id: str, forms_data: dict):
     headers = {"Authorization": f"Bearer {access_token}"}
     headers["X-Member-ID"] = str(member_id)
     params = {"member_id": member_id}
-    response = requests.post(url, headers=headers, params=params, json=forms_data)
+    response = requests.post(url, headers=headers, params=params, json=forms_data, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -316,7 +316,7 @@ def update_member_connections(access_token: str, member_id: str, connections_dat
     headers = {"Authorization": f"Bearer {access_token}"}
     headers["X-Member-ID"] = str(member_id)
     params = {"member_id": member_id}
-    response = requests.post(url, headers=headers, params=params, json=connections_data)
+    response = requests.post(url, headers=headers, params=params, json=connections_data, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -329,7 +329,7 @@ def log_user_activity(access_token: str, member_id: str, activity_data: dict):
     headers["X-Member-ID"] = str(member_id)
     # Add member_id to the activity_data at the same level as activity_details
     payload = {"member_id": member_id, **activity_data}
-    response = requests.post(url, headers=headers, json=payload)
+    response = requests.post(url, headers=headers, json=payload, timeout=10)
     response.raise_for_status()
     return response.json()
 
@@ -464,6 +464,6 @@ def search_contacts_by_email(access_token: str, email_address: str):
     url = f"{DH_API_BASE_URL}/v1/contacts/search_by_email/"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"email_address": email_address}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers, params=params, timeout=10)
     response.raise_for_status()
     return response.json()


### PR DESCRIPTION
## What

Adds a `timeout=` to the 29 outbound `requests.*` calls in the admin portal's `dhservices.py` that were missing one. Without a timeout, a stalled DHService/gateway peer can hang a waitress worker indefinitely (CWE-400, uncontrolled resource consumption). This enforces the existing project convention that every `requests` call must pass `timeout=`; the member portal was fixed previously (#194).

## Details

- `timeout=10`, matching the member-portal reference and this file's existing calls.
- Purely additive: 29 calls gain `timeout=10`, no other changes.

## Validation (on dev)

- Normal admin usage is unchanged (member search, open a member, load each tab).
- With DHService paused, an affected call now raises `ReadTimeout` at ~10s instead of hanging indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
