### PR TITLE
DHService: global exception handlers (400 for malformed body, generic 500)

### DIFF
--- a/code/DHService/fastapiapp.py
+++ b/code/DHService/fastapiapp.py
@@ -1,4 +1,9 @@
-from fastapi import FastAPI
+import json
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from dhs_logging import logger
 
 ###############################################################################
 # Configuration
@@ -6,3 +11,41 @@ from fastapi import FastAPI
 
 # Our one and only fastapi app
 app = FastAPI()
+
+
+###############################################################################
+# Global exception handlers
+#
+# Registered here, on the shared app object, so they apply to every endpoint
+# regardless of import order (both main.py and v1.py do `from fastapiapp import
+# app`). FastAPI registers its own HTTPException and RequestValidationError
+# handlers as more-specific keys in the same handler dict, so Starlette's
+# exception-class MRO walk resolves them before this broad Exception handler —
+# the real 401/403/404/422 responses are unaffected. This relies on Starlette's
+# current MRO-walk dispatch (verified live on dev), not a guaranteed public
+# contract; re-verify these status codes if Starlette/FastAPI is upgraded.
+###############################################################################
+
+
+@app.exception_handler(json.JSONDecodeError)
+async def json_decode_exception_handler(request: Request, exc: json.JSONDecodeError):
+    """Return 400 (not 500) when a request body is empty or not valid JSON.
+
+    The member-mutating POSTs read the body via `await request.json()`; an
+    unparseable body raises JSONDecodeError, which otherwise crashes to a 500.
+    JSONDecodeError subclasses ValueError, so Starlette's MRO match picks this
+    handler over the broad Exception handler below for decode errors.
+    """
+    # INFO, not WARNING: a malformed body is routine client error, not an
+    # operator-actionable condition, and the endpoint is publicly reachable.
+    logger.info(f"Malformed request body: {exc}")
+    return JSONResponse(status_code=400, content={"detail": "Malformed request body"})
+
+
+@app.exception_handler(Exception)
+async def generic_exception_handler(request: Request, exc: Exception):
+    """Catch-all backstop: log the error and return a generic 500 body with no
+    internal detail (defense-in-depth + consistent error shape + guaranteed
+    logging via the project logger)."""
+    logger.error(f"Unhandled exception: {exc}")
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})


### PR DESCRIPTION
## What

Adds two global FastAPI exception handlers to DHService (registered on the shared `app` in `code/DHService/fastapiapp.py`), so the service no longer returns a 500 on an unparseable request body and always returns a consistent, detail-free error shape:

- `json.JSONDecodeError` -> **400** `{"detail":"Malformed request body"}` (logged at INFO). An empty or non-JSON body sent to the member-mutating POSTs (which read the body via `await request.json()`) previously crashed to a 500; it is now rejected at the API boundary.
- `Exception` -> generic **500** `{"detail":"Internal server error"}` (logged at ERROR via the project logger) as a catch-all backstop.

A global handler on the shared app covers every endpoint, so this applies app-wide (member POSTs, admin role endpoints, etc.).

## Why

Malformed or missing request bodies were returning HTTP 500 instead of a 4xx. This is a defense-in-depth + consistent-error-shape + guaranteed-logging improvement, plus a real 400 for the unparseable-body case. Partial step toward #254 (the per-endpoint Pydantic request models that return 422 with field-level errors are the remaining work and are tracked there). CWE-550, CWE-1295.

## Not in scope

Per-endpoint Pydantic models / 422 validation (tracked under #254). Missing/invalid *keys* in an otherwise well-formed body still return a generic 500 until those land.

## Testing (on dev)

- Malformed/empty body -> 400 across all member-mutating POSTs and the admin role endpoints.
- Well-formed-but-missing-key -> generic 500 (logged).
- Regression: no token -> 401, bad `X-Member-ID` -> 422, well-formed GET/POST -> 200 (FastAPI's own HTTPException/RequestValidationError handlers still win).
- End-to-end: added a note to a member through the admin portal Notes tab; `POST` round-trip returned 200 and persisted.
