### PR TITLE
Add timeout to Microsoft Graph / Azure B2C HTTP calls

### DIFF
--- a/code/DHAdminPortal/app.py
+++ b/code/DHAdminPortal/app.py
@@ -464,6 +464,7 @@ def graphcall():
     graph_data = requests.get(  # Use token to call downstream service
         app_config.ENDPOINT,
         headers={"Authorization": "Bearer " + token["access_token"]},
+        timeout=30,
     ).json()
     return render_template("graph.html", result=graph_data)
 

--- a/code/workers/DHADController/b2c.py
+++ b/code/workers/DHADController/b2c.py
@@ -63,7 +63,7 @@ def get_b2c_user_id_by_ad_object_id(access_token, ad_object_id):
         'Authorization': f'Bearer {access_token}'
     }
     
-    response = requests.get(graph_endpoint, headers=headers)
+    response = requests.get(graph_endpoint, headers=headers, timeout=30)
     
     if response.status_code == 200:
         users = response.json().get('value', [])
@@ -90,7 +90,7 @@ def get_b2c_user_id_by_email(access_token, email_address):
         'Authorization': f'Bearer {access_token}'
     }
     
-    response = requests.get(graph_endpoint, headers=headers)
+    response = requests.get(graph_endpoint, headers=headers, timeout=30)
     
     if response.status_code == 200:
         users = response.json().get('value', [])
@@ -163,7 +163,7 @@ def create_user_in_b2c(access_token,
         'Content-Type': 'application/json'
     }
 
-    response = requests.post(graph_endpoint, json=user_data, headers=headers)
+    response = requests.post(graph_endpoint, json=user_data, headers=headers, timeout=30)
 
     if response.status_code == 201:
         b2c_user = response.json()
@@ -225,7 +225,7 @@ def update_user_in_b2c(first_name=None, last_name=None, email_address=None):
             }
         ]
     """    
-    response = requests.patch(graph_endpoint, json=user_data, headers=headers)
+    response = requests.patch(graph_endpoint, json=user_data, headers=headers, timeout=30)
     
     if response.status_code == 204:
         logger.info(f"User updated successfully in Azure B2C")
@@ -251,7 +251,7 @@ def set_user_enabled(access_token, b2c_user_id, enabled=True):
         'accountEnabled': enabled
     }
     
-    response = requests.patch(graph_endpoint, json=user_data, headers=headers)
+    response = requests.patch(graph_endpoint, json=user_data, headers=headers, timeout=30)
     
     if response.status_code == 204:
         logger.info(f"User {'enabled' if enabled else 'disabled'} successfully in Azure B2C")
@@ -271,7 +271,7 @@ def get_user_enabled_status(access_token, b2c_user_id):
         'Authorization': f'Bearer {access_token}'
     }
     
-    response = requests.get(graph_endpoint, headers=headers)
+    response = requests.get(graph_endpoint, headers=headers, timeout=30)
     
     if response.status_code == 200:
         user_data = response.json()


### PR DESCRIPTION
## What

Adds `timeout=` to the outbound Microsoft Graph / Azure B2C `requests.*` calls that were missing one: the admin portal `/graphcall` route and all six DHADController B2C Graph calls. Without a timeout, a stalled Graph endpoint can hang the request/worker indefinitely (CWE-400, uncontrolled resource consumption). Enforces the project convention that every `requests` call must pass `timeout=`.

## Details

- `timeout=30` (vs the 10s used for internal DHService calls), since AD + Graph round-trips are slower.
- Purely additive: 7 calls gain `timeout=30` (1 in `app.py`, 6 in `b2c.py`), no other changes.

## Validation

- These paths are not exercised on dev (Graph/B2C is skipped there), so this is a code-review-only change for the Graph calls themselves.
- DHADController was rebuilt and boots clean (0 restarts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
